### PR TITLE
[#133036569] Migrate to new ELB security policies

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -66,10 +66,11 @@ ci: globals check-env-vars ## Set Environment to CI
 
 ## Concourse profiles
 
-.PHONY: build-concourse ## Setup profiles for deploying a build concourse
-build-concourse:
+.PHONY: build-concourse
+build-concourse: ## Setup profiles for deploying a build concourse
 	$(eval export BOSH_INSTANCE_PROFILE=bosh-director-build)
 	$(eval export CONCOURSE_INSTANCE_PROFILE=concourse-build)
+	@true
 
 ## Actions
 

--- a/terraform/concourse/elb.tf
+++ b/terraform/concourse/elb.tf
@@ -34,6 +34,15 @@ resource "aws_elb" "concourse" {
   }
 }
 
+resource "aws_load_balancer_listener_policy" "concourse_listener_policies_443" {
+  load_balancer_name = "${aws_elb.concourse.name}"
+  load_balancer_port = 443
+
+  policy_names = [
+    "${var.default_elb_security_policy}",
+  ]
+}
+
 resource "aws_security_group" "concourse-elb" {
   name        = "${var.env}-concourse-elb"
   description = "Concourse ELB security group"

--- a/terraform/globals.tf
+++ b/terraform/globals.tf
@@ -114,6 +114,12 @@ variable "web_access_cidrs" {
   default     = ""
 }
 
+/* See https://docs.aws.amazon.com/elasticloadbalancing/latest/classic/elb-security-policy-table.html */
+variable "default_elb_security_policy" {
+  description = "Which Security policy to use for ELBs. This controls things like available SSL protocols/ciphers."
+  default     = "ELBSecurityPolicy-2016-08"
+}
+
 # List of Elastic Load Balancing Account ID to configure ELB access log policies
 # Provided by AWS in http://docs.aws.amazon.com/ElasticLoadBalancing/latest/DeveloperGuide/enable-access-logs.html
 variable "elb_account_ids" {


### PR DESCRIPTION
## What

Story: https://www.pivotaltracker.com/story/show/133036569

The default behaviour if this is unspecified is for the ELBs to get the AWS
default security policy at the time that the ELB is created. This has led to
our long-lived deployments having an older security policy, which raises
warnings in Trusted Advisor etc.

This therefore updates the concourse ELB to use the latest built-in AWS policy
(2016-08).

## How to review

Code sanity check. 
Run bootstrap (as far as concourse-terraform) and check if Concourse ELB has been updated. 

## Who can review

Not @alext or @combor