### PR TITLE
Update Bosh RDS postgres version in terraform.

### DIFF
--- a/terraform/bosh/rds.tf
+++ b/terraform/bosh/rds.tf
@@ -40,7 +40,7 @@ resource "aws_db_instance" "bosh" {
   allocated_storage = 5
   storage_type = "gp2"
   engine = "postgres"
-  engine_version = "9.4.5"
+  engine_version = "9.4.7"
   instance_class = "db.t2.medium"
   username = "dbadmin"
   password = "${var.secrets_bosh_postgres_password}"


### PR DESCRIPTION
## What

This has auto_minor_version_upgrade set to true (we're not specifying it
in the terraform config, and this is the default). This instance has
therefore been upgraded automatically to 9.4.7. As a result, terraform
fail with the error:

Error modifying DB Instance build-bosh: InvalidParameterCombination:
Cannot upgrade postgres from 9.4.7 to 9.4.5

Updating this version to match will unblock the pipeline.

## How to review

Code review. Verify that the Bosh RDS instance for the CI build deployment is indeed running the matching version of postgres.

## Who can review

Anyone but myself.