### PR TITLE
[#133036569] Fix specification of ELB security policy.

### DIFF
--- a/terraform/concourse/elb.tf
+++ b/terraform/concourse/elb.tf
@@ -34,13 +34,15 @@ resource "aws_elb" "concourse" {
   }
 }
 
-resource "aws_load_balancer_listener_policy" "concourse_listener_policies_443" {
-  load_balancer_name = "${aws_elb.concourse.name}"
-  load_balancer_port = 443
+resource "aws_lb_ssl_negotiation_policy" "concourse" {
+  name          = "paas-${var.default_elb_security_policy}"
+  load_balancer = "${aws_elb.concourse.id}"
+  lb_port       = 443
 
-  policy_names = [
-    "${var.default_elb_security_policy}",
-  ]
+  attribute {
+    name  = "Reference-Security-Policy"
+    value = "${var.default_elb_security_policy}"
+  }
 }
 
 resource "aws_security_group" "concourse-elb" {


### PR DESCRIPTION
## What

This fixes #11. The previous version will only work for recently created ELBs. See the commit message for more details.

## How to review

This can be reviewed in the same manner as https://github.com/alphagov/paas-cf/pull/653.

Alternatively, you could trust that if the change works on paas-cf, it'll work here.

## Who can review

Anyone but myself.