### PR TITLE
[#131876783] Remove vagrant IP from bosh_rds security group.

### DIFF
--- a/terraform/bosh/rds.tf
+++ b/terraform/bosh/rds.tf
@@ -14,10 +14,9 @@ resource "aws_security_group" "bosh_rds" {
   vpc_id      = "${var.vpc_id}"
 
   ingress {
-    from_port   = 5432
-    to_port     = 5432
-    protocol    = "tcp"
-    cidr_blocks = ["${var.vagrant_cidr}"]
+    from_port = 5432
+    to_port   = 5432
+    protocol  = "tcp"
 
     security_groups = [
       "${aws_security_group.bosh.id}",


### PR DESCRIPTION
## What

There's no need for concourse-lite to connect to the RDS instance.
Additionally, this entry wasn't being expunged at the end of the
pipeline because the expunge terraform run only targets the `bosh`
security group, and doesn't include this one.

## How to review

Run the create pipeline and verify it successfully deploys a bosh and concourse.

## Who can review

Anyone but myself.