### PR TITLE
[#131876273] Add datadog agent to Bosh and Concourse

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -53,11 +53,13 @@ globals:
 dev: globals check-env-vars ## Set Environment to DEV
 	$(eval export SYSTEM_DNS_ZONE_NAME=${DEPLOY_ENV}.dev.cloudpipeline.digital)
 	$(eval export AWS_ACCOUNT=dev)
+	$(eval export ENABLE_DATADOG ?= false)
 
 .PHONY: ci
 ci: globals check-env-vars ## Set Environment to CI
 	$(eval export SYSTEM_DNS_ZONE_NAME=${DEPLOY_ENV}.ci.cloudpipeline.digital)
 	$(eval export AWS_ACCOUNT=ci)
+	$(eval export ENABLE_DATADOG=true)
 
 .PHONY: fly-login
 fly-login: ## Do a fly login and sync

--- a/Makefile
+++ b/Makefile
@@ -93,3 +93,11 @@ tunnel: check-env-vars ## SSH tunnel to internal IPs
 
 stop-tunnel: check-env-vars ## Stop SSH tunnel
 	@./concourse/scripts/ssh.sh stop
+
+.PHONY: upload-datadog-secrets
+upload-datadog-secrets: check-env-vars ## Decrypt and upload Datadog credentials to S3
+	$(eval export DATADOG_PASSWORD_STORE_DIR?=${HOME}/.paas-pass)
+	$(if ${AWS_ACCOUNT},,$(error Must set environment to ci/staging/prod))
+	$(if ${DATADOG_PASSWORD_STORE_DIR},,$(error Must pass DATADOG_PASSWORD_STORE_DIR=<path_to_password_store>))
+	$(if $(wildcard ${DATADOG_PASSWORD_STORE_DIR}),,$(error Password store ${DATADOG_PASSWORD_STORE_DIR} does not exist))
+	@scripts/upload-datadog-secrets.sh

--- a/concourse/pipelines/create.yml
+++ b/concourse/pipelines/create.yml
@@ -118,6 +118,13 @@ resources:
       region_name: {{aws_region}}
       versioned_file: concourse-secrets.yml
 
+  - name: concourse-manifest
+    type: s3-iam
+    source:
+      bucket: {{state_bucket}}
+      region_name: {{aws_region}}
+      versioned_file: concourse-manifest.yml
+
 jobs:
   - name: init-bucket
     serial: true
@@ -875,6 +882,10 @@ jobs:
               ./paas-bootstrap/manifests/shared/build_manifest.sh $CONCOURSE_MANIFEST_STUBS \
                 > concourse-manifest/concourse-manifest.yml
               ls -l concourse-manifest/concourse-manifest.yml
+        on_success:
+          put: concourse-manifest
+          params:
+            file: concourse-manifest/concourse-manifest.yml
 
       - task: get-and-upload-stemcell
         config:
@@ -917,6 +928,10 @@ jobs:
               sed -e "s/^director_uuid:.*/director_uuid: $(bosh status --uuid)/" < concourse-manifest/concourse-manifest.yml > updated-concourse-manifest/concourse-manifest.yml
               bosh deployment updated-concourse-manifest/concourse-manifest.yml
               bosh -n deploy
+        on_success:
+          put: concourse-manifest
+          params:
+            file: updated-concourse-manifest/concourse-manifest.yml
 
       - task: test-bosh-vms
         config:

--- a/concourse/pipelines/create.yml
+++ b/concourse/pipelines/create.yml
@@ -576,6 +576,9 @@ jobs:
           outputs:
             - name: bosh-manifest
           params:
+            AWS_ACCOUNT: {{aws_account}}
+            DATADOG_API_KEY: {{datadog_api_key}}
+            ENABLE_DATADOG: {{enable_datadog}}
             BOSH_MANIFEST_STUBS: |
               ./paas-bootstrap/manifests/bosh-manifest/bosh-manifest.yml
               ./bosh-secrets/bosh-secrets.yml
@@ -585,13 +588,17 @@ jobs:
             BOSH_FQDN: {{bosh_fqdn}}
             BOSH_FQDN_EXTERNAL: {{bosh_fqdn_external}}
             BOSH_INSTANCE_PROFILE: {{bosh_instance_profile}}
-            AWS_ACCOUNT: {{aws_account}}
           run:
             path: sh
             args:
               - -e
               - -c
               - |
+                if [ "${ENABLE_DATADOG}" = "true" ] ; then
+                   BOSH_MANIFEST_STUBS="${BOSH_MANIFEST_STUBS}
+                                        ./paas-bootstrap/manifests/bosh-manifest/extensions/datadog-agent.yml
+                                        ./paas-bootstrap/manifests/shared/deployments/datadog-agent.yml"
+                fi
                 ./paas-bootstrap/manifests/shared/build_manifest.sh $BOSH_MANIFEST_STUBS > bosh-manifest/bosh-manifest.yml
         on_success:
           put: bosh-manifest
@@ -838,6 +845,9 @@ jobs:
         config:
           image: docker:///governmentpaas/spruce
           params:
+            AWS_ACCOUNT: {{aws_account}}
+            DATADOG_API_KEY: {{datadog_api_key}}
+            ENABLE_DATADOG: {{enable_datadog}}
             CONCOURSE_MANIFEST_STUBS: |
               ./paas-bootstrap/manifests/concourse-manifest/concourse-base.yml
               concourse-secrets/concourse-secrets.yml
@@ -857,6 +867,11 @@ jobs:
             - -e
             - -c
             - |
+              if [ "${ENABLE_DATADOG}" = "true" ] ; then
+                 CONCOURSE_MANIFEST_STUBS="${CONCOURSE_MANIFEST_STUBS}
+                                ./paas-bootstrap/manifests/concourse-manifest/extensions/datadog-agent.yml
+                                ./paas-bootstrap/manifests/shared/deployments/datadog-agent.yml"
+              fi
               ./paas-bootstrap/manifests/shared/build_manifest.sh $CONCOURSE_MANIFEST_STUBS \
                 > concourse-manifest/concourse-manifest.yml
               ls -l concourse-manifest/concourse-manifest.yml

--- a/concourse/pipelines/destroy.yml
+++ b/concourse/pipelines/destroy.yml
@@ -62,6 +62,13 @@ resources:
       versioned_file: concourse.tfstate
       region_name: {{aws_region}}
 
+  - name: concourse-manifest
+    type: s3-iam
+    source:
+      bucket: {{state_bucket}}
+      region_name: {{aws_region}}
+      versioned_file: concourse-manifest.yml
+
 jobs:
 
   - name: enable-bosh-access
@@ -139,6 +146,7 @@ jobs:
         - get: bosh-secrets
         - get: vpc-tfstate
         - get: concourse-tfstate
+        - get: concourse-manifest
 
       - task: destroy-concourse
         config:
@@ -146,6 +154,7 @@ jobs:
           inputs:
           - name: paas-bootstrap
           - name: bosh-secrets
+          - name: concourse-manifest
           run:
             path: sh
             args:
@@ -153,7 +162,8 @@ jobs:
             - -c
             - |
               ./paas-bootstrap/concourse/scripts/bosh_login.sh {{bosh_fqdn_external}} bosh-secrets/bosh-secrets.yml
-              bosh -n delete deployment --force concourse
+              DEPLOYMENT_NAME=$(./paas-bootstrap/concourse/scripts/val_from_yaml.rb name concourse-manifest/concourse-manifest.yml)
+              bosh -n delete deployment --force "$DEPLOYMENT_NAME"
 
       - task: vpc-terraform-outputs-to-sh
         config:

--- a/doc/datadog.md
+++ b/doc/datadog.md
@@ -1,0 +1,18 @@
+# Datadog
+
+Datadog is enabled by default for non-development environments. When testing Datadog in a dev environment you must set `ENABLE_DATADOG=true` when configuring the pipelines. The pipelines are configured using `make dev bootstrap`.
+
+## Credentials
+
+When setting up an environment the Datadog credentials need to be decrypted and pushed into the S3 state bucket as they are required during pipeline runs. Each environment (dev, ci, staging, and prod) has its own set of Application and API credentials in the PaaS credential store.
+
+### Requirements
+
+* Make sure you have access to the PaaS credential store, this is required for Datadog credentials.
+* Load the AWS credentials for the environment you are setting up datadog for. These are required as the Datadog secrets file is stored in an S3 bucket.
+
+### Usage
+```
+make <ENV> upload-datadog-secrets
+```
+

--- a/manifests/bosh-manifest/bosh-manifest.yml
+++ b/manifests/bosh-manifest/bosh-manifest.yml
@@ -1,5 +1,5 @@
 ---
-name: (( grab meta.environment ))
+name: bosh
 
 meta:
   environment: (( grab terraform_outputs.environment ))

--- a/manifests/bosh-manifest/extensions/datadog-agent.yml
+++ b/manifests/bosh-manifest/extensions/datadog-agent.yml
@@ -1,0 +1,10 @@
+---
+jobs:
+- name: bosh
+  templates:
+  - {name: datadog-agent, release: datadog-agent}
+  properties:
+    datadog: (( inject meta.datadog ))
+    tags:
+      bosh-job: bosh
+      bosh-az: (( grab terraform_outputs.bosh_az_label ))

--- a/manifests/bosh-manifest/spec/fixtures/bosh-terraform-outputs.yml
+++ b/manifests/bosh-manifest/spec/fixtures/bosh-terraform-outputs.yml
@@ -13,6 +13,7 @@ terraform_outputs:
   bosh_db_username: bosh
   bosh_db_dbname: bosh
   bosh_az: eu-west-1a
+  bosh_az_label: z1
   bosh_default_gw: 10.0.0.1
   bosh_subnet_cidr: 10.0.0.0/24
   bosh_ssh_key_pair_name: bosh_keypair

--- a/manifests/bosh-manifest/spec/properties_spec.rb
+++ b/manifests/bosh-manifest/spec/properties_spec.rb
@@ -32,4 +32,8 @@ RSpec.describe "manifest properties validations" do
   it "disables the health manager resurrector" do
     expect(bosh_properties["hm"]["resurrector_enabled"]).to eq(false)
   end
+
+  it "configures datadog tag bosh-job" do
+    expect(bosh_properties["tags"]["bosh-job"]).to eq("bosh")
+  end
 end

--- a/manifests/bosh-manifest/spec/shared_config_spec.rb
+++ b/manifests/bosh-manifest/spec/shared_config_spec.rb
@@ -1,0 +1,8 @@
+RSpec.describe "Gets properties from shared config" do
+  let(:manifest) { manifest_with_defaults }
+  let(:bosh_properties) { manifest.fetch("jobs").select { |x| x["name"] == "bosh" }.first["properties"] }
+
+  it "for datadog" do
+    expect(bosh_properties["use_dogstatsd"]).to eq false
+  end
+end

--- a/manifests/bosh-manifest/spec/support/manifest_helpers.rb
+++ b/manifests/bosh-manifest/spec/support/manifest_helpers.rb
@@ -19,6 +19,7 @@ private
     ENV["BOSH_FQDN"] = "bosh.domain"
     ENV["AWS_ACCOUNT"] = "dev"
     ENV["BOSH_INSTANCE_PROFILE"] = "bosh-director-build"
+    ENV["DATADOG_API_KEY"] = "abcd1234"
   end
 
   def load_default_manifest
@@ -27,9 +28,11 @@ private
       [
         File.expand_path("../../../../shared/build_manifest.sh", __FILE__),
         File.expand_path("../../../bosh-manifest.yml", __FILE__),
+        File.expand_path("../../../extensions/datadog-agent.yml", __FILE__),
         File.expand_path("../../fixtures/bosh-secrets.yml", __FILE__),
         File.expand_path("../../fixtures/bosh-ssl-certificates.yml", __FILE__),
         File.expand_path("../../fixtures/bosh-terraform-outputs.yml", __FILE__),
+        File.expand_path("../../../../shared/deployments/datadog-agent.yml", __FILE__),
       ].join(' ')
     )
     expect(status).to be_success, "build_manifest.sh exited #{status.exitstatus}, stderr:\n#{error}"

--- a/manifests/concourse-manifest/extensions/datadog-agent.yml
+++ b/manifests/concourse-manifest/extensions/datadog-agent.yml
@@ -26,4 +26,6 @@ jobs:
           riemann:
             host: '127.0.0.1'
             service_prefix: 'concourse.'
-
+            tags:
+              aws_account: (( grab $AWS_ACCOUNT ))
+              deploy_env: (( grab terraform_outputs.environment ))

--- a/manifests/concourse-manifest/extensions/datadog-agent.yml
+++ b/manifests/concourse-manifest/extensions/datadog-agent.yml
@@ -1,0 +1,29 @@
+releases:
+  - name: riemann
+    url: https://github.com/alphagov/paas-riemann-boshrelease/releases/download/v0.5.0-dev/riemann-gds-4.tgz
+    sha1: 76bbc59dfb46052353226839c67ad1f011ed2225
+    version: gds-4
+
+jobs:
+  - name: concourse
+    templates:
+      - name: datadog-agent
+        release: datadog-agent
+        properties:
+          datadog: (( inject meta.datadog ))
+          tags:
+            bosh-job: concourse
+            bosh-az: z1
+      - name: riemann
+        release: riemann
+        properties:
+          riemann:
+            datadog:
+              api_key: (( grab meta.datadog.api_key ))
+
+      - name: atc
+        properties:
+          riemann:
+            host: '127.0.0.1'
+            service_prefix: 'concourse.'
+

--- a/manifests/concourse-manifest/spec/manifest_generation_spec.rb
+++ b/manifests/concourse-manifest/spec/manifest_generation_spec.rb
@@ -21,6 +21,7 @@ RSpec.describe "manifest generation" do
 
   let(:concourse_job) { manifest_with_defaults.fetch("jobs").find { |job| job["name"] == "concourse" } }
   let(:atc_template) { concourse_job.fetch("templates").find { |t| t["name"] == "atc" } }
+  let(:datadog_template) { concourse_job.fetch("templates").find { |t| t["name"] == "datadog-agent" } }
 
   it "gets values from vpc terraform outputs" do
     expect(
@@ -53,5 +54,18 @@ RSpec.describe "manifest generation" do
     # `merge!': can't convert nil into Hash (TypeError)
     job_level_properties = concourse_job["properties"]
     expect(job_level_properties).to be_a(Hash)
+  end
+
+  it "configures datadog tag bosh-job" do
+    job_level_properties = datadog_template["properties"]
+    expect(job_level_properties["tags"]["bosh-job"]).to eq("concourse")
+  end
+
+  it "configures datadog tag bosh-az with the right AZ as it is defined in the deployment" do
+    concourse_resource_pool = manifest_with_defaults.fetch("resource_pools").find { |job| job["name"] == "concourse" }
+    expect(concourse_resource_pool["cloud_properties"]["availability_zone"]).to eq("eu-west-1a")
+
+    job_level_properties = datadog_template["properties"]
+    expect(job_level_properties["tags"]["bosh-az"]).to eq("z1")
   end
 end

--- a/manifests/concourse-manifest/spec/shared_config_spec.rb
+++ b/manifests/concourse-manifest/spec/shared_config_spec.rb
@@ -1,0 +1,10 @@
+
+RSpec.describe "Concourse shared properties" do
+  let(:manifest) { manifest_with_defaults }
+  let(:concourse_job) { manifest.fetch("jobs").find { |job| job["name"] == "concourse" } }
+  let(:datadog_template) { concourse_job.fetch("templates").find { |t| t["name"] == "datadog-agent" } }
+
+  it "Adds datadog and pulls datadog properties from a shared config file" do
+    expect(datadog_template.fetch("properties").fetch("use_dogstatsd")).to eq(false)
+  end
+end

--- a/manifests/concourse-manifest/spec/support/manifest_helpers.rb
+++ b/manifests/concourse-manifest/spec/support/manifest_helpers.rb
@@ -17,6 +17,7 @@ private
   def fake_env_vars
     ENV["AWS_ACCOUNT"] = "dev"
     ENV["CONCOURSE_INSTANCE_PROFILE"] = "concourse-build"
+    ENV["DATADOG_API_KEY"] = "abcd1234"
   end
 
   def load_default_manifest
@@ -25,11 +26,13 @@ private
       [
         File.expand_path("../../../../shared/build_manifest.sh", __FILE__),
         File.expand_path("../../../concourse-base.yml", __FILE__),
+        File.expand_path("../../../extensions/datadog-agent.yml", __FILE__),
         File.expand_path("../../fixtures/predefined-concourse-secrets.yml", __FILE__),
         File.expand_path("../../fixtures/generated-concourse-secrets.yml", __FILE__),
         File.expand_path("../../fixtures/concourse-terraform-outputs.yml", __FILE__),
         File.expand_path("../../fixtures/bosh-terraform-outputs.yml", __FILE__),
         File.expand_path("../../fixtures/vpc-terraform-outputs.yml", __FILE__),
+        File.expand_path("../../../../shared/deployments/datadog-agent.yml", __FILE__),
       ].join(' ')
     )
     expect(status).to be_success, "build_manifest.sh exited #{status.exitstatus}, stderr:\n#{error}"

--- a/manifests/shared/deployments/datadog-agent.yml
+++ b/manifests/shared/deployments/datadog-agent.yml
@@ -1,0 +1,15 @@
+---
+releases:
+- name: datadog-agent
+  sha1: 14c7f9be2eb534fda1f4c70ea2355865ac93a87b
+  url: https://github.com/alphagov/paas-datadog-agent-boshrelease/releases/download/v5.8.5.3-gds/datadog-agent-v5.8.5.3-gds.tgz
+  version: "v5.8.5.3-gds"
+
+meta:
+  datadog:
+    api_key: (( grab $DATADOG_API_KEY || "undefined" ))
+    use_dogstatsd: false
+    include_bosh_tags: true
+    tags:
+      aws_account: (( grab $AWS_ACCOUNT ))
+

--- a/manifests/shared/deployments/datadog-agent.yml
+++ b/manifests/shared/deployments/datadog-agent.yml
@@ -12,4 +12,5 @@ meta:
     include_bosh_tags: true
     tags:
       aws_account: (( grab $AWS_ACCOUNT ))
+      deploy_env: (( grab terraform_outputs.environment ))
 

--- a/scripts/upload-datadog-secrets.sh
+++ b/scripts/upload-datadog-secrets.sh
@@ -1,0 +1,19 @@
+#!/bin/sh
+
+set -eu
+
+export PASSWORD_STORE_DIR=${DATADOG_PASSWORD_STORE_DIR}
+
+DATADOG_API_KEY=$(pass "datadog/${AWS_ACCOUNT}/datadog_api_key")
+DATADOG_APP_KEY=$(pass "datadog/${AWS_ACCOUNT}/datadog_app_key")
+
+SECRETS=$(mktemp secrets.yml.XXXXXX)
+trap 'rm  "${SECRETS}"' EXIT
+
+cat > "${SECRETS}" << EOF
+---
+datadog_api_key: ${DATADOG_API_KEY}
+datadog_app_key: ${DATADOG_APP_KEY}
+EOF
+
+aws s3 cp "${SECRETS}" "s3://gds-paas-${DEPLOY_ENV}-bootstrap/datadog-secrets.yml"

--- a/terraform/bosh/outputs.tf
+++ b/terraform/bosh/outputs.tf
@@ -50,6 +50,10 @@ output "bosh_az" {
   value = "${var.bosh_az}"
 }
 
+output "bosh_az_label" {
+  value = "${lookup(var.zone_labels, var.bosh_az)}"
+}
+
 output "bosh_ssh_key_pair_name" {
   value = "${aws_key_pair.bosh_ssh_key_pair.key_name}"
 }

--- a/terraform/globals.tf
+++ b/terraform/globals.tf
@@ -39,6 +39,15 @@ variable "zone_index" {
   }
 }
 
+variable "zone_labels" {
+  description = "AWS availability zone labels as used in BOSH manifests (z1-z3)"
+  default     = {
+    eu-west-1a = "z1"
+    eu-west-1b = "z2"
+    eu-west-1c = "z3"
+  }
+}
+
 variable "zone_count" {
   description = "Number of zones to use"
   default = 3


### PR DESCRIPTION
## What

[#131876273 - Deploy build concourse](https://www.pivotaltracker.com/n/projects/1275640/stories/131876273)

We want to gather metrics from Bosh and Concourse so we can monitor them in Datadog. This pull request adds the Datadog agent to the machines and the necessary logic to turn off this functionality in our dev environments.

## How to review

* Set your `$DEPLOY_ENV` to a value different to your existing dev environment
* Deploy from this branch using the README. There should be no data sent to Datadog at this stage. Example:
    ```
    BOSH_INSTANCE_PROFILE=bosh-director-build CONCOURSE_INSTANCE_PROFILE=concourse-build BRANCH=add-datadog-131876273 DEPLOY_ENV="$DEPLOY_ENV" make dev bootstrap
    ```
* Follow the documentation in `doc/datadog.md` to upload credentials and deploy with checks enabled for your dev environment
* Check metrics are sent to Datadog. They should have a `bosh-deployment` tag which is set to your `$DEPLOY_ENV` value.
    * Those sent by the agent: `system.*`
    * Those sent by Riemann: `concourse.*`
* Tear down your environment afterwards (Run the destroy pipeline)

## Who can review

Anyone but me or @alext 