### PR TITLE
[#131289833] Parameterised roles

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ env:
   global:
     - TF_VERSION="0.7.3"
     - SPRUCE_VERSION="1.5.0"
-    - DEPLOY_ENV="travis"
 
 addons:
   apt:

--- a/Makefile
+++ b/Makefile
@@ -61,6 +61,8 @@ ci: globals check-env-vars ## Set Environment to CI
 
 .PHONY: bootstrap
 bootstrap: ## Start bootstrap
+	$(if ${BOSH_INSTANCE_PROFILE},,$(error Must pass BOSH_INSTANCE_PROFILE=<name>))
+	$(if ${CONCOURSE_INSTANCE_PROFILE},,$(error Must pass CONCOURSE_INSTANCE_PROFILE=<name>))
 	vagrant/deploy.sh
 
 .PHONY: bootstrap-destroy

--- a/Makefile
+++ b/Makefile
@@ -30,9 +30,9 @@ spec:
 lint_yaml:
 	find . -name '*.yml' -not -path '*/vendor/*' | xargs $(YAMLLINT) -c yamllint.yml
 
-lint_terraform: dev
-	$(eval export TF_VAR_system_dns_zone_name=$SYSTEM_DNS_ZONE_NAME)
-	$(eval export TF_VAR_apps_dns_zone_name=$APPS_DNS_ZONE_NAME)
+lint_terraform:
+	$(eval export TF_VAR_system_dns_zone_name=service.com)
+	$(eval export TF_VAR_apps_dns_zone_name=apps.com)
 	find terraform -mindepth 1 -maxdepth 1 -type d -print0 | xargs -0 -n 1 -t terraform graph > /dev/null
 
 lint_shellcheck:

--- a/README.md
+++ b/README.md
@@ -21,6 +21,9 @@ or destroyed.
 
 In order to use this repository you will need:
 
+* Predefined [IAM instance profiles](http://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_use_switch-role-ec2_instance-profiles.html) that will be assigned to Concourse-lite, BOSH and Concourse. `concourse-lite` is a hard coded name, whereas the BOSH and Concourse roles can be any name and must be exported with respective variables `BOSH_INSTANCE_PROFILE` and `CONCOURSE_INSTANCE_PROFILE`. See [aws-account-wide-terraform](https://github.gds/government-paas/aws-account-wide-terraform) for details
+(not public because it also contains state files).
+
 * [AWS Command Line tool (`awscli`)](https://aws.amazon.com/cli/). You can
 install it using [any of the official methods](http://docs.aws.amazon.com/cli/latest/userguide/installing.html)
 or by using [`virtualenv`](https://virtualenv.pypa.io/en/latest/) and pip `pip install -r requirements.txt`
@@ -206,4 +209,3 @@ Stop the tunnel with: `make <env> stop-tunnel`
 
 ## Other useful commands
 Type `make` to get the list of all available commands.
-

--- a/concourse/pipelines/create.yml
+++ b/concourse/pipelines/create.yml
@@ -585,6 +585,7 @@ jobs:
               ./terraform-outputs/vpc.terraform-outputs.yml
             BOSH_FQDN: {{bosh_fqdn}}
             BOSH_FQDN_EXTERNAL: {{bosh_fqdn_external}}
+            BOSH_INSTANCE_PROFILE: {{bosh_instance_profile}}
           run:
             path: sh
             args:
@@ -843,6 +844,7 @@ jobs:
               terraform-outputs/concourse-terraform-outputs.yml
               terraform-outputs/vpc-terraform-outputs.yml
               terraform-outputs/bosh-terraform-outputs.yml
+            CONCOURSE_INSTANCE_PROFILE: {{concourse_instance_profile}}
           inputs:
           - name: paas-bootstrap
           - name: concourse-secrets

--- a/concourse/pipelines/create.yml
+++ b/concourse/pipelines/create.yml
@@ -586,6 +586,7 @@ jobs:
             BOSH_FQDN: {{bosh_fqdn}}
             BOSH_FQDN_EXTERNAL: {{bosh_fqdn_external}}
             BOSH_INSTANCE_PROFILE: {{bosh_instance_profile}}
+            AWS_ACCOUNT: {{aws_account}}
           run:
             path: sh
             args:

--- a/concourse/pipelines/destroy.yml
+++ b/concourse/pipelines/destroy.yml
@@ -173,7 +173,6 @@ jobs:
               < vpc-tfstate/vpc.tfstate \
               > vpc-terraform-outputs/tfvars.sh
               ls -l vpc-terraform-outputs/tfvars.sh
-              cat vpc-terraform-outputs/tfvars.sh
 
       - task: destroy-concourse-terraform
         config:

--- a/concourse/scripts/pipelines.sh
+++ b/concourse/scripts/pipelines.sh
@@ -24,6 +24,8 @@ bosh_manifest_state: bosh-manifest-state-${BOSH_AZ:-eu-west-1a}.json
 bosh_fqdn: bosh.${SYSTEM_DNS_ZONE_NAME}
 bosh_fqdn_external: bosh-external.${SYSTEM_DNS_ZONE_NAME}
 concourse_atc_password: ${CONCOURSE_ATC_PASSWORD}
+bosh_instance_profile: ${BOSH_INSTANCE_PROFILE}
+concourse_instance_profile: ${CONCOURSE_INSTANCE_PROFILE}
 EOF
 }
 

--- a/manifests/bosh-manifest/deployments/020-compiled-package-cache.yml
+++ b/manifests/bosh-manifest/deployments/020-compiled-package-cache.yml
@@ -4,4 +4,4 @@ jobs:
     compiled_package_cache:
       options:
         credentials_source: env_or_profile
-        bucket_name: (( grab terraform_outputs.compiled_cache_bucket_name ))
+        bucket_name: (( concat "gds-paas-bosh-cache-" $AWS_ACCOUNT ))

--- a/manifests/bosh-manifest/deployments/aws/000-bosh-infrastructure.yml
+++ b/manifests/bosh-manifest/deployments/aws/000-bosh-infrastructure.yml
@@ -9,7 +9,7 @@ resource_pools:
     instance_type: t2.medium
     ephemeral_disk: {size: 40000, type: gp2}
     availability_zone: (( grab terraform_outputs.bosh_az ))
-    iam_instance_profile: bosh-director
+    iam_instance_profile: (( grab $BOSH_INSTANCE_PROFILE ))
   env:
     bosh:
       password: (( grab secrets.bosh_vcap_password ))

--- a/manifests/bosh-manifest/spec/fixtures/bosh-terraform-outputs.yml
+++ b/manifests/bosh-manifest/spec/fixtures/bosh-terraform-outputs.yml
@@ -2,8 +2,6 @@
 terraform_outputs:
   bosh_security_group: bosh_security_group
   bosh_subnet_id: subnet-bosh
-  compiled_cache_bucket_host: s3-eu-west-1.amazonaws.com
-  compiled_cache_bucket_name: shared-cf-bosh-blobstore-unit-test
   bosh_blobstore_bucket_name: test-bosh-blobstore
   bosh_managed_security_group: bosh_default_sg
   environment: test

--- a/manifests/bosh-manifest/spec/support/manifest_helpers.rb
+++ b/manifests/bosh-manifest/spec/support/manifest_helpers.rb
@@ -17,6 +17,8 @@ private
   def fake_env_vars
     ENV["BOSH_FQDN_EXTERNAL"] = "bosh-external.domain"
     ENV["BOSH_FQDN"] = "bosh.domain"
+    ENV["AWS_ACCOUNT"] = "dev"
+    ENV["BOSH_INSTANCE_PROFILE"] = "bosh-director-build"
   end
 
   def load_default_manifest

--- a/manifests/concourse-manifest/concourse-base.yml
+++ b/manifests/concourse-manifest/concourse-base.yml
@@ -34,7 +34,7 @@ resource_pools:
     cloud_properties:
       instance_type: m4.large
       availability_zone: (( grab meta.zone ))
-      iam_instance_profile: bosh-managed
+      iam_instance_profile: (( grab $CONCOURSE_INSTANCE_PROFILE ))
       elbs:
       - (( grab terraform_outputs.concourse_elb_name ))
       ephemeral_disk:

--- a/manifests/concourse-manifest/concourse-base.yml
+++ b/manifests/concourse-manifest/concourse-base.yml
@@ -148,7 +148,7 @@ compilation:
   cloud_properties:
     instance_type: c3.large
     availability_zone: (( grab meta.zone ))
-    iam_instance_profile: bosh-director
+    iam_instance_profile: compilation-vm
     auto_assign_public_ip: true
 
 update:

--- a/manifests/concourse-manifest/spec/fixtures/bosh-terraform-outputs.yml
+++ b/manifests/concourse-manifest/spec/fixtures/bosh-terraform-outputs.yml
@@ -2,8 +2,6 @@
 terraform_outputs:
   bosh_security_group: bosh_security_group
   bosh_subnet_id: subnet-bosh
-  compiled_cache_bucket_host: s3-eu-west-1.amazonaws.com
-  compiled_cache_bucket_name: shared-cf-bosh-blobstore-unit-test
   bosh_blobstore_bucket_name: test-bosh-blobstore
   bosh_managed_security_group: bosh_default_sg
   environment: test

--- a/manifests/concourse-manifest/spec/support/manifest_helpers.rb
+++ b/manifests/concourse-manifest/spec/support/manifest_helpers.rb
@@ -14,7 +14,13 @@ module ManifestHelpers
 
 private
 
+  def fake_env_vars
+    ENV["AWS_ACCOUNT"] = "dev"
+    ENV["CONCOURSE_INSTANCE_PROFILE"] = "concourse-build"
+  end
+
   def load_default_manifest
+    fake_env_vars
     output, error, status = Open3.capture3(
       [
         File.expand_path("../../../../shared/build_manifest.sh", __FILE__),

--- a/terraform/bosh/outputs.tf
+++ b/terraform/bosh/outputs.tf
@@ -26,14 +26,6 @@ output "microbosh_static_public_ip" {
   value = "${aws_eip.bosh.public_ip}"
 }
 
-output "compiled_cache_bucket_host" {
-  value = "s3-${var.region}.amazonaws.com"
-}
-
-output "compiled_cache_bucket_name" {
-  value = "shared-cf-bosh-blobstore-${var.aws_account}"
-}
-
 output "bosh_blobstore_bucket_name" {
   value = "${aws_s3_bucket.bosh-blobstore.id}"
 }


### PR DESCRIPTION
# What

Story: [Implement IAM roles for instances in the release build VPC](https://www.pivotaltracker.com/story/show/131289833)

paas-bootstrap is generic but we want to be able to build specific concourse with specific permissions. We now allow to pass instance profiles as environment variables. They should be defined in aws-account-wide-terraform.
Other improvements:
- restrict permissions of the compilation VM
- remove unused terraform outputs
- improve naming of compiled package cache bucket

This depends on a PR in aws-account-wide-terraform.
# How to review
- Apply PR in aws-account-wide-terraform
- Build:

```
BOSH_INSTANCE_PROFILE=bosh-director-build CONCOURSE_INSTANCE_PROFILE=concourse-build DEPLOY_ENV=test-123 make dev bootstrap
```
- Concourse should run at: https://concourse.build-123.dev.cloudpipeline.digital
- Concourse and BOSH should have specific instance profiles
- Destroy:

```
BOSH_INSTANCE_PROFILE=bosh-director-build CONCOURSE_INSTANCE_PROFILE=concourse-build DEPLOY_ENV=build-123 make dev bootstrap-destroy
```
# Who can review

Not @benhyland or me
