### PR TITLE
[#131355143] Add terraform code to create release buckets: datadog-agent-boshrelease

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 vagrant/.vagrant/
 bin/fly*
+*.tfstate.backup

--- a/terraform/boshreleases/README.md
+++ b/terraform/boshreleases/README.md
@@ -1,0 +1,7 @@
+Bucket definitions for bosh releases
+====================================
+
+This directory contains the bucket definitions for bosh releases.
+
+The buckets will be created in the `ci` AWS account, as it is the most likely
+one to run the pipelines.

--- a/terraform/boshreleases/aws.tf
+++ b/terraform/boshreleases/aws.tf
@@ -1,0 +1,8 @@
+provider "aws" {
+  region = "${var.region}"
+
+  /* Guard to prevent operating on an unintended account */
+  allowed_account_ids = [
+    "${lookup(var.account_ids, var.aws_account)}",
+  ]
+}

--- a/terraform/boshreleases/buckets-boshreleases.tf
+++ b/terraform/boshreleases/buckets-boshreleases.tf
@@ -1,0 +1,5 @@
+resource "aws_s3_bucket" "datadog-agent-boshrelease" {
+  bucket = "gds-paas-datadog-agent-boshrelease"
+  acl = "public-read"
+  force_destroy = "true"
+}

--- a/terraform/boshreleases/terraform.tfstate
+++ b/terraform/boshreleases/terraform.tfstate
@@ -1,0 +1,16 @@
+{
+    "version": 3,
+    "terraform_version": "0.7.3",
+    "serial": 0,
+    "lineage": "c459594a-a37a-4613-9b1a-4810119d8bd5",
+    "modules": [
+        {
+            "path": [
+                "root"
+            ],
+            "outputs": {},
+            "resources": {},
+            "depends_on": []
+        }
+    ]
+}

--- a/terraform/boshreleases/terraform.tfstate
+++ b/terraform/boshreleases/terraform.tfstate
@@ -1,7 +1,7 @@
 {
     "version": 3,
     "terraform_version": "0.7.3",
-    "serial": 0,
+    "serial": 1,
     "lineage": "c459594a-a37a-4613-9b1a-4810119d8bd5",
     "modules": [
         {
@@ -9,7 +9,33 @@
                 "root"
             ],
             "outputs": {},
-            "resources": {},
+            "resources": {
+                "aws_s3_bucket.datadog-agent-boshrelease": {
+                    "type": "aws_s3_bucket",
+                    "depends_on": [],
+                    "primary": {
+                        "id": "gds-paas-datadog-agent-boshrelease",
+                        "attributes": {
+                            "acceleration_status": "",
+                            "acl": "public-read",
+                            "arn": "arn:aws:s3:::gds-paas-datadog-agent-boshrelease",
+                            "bucket": "gds-paas-datadog-agent-boshrelease",
+                            "force_destroy": "true",
+                            "hosted_zone_id": "Z1BKCTXD74EZPE",
+                            "id": "gds-paas-datadog-agent-boshrelease",
+                            "policy": "",
+                            "region": "eu-west-1",
+                            "request_payer": "BucketOwner",
+                            "tags.%": "0",
+                            "website.#": "0"
+                        },
+                        "meta": {},
+                        "tainted": false
+                    },
+                    "deposed": [],
+                    "provider": ""
+                }
+            },
             "depends_on": []
         }
     ]

--- a/terraform/boshreleases/variables.tf
+++ b/terraform/boshreleases/variables.tf
@@ -1,0 +1,13 @@
+variable "account_ids" {
+  default = {
+    ci = "1234567890"
+  }
+}
+
+variable "aws_account" {
+  default = "ci"
+}
+
+variable "region" {
+  default = "eu-west-1"
+}


### PR DESCRIPTION
[#131355143 Add metron metrics to datadog](https://www.pivotaltracker.com/story/show/131355143)
## What?

To keep the blobs of our custom releases, we need to create S3 buckets.

We decided to keep these buckets on the AWS CI account, as it is the one
that will run the pipelines to compile and publish the releases.

Meanwhile we don't have a better way to manage the configuation, we keep in
this repository the related repo that we can run locally.

The terraform state will be kept as commits in this repository.

In this case we create the bucket for datadog-agent-boshrelease, which we needed to fork to include the spruce blob as in https://github.com/onemedical/datadog-agent-boshrelease/pull/7
## How to review?

Check it makes sense. It has been already applied to the AWS account.
## Who?

Anyone but me or @richardc
