### PR TITLE
[#131876273] Bring up to date with paas-cf

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,12 @@
+## What
+
+Describe what you have changed and why.
+
+## How to review
+
+Describe the steps required to test the changes.
+
+## Who can review
+
+Describe who can review the changes. Or more importantly, list the people
+that can't review, because they worked on it.

--- a/Makefile
+++ b/Makefile
@@ -59,6 +59,13 @@ ci: globals check-env-vars ## Set Environment to CI
 	$(eval export SYSTEM_DNS_ZONE_NAME=${DEPLOY_ENV}.ci.cloudpipeline.digital)
 	$(eval export AWS_ACCOUNT=ci)
 
+.PHONY: fly-login
+fly-login: ## Do a fly login and sync
+	$(eval export TARGET_CONCOURSE=deployer)
+	$$("./concourse/scripts/environment.sh") && \
+		./concourse/scripts/fly_sync_and_login.sh
+
+
 .PHONY: bootstrap
 bootstrap: ## Start bootstrap
 	$(if ${BOSH_INSTANCE_PROFILE},,$(error Must pass BOSH_INSTANCE_PROFILE=<name>))

--- a/Makefile
+++ b/Makefile
@@ -80,7 +80,7 @@ bootstrap-destroy: ## Destroy bootstrap
 showenv: ## Display environment information
 	$(eval export TARGET_CONCOURSE=deployer)
 	@echo CONCOURSE_IP=$$(aws ec2 describe-instances \
-		--filters 'Name=tag:Name,Values=concourse/0' "Name=key-name,Values=${DEPLOY_ENV}_concourse_key_pair" \
+		--filters 'Name=tag:Name,Values=concourse/*' "Name=key-name,Values=${DEPLOY_ENV}_concourse_key_pair" \
 		--query 'Reservations[].Instances[].PublicIpAddress' --output text)
 	@concourse/scripts/environment.sh
 

--- a/concourse/scripts/fly_sync_and_login.sh
+++ b/concourse/scripts/fly_sync_and_login.sh
@@ -16,3 +16,6 @@ chmod +x "$FLY_CMD"
 echo "Doing fly login"
 echo -e "${CONCOURSE_ATC_USER}\n${CONCOURSE_ATC_PASSWORD}" | \
   $FLY_CMD -t "${FLY_TARGET}" login -k --concourse-url "${CONCOURSE_URL}"
+
+echo "Doing fly sync"
+$FLY_CMD -t "${FLY_TARGET}" sync

--- a/manifests/bosh-manifest/bosh-manifest.yml
+++ b/manifests/bosh-manifest/bosh-manifest.yml
@@ -149,8 +149,8 @@ resource_pools:
 - name: bosh
   network: private
   stemcell:
-    url: https://bosh.io/d/stemcells/bosh-aws-xen-hvm-ubuntu-trusty-go_agent?v=3263.8
-    sha1: 95ecc2709ac62f21d0a1c6cac023585c3919b825
+    url: https://bosh.io/d/stemcells/bosh-aws-xen-hvm-ubuntu-trusty-go_agent?v=3263.10
+    sha1: 42ea4577caec4aec463bed951cfdffb935961270
   cloud_properties:
     instance_type: t2.medium
     ephemeral_disk: {size: 40000, type: gp2}

--- a/manifests/concourse-manifest/concourse-base.yml
+++ b/manifests/concourse-manifest/concourse-base.yml
@@ -2,7 +2,7 @@
 meta:
   stemcell:
     name: bosh-aws-xen-hvm-ubuntu-trusty-go_agent
-    version: "3262.12"
+    version: "3263.10"
 
   zone: (( grab terraform_outputs.zone0 ))
 

--- a/manifests/concourse-manifest/concourse-base.yml
+++ b/manifests/concourse-manifest/concourse-base.yml
@@ -12,9 +12,9 @@ director_uuid: ~
 
 releases:
   - name: concourse
-    version: 2.2.1
-    url: https://bosh.io/d/github.com/concourse/concourse?v=2.2.1
-    sha1: 879d5cb45d12f173ff4c7912c7c7cdcd3e18c442
+    version: 2.4.0
+    url: https://bosh.io/d/github.com/concourse/concourse?v=2.4.0
+    sha1: 8eb1e707594b47adc7bfa10c89fe17524caf8461
   - name: garden-runc
     version: 0.8.0
     url: https://bosh.io/d/github.com/cloudfoundry/garden-runc-release?v=0.8.0

--- a/manifests/shared/lib/secret_generator.rb
+++ b/manifests/shared/lib/secret_generator.rb
@@ -3,11 +3,11 @@ require 'openssl'
 require 'digest/md5'
 
 class SecretGenerator
-  PASSWORD_LENGTH = 12
+  PASSWORD_LENGTH = 18
 
   def self.random_password
-    bytes = PASSWORD_LENGTH * 3 / 4
-    SecureRandom.urlsafe_base64(bytes)
+    bytes = PASSWORD_LENGTH / 2
+    SecureRandom.hex(bytes)
   end
 
   def self.sha512_crypt(password, salt = nil)

--- a/manifests/shared/spec/secret_generator_spec.rb
+++ b/manifests/shared/spec/secret_generator_spec.rb
@@ -2,7 +2,7 @@
 require 'secret_generator'
 
 RSpec.describe SecretGenerator do
-  SIMPLE_PASSWORD_REGEX = /\A[a-zA-Z0-9_-]+\z/
+  SIMPLE_PASSWORD_REGEX = /\A[a-zA-Z0-9]+\z/
 
   describe "password generation" do
     it "generates a passwords of the required length" do
@@ -17,7 +17,7 @@ RSpec.describe SecretGenerator do
         "Duplicate passwords generated (#{duplicated_passwords.join(',')} generated more than once)"
     end
 
-    it "only uses URL-safe characters" do
+    it "only uses alphanumeric characters" do
       10.times do
         expect(SecretGenerator.random_password).to match(SIMPLE_PASSWORD_REGEX)
       end


### PR DESCRIPTION
## What

Before deploying this, we want to bring things up to date with paas-cf. This includes some upgrades and fixes related to this:

* Upgrade concourse to 2.4.0
* Upgrade stemcells to latest version
* Pull in some fixes from paas-cf (fly sync after login, fix password generation)
* Fix showenv to work with new bosh UUID instance indexes (necessary for `ssh_concourse` to work)
* Add the PR template to match paas-cf

## How to review

Deploy the thing following the README (note don't use the same `DEPLOY_ENV` as an existing paas-cf deployment).
Verify it works.
Verify you can ssh to the concourse instance using `make dev ssh_concourse`.

## Who can review

Anyone but @henrytk or myself.