### PR TITLE
Add make target to setup build profiles.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,6 +49,8 @@ globals:
 	$(eval export AWS_DEFAULT_REGION=eu-west-1)
 	@true
 
+## Environments
+
 .PHONY: dev
 dev: globals check-env-vars ## Set Environment to DEV
 	$(eval export SYSTEM_DNS_ZONE_NAME=${DEPLOY_ENV}.dev.cloudpipeline.digital)
@@ -61,12 +63,21 @@ ci: globals check-env-vars ## Set Environment to CI
 	$(eval export AWS_ACCOUNT=ci)
 	$(eval export ENABLE_DATADOG=true)
 
+
+## Concourse profiles
+
+.PHONY: build-concourse ## Setup profiles for deploying a build concourse
+build-concourse:
+	$(eval export BOSH_INSTANCE_PROFILE=bosh-director-build)
+	$(eval export CONCOURSE_INSTANCE_PROFILE=concourse-build)
+
+## Actions
+
 .PHONY: fly-login
 fly-login: ## Do a fly login and sync
 	$(eval export TARGET_CONCOURSE=deployer)
 	$$("./concourse/scripts/environment.sh") && \
 		./concourse/scripts/fly_sync_and_login.sh
-
 
 .PHONY: bootstrap
 bootstrap: ## Start bootstrap

--- a/README.md
+++ b/README.md
@@ -21,8 +21,7 @@ or destroyed.
 
 In order to use this repository you will need:
 
-* Predefined [IAM instance profiles](http://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_use_switch-role-ec2_instance-profiles.html) that will be assigned to Concourse-lite, BOSH and Concourse. `concourse-lite` is a hard coded name, whereas the BOSH and Concourse roles can be any name and must be exported with respective variables `BOSH_INSTANCE_PROFILE` and `CONCOURSE_INSTANCE_PROFILE`. See [aws-account-wide-terraform](https://github.gds/government-paas/aws-account-wide-terraform) for details
-(not public because it also contains state files).
+* Predefined [IAM instance profiles](http://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_use_switch-role-ec2_instance-profiles.html) that will be assigned to Concourse-lite, BOSH and Concourse. See below for details.
 
 * [AWS Command Line tool (`awscli`)](https://aws.amazon.com/cli/). You can
 install it using [any of the official methods](http://docs.aws.amazon.com/cli/latest/userguide/installing.html)
@@ -68,12 +67,18 @@ $ export DEPLOY_ENV=environment-name
 
 ### Deploy
 
-Create Concourse Lite with `make`. Select the target based on which AWS account you want to work with. For instance for a DEV bootstrap:
+Create Concourse Lite with `make`. There are targets to select the target AWS account, and to select the profiles to apply. For instance for a DEV build concourse bootstrap:
 
 ```
-make dev bootstrap
+make dev build-concourse bootstrap
 ```
+
 `make help` will show all available options.
+
+To deploy a concourse with custom profiles, it's necessary to set corresponding ENV vars. eg:
+```
+BOSH_INSTANCE_PROFILE=bosh-director-foo CONCOURSE_INSTANCE_PROFILE=concourse-foo make dev bootstrap
+```
 
 NB: This will [auto-delete overnight](#overnight-deletion-of-environments)
 by default.


### PR DESCRIPTION
## What

To save looking up the relevant instance profiles each time, this adds a
make target to set them. This can be used as `make dev build-concourse
bootstrap`. I anticipate that other profiles will be added over time as
this expands to handling more than just the build concourse.

## How to review

Check the changes look sensible.
Check you can spin up a bootstrap concourse using the new target (no need to run any pipelines in this).

## Who can review

Anyone but myself.
