### PR TITLE
[#131876783] Make non-dev Concourses safer to use

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -61,6 +61,7 @@ dev: globals check-env-vars ## Set Environment to DEV
 	$(eval export SYSTEM_DNS_ZONE_NAME=${DEPLOY_ENV}.dev.cloudpipeline.digital)
 	$(eval export AWS_ACCOUNT=dev)
 	$(eval export ENABLE_DATADOG ?= false)
+	$(eval export CONCOURSE_AUTH_DURATION=48h)
 
 .PHONY: ci
 ci: globals check-env-vars ## Set Environment to CI

--- a/concourse/pipelines/create.yml
+++ b/concourse/pipelines/create.yml
@@ -935,6 +935,31 @@ jobs:
           params:
             file: updated-concourse-manifest/concourse-manifest.yml
 
+      - task: add-env-specific-team
+        config:
+          image: docker:///governmentpaas/self-update-pipelines
+          inputs:
+            - name: paas-bootstrap
+            - name: concourse-manifest
+          params:
+            CONCOURSE_HOSTNAME: {{concourse_hostname}}
+            SYSTEM_DNS_ZONE_NAME: {{system_dns_zone_name}}
+            CONCOURSE_ATC_PASSWORD: {{concourse_atc_password}}
+            CONCOURSE_ATC_USER: admin
+            FLY_TEAM: {{aws_account}}
+            FLY_TARGET: {{deploy_env}}
+            FLY_CMD: ./paas-bootstrap/bin/fly
+          run:
+            path: sh
+            args:
+              - -e
+              - -c
+              - |
+                export CONCOURSE_URL="https://${CONCOURSE_HOSTNAME}.${SYSTEM_DNS_ZONE_NAME}"
+                ./paas-bootstrap/concourse/scripts/fly_sync_and_login.sh
+                echo y | ${FLY_CMD} -t ${FLY_TARGET} set-team -n ${FLY_TEAM} \
+                           --basic-auth-username admin --basic-auth-password ${CONCOURSE_ATC_PASSWORD}
+
       - task: test-bosh-vms
         config:
           platform: linux

--- a/concourse/pipelines/create.yml
+++ b/concourse/pipelines/create.yml
@@ -758,6 +758,7 @@ jobs:
           - name: git-ssh-public-key
           - name: concourse-ssh-key
           params:
+            VAGRANT_IP: {{vagrant_ip}}
             TF_VAR_env: {{deploy_env}}
             TF_VAR_concourse_hostname: {{concourse_hostname}}
             TF_VAR_system_dns_zone_name: {{system_dns_zone_name}}
@@ -775,7 +776,8 @@ jobs:
               export TF_VAR_git_rsa_id_pub
               TF_VAR_git_rsa_id_pub=$(cat git-ssh-public-key/git_id_rsa.pub)
 
-              terraform apply \
+              terraform_params=${VAGRANT_IP:+-var vagrant_cidr=$VAGRANT_IP/32}
+              terraform apply ${terraform_params} \
                 -var-file=paas-bootstrap/terraform/{{aws_account}}.tfvars \
                 -state=concourse-tfstate/concourse.tfstate \
                 -state-out=concourse.tfstate \
@@ -990,15 +992,18 @@ jobs:
           passed: ['concourse-deploy']
         - get: vpc-tfstate
         - get: bosh-tfstate
+        - get: concourse-tfstate
 
-      - task: vpc-terraform-outputs-to-sh
+      - task: terraform-outputs-to-sh
         config:
           image: docker:///ruby#2.2-slim
           inputs:
           - name: paas-bootstrap
           - name: vpc-tfstate
+          - name: bosh-tfstate
           outputs:
           - name: vpc-terraform-outputs
+          - name: bosh-terraform-outputs
           run:
             path: sh
             args:
@@ -1009,6 +1014,10 @@ jobs:
               < vpc-tfstate/vpc.tfstate \
               > vpc-terraform-outputs/tfvars.sh
               ls -l vpc-terraform-outputs/tfvars.sh
+              ruby paas-bootstrap/concourse/scripts/extract_tf_vars_from_terraform_state.rb \
+              < bosh-tfstate/bosh.tfstate \
+              > bosh-terraform-outputs/tfvars.sh
+              ls -l bosh-terraform-outputs/tfvars.sh
 
       - task: remove-vagrant-IP-from-ssh-SG
         config:
@@ -1067,3 +1076,36 @@ jobs:
           params:
             file: remove-vagrant-IP-from-BOSH-SG/bosh.tfstate
 
+      - task: remove-vagrant-IP-from-Concourse-SG
+        config:
+          platform: linux
+          image: docker:///governmentpaas/terraform
+          inputs:
+          - name: paas-bootstrap
+          - name: vpc-terraform-outputs
+          - name: bosh-terraform-outputs
+          - name: concourse-tfstate
+          params:
+            TF_VAR_env: {{deploy_env}}
+            TF_VAR_concourse_hostname: {{concourse_hostname}}
+            TF_VAR_system_dns_zone_name: {{system_dns_zone_name}}
+            TF_VAR_git_rsa_id_pub: ""
+            AWS_DEFAULT_REGION: {{aws_region}}
+          run:
+            path: sh
+            args:
+            - -e
+            - -c
+            - |
+              . vpc-terraform-outputs/tfvars.sh
+              . bosh-terraform-outputs/tfvars.sh
+
+              terraform apply -target=aws_security_group.concourse \
+                -var-file=paas-bootstrap/terraform/{{aws_account}}.tfvars \
+                -state=concourse-tfstate/concourse.tfstate \
+                -state-out=concourse.tfstate \
+                paas-bootstrap/terraform/concourse
+        ensure:
+          put: concourse-tfstate
+          params:
+            file: remove-vagrant-IP-from-Concourse-SG/concourse.tfstate

--- a/concourse/pipelines/create.yml
+++ b/concourse/pipelines/create.yml
@@ -859,6 +859,7 @@ jobs:
             AWS_ACCOUNT: {{aws_account}}
             DATADOG_API_KEY: {{datadog_api_key}}
             ENABLE_DATADOG: {{enable_datadog}}
+            CONCOURSE_AUTH_DURATION: {{concourse_auth_duration}}
             CONCOURSE_MANIFEST_STUBS: |
               ./paas-bootstrap/manifests/concourse-manifest/concourse-base.yml
               concourse-secrets/concourse-secrets.yml

--- a/concourse/scripts/pipelines.sh
+++ b/concourse/scripts/pipelines.sh
@@ -46,6 +46,7 @@ bosh_instance_profile: ${BOSH_INSTANCE_PROFILE}
 concourse_instance_profile: ${CONCOURSE_INSTANCE_PROFILE}
 enable_datadog: ${ENABLE_DATADOG}
 datadog_api_key: ${datadog_api_key:-}
+concourse_auth_duration: ${CONCOURSE_AUTH_DURATION:-5m}
 EOF
 }
 

--- a/manifests/concourse-manifest/concourse-base.yml
+++ b/manifests/concourse-manifest/concourse-base.yml
@@ -94,6 +94,7 @@ jobs:
           external_url: (( concat "https://" terraform_outputs.concourse_dns_name ))
           basic_auth_username: admin
           basic_auth_password: (( grab secrets.concourse_atc_password ))
+          auth_duration: (( grab $CONCOURSE_AUTH_DURATION ))
 
           postgresql:
             address: 127.0.0.1:5432

--- a/manifests/concourse-manifest/spec/support/manifest_helpers.rb
+++ b/manifests/concourse-manifest/spec/support/manifest_helpers.rb
@@ -18,6 +18,7 @@ private
     ENV["AWS_ACCOUNT"] = "dev"
     ENV["CONCOURSE_INSTANCE_PROFILE"] = "concourse-build"
     ENV["DATADOG_API_KEY"] = "abcd1234"
+    ENV["CONCOURSE_AUTH_DURATION"] = "5m"
   end
 
   def load_default_manifest

--- a/terraform/concourse/elb.tf
+++ b/terraform/concourse/elb.tf
@@ -58,20 +58,11 @@ resource "aws_security_group" "concourse-elb" {
     cidr_blocks = ["0.0.0.0/0"]
   }
 
-  /* FIXME: Merge these two ingress block back together once */
-  /* https://github.com/hashicorp/terraform/issues/5301 is resolved. */
   ingress {
     from_port   = 443
     to_port     = 443
     protocol    = "tcp"
-    cidr_blocks = ["${compact(split(",", var.admin_cidrs))}"]
-  }
-
-  ingress {
-    from_port   = 443
-    to_port     = 443
-    protocol    = "tcp"
-    cidr_blocks = ["${aws_eip.concourse.public_ip}/32"]
+    cidr_blocks = ["${compact(concat(split(",", var.admin_cidrs), list("${aws_eip.concourse.public_ip}/32"), list(var.vagrant_cidr)))}"]
   }
 
   tags {


### PR DESCRIPTION
## What

Port some changes from alphagov/paas-cf which make Concourse servers in non-development environments safer to use, by introducing a "team" which indicates the environment name and forcing people to re-login after short periods of time when making changes.

## How to review

This functionality has been tested before in paas-cf and I've tested it from scratch against this branch (in addition to ongoing WIP branch that Alex and I have for Deployer Concourse), so if you're comfortable with reviewing the code-only then I think that'd be OK.

1. Checkout this branch: `feature/131876783-distinct_concourses`
1. Create a bootstrap: `BRANCH=$(git rev-parse --abbrev-ref HEAD) make dev build-concourse bootstrap`
1. Run the `create` pipeline.
1. Confirm that it shows you the environment name when you login at: `https://concourse.${DEPLOY_ENV}.dev.cloudpipeline.digital/`

Testing the auth duration is more difficult. You can temporarily remove the line `$(eval export CONCOURSE_AUTH_DURATION=48h)` from the `dev` target in the `Makefile` and repeat the steps, then see if you have to re-login to the Build Concourse after 5 minutes.

## Who can review

Not @dcarley