### PR TITLE
[#131876783] Enable datadog bosh health_manager integration

### DIFF
--- a/concourse/pipelines/create.yml
+++ b/concourse/pipelines/create.yml
@@ -585,6 +585,7 @@ jobs:
           params:
             AWS_ACCOUNT: {{aws_account}}
             DATADOG_API_KEY: {{datadog_api_key}}
+            DATADOG_APP_KEY: {{datadog_app_key}}
             ENABLE_DATADOG: {{enable_datadog}}
             BOSH_MANIFEST_STUBS: |
               ./paas-bootstrap/manifests/bosh-manifest/bosh-manifest.yml
@@ -858,6 +859,7 @@ jobs:
           params:
             AWS_ACCOUNT: {{aws_account}}
             DATADOG_API_KEY: {{datadog_api_key}}
+            DATADOG_APP_KEY: {{datadog_app_key}}
             ENABLE_DATADOG: {{enable_datadog}}
             CONCOURSE_AUTH_DURATION: {{concourse_auth_duration}}
             CONCOURSE_MANIFEST_STUBS: |

--- a/concourse/scripts/pipelines.sh
+++ b/concourse/scripts/pipelines.sh
@@ -46,6 +46,7 @@ bosh_instance_profile: ${BOSH_INSTANCE_PROFILE}
 concourse_instance_profile: ${CONCOURSE_INSTANCE_PROFILE}
 enable_datadog: ${ENABLE_DATADOG}
 datadog_api_key: ${datadog_api_key:-}
+datadog_app_key: ${datadog_app_key:-}
 concourse_auth_duration: ${CONCOURSE_AUTH_DURATION:-5m}
 EOF
 }

--- a/manifests/bosh-manifest/extensions/datadog-agent.yml
+++ b/manifests/bosh-manifest/extensions/datadog-agent.yml
@@ -8,3 +8,8 @@ jobs:
     tags:
       bosh-job: bosh
       bosh-az: (( grab terraform_outputs.bosh_az_label ))
+    hm:
+      datadog_enabled: (( grab meta.datadog.enabled ))
+      datadog:
+          api_key: (( grab meta.datadog.api_key ))
+          application_key: (( grab meta.datadog.application_key ))

--- a/manifests/bosh-manifest/spec/support/manifest_helpers.rb
+++ b/manifests/bosh-manifest/spec/support/manifest_helpers.rb
@@ -20,6 +20,8 @@ private
     ENV["AWS_ACCOUNT"] = "dev"
     ENV["BOSH_INSTANCE_PROFILE"] = "bosh-director-build"
     ENV["DATADOG_API_KEY"] = "abcd1234"
+    ENV["DATADOG_APP_KEY"] = "abcd4321"
+    ENV["ENABLE_DATADOG"] = "true"
   end
 
   def load_default_manifest

--- a/manifests/concourse-manifest/spec/support/manifest_helpers.rb
+++ b/manifests/concourse-manifest/spec/support/manifest_helpers.rb
@@ -18,6 +18,8 @@ private
     ENV["AWS_ACCOUNT"] = "dev"
     ENV["CONCOURSE_INSTANCE_PROFILE"] = "concourse-build"
     ENV["DATADOG_API_KEY"] = "abcd1234"
+    ENV["DATADOG_APP_KEY"] = "abcd4321"
+    ENV["ENABLE_DATADOG"] = "true"
     ENV["CONCOURSE_AUTH_DURATION"] = "5m"
   end
 

--- a/manifests/shared/deployments/datadog-agent.yml
+++ b/manifests/shared/deployments/datadog-agent.yml
@@ -7,7 +7,9 @@ releases:
 
 meta:
   datadog:
+    enabled: (( grab $ENABLE_DATADOG ))
     api_key: (( grab $DATADOG_API_KEY || "undefined" ))
+    application_key: (( grab $DATADOG_APP_KEY || "undefined" ))
     use_dogstatsd: false
     include_bosh_tags: true
     tags:


### PR DESCRIPTION
## What

This pull in the change that was made in paas-cf here: https://github.com/alphagov/paas-cf/pull/607


Bosh health_manager supports integration with datadog[1].
It sends all metrics received during the agent heartbeats.

These heartbeat happen once every minute, and include multiple metrics
about the VM health: cpu, load, memory... and about the monit services in
the VM being running OK (`bosh.healthmonitor.system.healthy`)

We are mainly interested in `bosh.healthmonitor.system.healthy` as the
other metrics are also reported by the datadog agents, which we will not
stop using.

We use the variable ENABLE_DATADOG to enable/disable the datadog
integration.

[1] https://github.com/cloudfoundry/bosh/blob/master/release/jobs/health_monitor/spec#L185-L194

## How to review

Code review - verify that these changes match the ones in paas-cf that they're based on.

As per https://github.com/alphagov/paas-cf/pull/607, deploy with Datadog enabled and verify that the checks are created correctly.

## Who can review

Anyone but myself or @dcarley 