### PR TITLE
Fix state bucket name in dev scripts.

### DIFF
--- a/concourse/scripts/pipelines.sh
+++ b/concourse/scripts/pipelines.sh
@@ -5,9 +5,11 @@ SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)
 
 "${SCRIPT_DIR}/fly_sync_and_login.sh"
 
+state_bucket=gds-paas-${DEPLOY_ENV}-state
+
 get_datadog_secrets() {
   # shellcheck disable=SC2154
-  secrets_uri="s3://gds-paas-${DEPLOY_ENV}-bootstrap/datadog-secrets.yml"
+  secrets_uri="s3://${state_bucket}/datadog-secrets.yml"
   export datadog_api_key
   export datadog_app_key
   if aws s3 ls "${secrets_uri}" > /dev/null ; then
@@ -28,7 +30,7 @@ generate_vars_file() {
 aws_account: ${AWS_ACCOUNT}
 vagrant_ip: ${VAGRANT_IP}
 deploy_env: ${DEPLOY_ENV}
-state_bucket: gds-paas-${DEPLOY_ENV}-state
+state_bucket: ${state_bucket}
 branch_name: ${BRANCH:-master}
 aws_region: ${AWS_DEFAULT_REGION:-eu-west-1}
 concourse_atc_password: ${CONCOURSE_ATC_PASSWORD}

--- a/concourse/scripts/ssh.sh
+++ b/concourse/scripts/ssh.sh
@@ -5,6 +5,7 @@ TUNNEL=${1:-}
 SOCKET_DIR=~/.ssh
 SOCKET_DEF=%r@%h:%p
 SOCKET=$SOCKET_DIR/$SOCKET_DEF
+state_bucket=gds-paas-${DEPLOY_ENV}-state
 
 download_key() {
   key=/tmp/concourse_id_rsa.$RANDOM
@@ -12,12 +13,12 @@ download_key() {
 
   eval "$(make dev showenv | grep CONCOURSE_IP=)"
 
-  aws s3 cp "s3://gds-paas-${DEPLOY_ENV}-bootstrap/concourse_id_rsa" $key && chmod 400 $key
+  aws s3 cp "s3://${state_bucket}/concourse_id_rsa" $key && chmod 400 $key
 }
 
 ssh_concourse() {
   echo
-  aws s3 cp "s3://gds-paas-${DEPLOY_ENV}-bootstrap/concourse-secrets.yml" - | \
+  aws s3 cp "s3://${state_bucket}/concourse-secrets.yml" - | \
     ruby -ryaml -e 'puts "Sudo password is " + YAML.load(STDIN)["secrets"]["concourse_vcap_password_orig"]'
   echo
 

--- a/scripts/upload-datadog-secrets.sh
+++ b/scripts/upload-datadog-secrets.sh
@@ -16,4 +16,4 @@ datadog_api_key: ${DATADOG_API_KEY}
 datadog_app_key: ${DATADOG_APP_KEY}
 EOF
 
-aws s3 cp "${SECRETS}" "s3://gds-paas-${DEPLOY_ENV}-bootstrap/datadog-secrets.yml"
+aws s3 cp "${SECRETS}" "s3://gds-paas-${DEPLOY_ENV}-state/datadog-secrets.yml"


### PR DESCRIPTION
## What

These references to the old state bucket name were missed when the
bucket was renamed in ead368e. Without this, ssh to the concourse
instance fails because it can't find the key in the bucket etc.

## How to review

Attempt to ssh to a concourse deployed from this repo. It should now succeed

## Who can review

Anyone but myself.