### PR TITLE
[#131876783] Generate concourse DB password

### DIFF
--- a/manifests/concourse-manifest/concourse-base.yml
+++ b/manifests/concourse-manifest/concourse-base.yml
@@ -86,7 +86,7 @@ jobs:
           databases:
             - name: atc
               role: atc
-              password: dummy-password
+              password: (( grab secrets.concourse_postgres_password ))
 
       - name: atc
         release: concourse
@@ -100,7 +100,7 @@ jobs:
             database: atc
             role:
               name: atc
-              password: dummy-password
+              password: (( grab secrets.concourse_postgres_password ))
 
       - name: groundcrew
         release: concourse

--- a/manifests/concourse-manifest/scripts/generate-concourse-secrets.rb
+++ b/manifests/concourse-manifest/scripts/generate-concourse-secrets.rb
@@ -7,6 +7,7 @@ require File.expand_path("../../../shared/lib/secret_generator", __FILE__)
 generator = SecretGenerator.new(
   "concourse_nats_password" => :simple,
   "concourse_vcap_password" => :sha512_crypted,
+  "concourse_postgres_password" => :simple,
 )
 
 option_parser = OptionParser.new do |opts|

--- a/manifests/concourse-manifest/spec/fixtures/generated-concourse-secrets.yml
+++ b/manifests/concourse-manifest/spec/fixtures/generated-concourse-secrets.yml
@@ -2,3 +2,4 @@
 secrets:
   concourse_nats_password: CONCOURSE_NATS_PASSWORD
   concourse_vcap_password: CONCOURSE_VCAP_PASSWORD
+  concourse_postgres_password: dummy-password


### PR DESCRIPTION
## What

In order to be a bit more secure, generate postgres password on for
concourse instead of using hardcoded value.

Cherry picked from alphagov/paas-cf@7014122. This is not very disruptive for an
existing instance:

```
Detecting deployment changes
----------------------------
jobs:
- name: concourse
  templates:
  - name: postgresql
    properties:
      databases:
      - name: "<redacted>"
        password: "<redacted>"
        password: "<redacted>"
  - name: atc
    properties:
      postgresql:
        role:
          password: "<redacted>"
          password: "<redacted>"

Deploying
---------

Director task 7
Deprecation: Ignoring cloud config. Manifest contains 'networks' section.

  Started preparing deployment > Preparing deployment. Done (00:00:00)

  Started preparing package compilation > Finding packages to compile. Done (00:00:00)

  Started updating instance concourse > concourse/4d42d338-774b-49ea-912a-518a751809e8 (0) (canary). Done (00:01:05)

Task 7 done
```

## How to review

I have tested this and it's quite time consuming. I'd be comfortable if you've seen this happen on alphagov/paas-cf before and don't want to run all this again:

1. Provision a bootstrap Concourse from the `master` branch.
1. Run the `create` pipeline to make a subsequent Concourse.
1. Login to the Concourse.
1. Switch to this branch and push the pipelines to your bootstrap Concourse.
1. Re-run the `create` pipeline and observe it re-deploy the subsequent Concourse.
1. Confirm that you can still access the subsequent Concourse.

## Who can review

Not @dcarley