### PR TITLE
[#131876783] Migration from paas-cf to paas-bootstrap

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -79,6 +79,13 @@ build-concourse: ## Setup profiles for deploying a build concourse
 	$(eval export CONCOURSE_INSTANCE_PROFILE=concourse-build)
 	@true
 
+.PHONY: deployer-concourse
+deployer-concourse: ## Setup profiles for deploying a paas-cf deployer concourse
+	$(eval export BOSH_INSTANCE_PROFILE=bosh-director-cf)
+	$(eval export CONCOURSE_HOSTNAME=deployer)
+	$(eval export CONCOURSE_INSTANCE_PROFILE=deployer-concourse)
+	@true
+
 ## Actions
 
 .PHONY: fly-login

--- a/Makefile
+++ b/Makefile
@@ -50,8 +50,10 @@ lint_ruby:
 	bundle exec govuk-lint-ruby
 
 .PHONY: globals
+PASSWORD_STORE_DIR?=${HOME}/.paas-pass
 globals:
 	$(eval export AWS_DEFAULT_REGION=eu-west-1)
+	$(eval export PASSWORD_STORE_DIR=${PASSWORD_STORE_DIR})
 	@true
 
 ## Environments
@@ -68,18 +70,21 @@ ci: globals check-env-vars ## Set Environment to CI
 	$(eval export SYSTEM_DNS_ZONE_NAME=${DEPLOY_ENV}.ci.cloudpipeline.digital)
 	$(eval export AWS_ACCOUNT=ci)
 	$(eval export ENABLE_DATADOG=true)
+	$(eval export DECRYPT_CONCOURSE_ATC_PASSWORD=ci_deployments/${DEPLOY_ENV})
 
 .PHONY: staging
 staging: globals check-env-vars ## Set Environment to Staging
 	$(eval export SYSTEM_DNS_ZONE_NAME=staging.cloudpipeline.digital)
 	$(eval export AWS_ACCOUNT=staging)
 	$(eval export ENABLE_DATADOG=true)
+	$(eval export DECRYPT_CONCOURSE_ATC_PASSWORD=staging_deployment)
 
 .PHONY: prod
 prod: globals check-env-vars ## Set Environment to Production
 	$(eval export SYSTEM_DNS_ZONE_NAME=cloud.service.gov.uk)
 	$(eval export AWS_ACCOUNT=prod)
 	$(eval export ENABLE_DATADOG=true)
+	$(eval export DECRYPT_CONCOURSE_ATC_PASSWORD=prod_deployment)
 
 
 ## Concourse profiles

--- a/Makefile
+++ b/Makefile
@@ -76,6 +76,7 @@ ci: globals check-env-vars ## Set Environment to CI
 build-concourse: ## Setup profiles for deploying a build concourse
 	$(eval export BOSH_INSTANCE_PROFILE=bosh-director-build)
 	$(eval export CONCOURSE_HOSTNAME=concourse)
+	$(eval export CONCOURSE_INSTANCE_TYPE=m4.large)
 	$(eval export CONCOURSE_INSTANCE_PROFILE=concourse-build)
 	@true
 
@@ -83,6 +84,7 @@ build-concourse: ## Setup profiles for deploying a build concourse
 deployer-concourse: ## Setup profiles for deploying a paas-cf deployer concourse
 	$(eval export BOSH_INSTANCE_PROFILE=bosh-director-cf)
 	$(eval export CONCOURSE_HOSTNAME=deployer)
+	$(eval export CONCOURSE_INSTANCE_TYPE=m4.xlarge)
 	$(eval export CONCOURSE_INSTANCE_PROFILE=deployer-concourse)
 	@true
 
@@ -98,6 +100,7 @@ fly-login: ## Do a fly login and sync
 bootstrap: ## Start bootstrap
 	$(if ${BOSH_INSTANCE_PROFILE},,$(error Must pass BOSH_INSTANCE_PROFILE=<name>))
 	$(if ${CONCOURSE_HOSTNAME},,$(error Must pass CONCOURSE_HOSTNAME=<name>))
+	$(if ${CONCOURSE_INSTANCE_TYPE},,$(error Must pass CONCOURSE_INSTANCE_TYPE=<name>))
 	$(if ${CONCOURSE_INSTANCE_PROFILE},,$(error Must pass CONCOURSE_INSTANCE_PROFILE=<name>))
 	vagrant/deploy.sh
 

--- a/Makefile
+++ b/Makefile
@@ -69,6 +69,18 @@ ci: globals check-env-vars ## Set Environment to CI
 	$(eval export AWS_ACCOUNT=ci)
 	$(eval export ENABLE_DATADOG=true)
 
+.PHONY: staging
+staging: globals check-env-vars ## Set Environment to Staging
+	$(eval export SYSTEM_DNS_ZONE_NAME=staging.cloudpipeline.digital)
+	$(eval export AWS_ACCOUNT=staging)
+	$(eval export ENABLE_DATADOG=true)
+
+.PHONY: prod
+prod: globals check-env-vars ## Set Environment to Production
+	$(eval export SYSTEM_DNS_ZONE_NAME=cloud.service.gov.uk)
+	$(eval export AWS_ACCOUNT=prod)
+	$(eval export ENABLE_DATADOG=true)
+
 
 ## Concourse profiles
 

--- a/README.md
+++ b/README.md
@@ -73,6 +73,12 @@ Create Concourse Lite with `make`. There are targets to select the target AWS ac
 make dev build-concourse bootstrap
 ```
 
+Or a DEV deployer concourse bootstrap:
+
+```
+make dev deployer-concourse bootstrap
+```
+
 `make help` will show all available options.
 
 To deploy a concourse with custom profiles, it's necessary to set corresponding ENV vars. eg:
@@ -107,11 +113,11 @@ You will need a working [Concourse Lite](#concourse-lite).
 
 Run the `create` pipeline from your *Concourse Lite*.
 
-When complete you can access the UI from a browser with the same credentials as
-your *Concourse Lite* on the following URL:
+When complete, you can access the new Concourse from your browser. The URL
+and credentials can be found from:
 
 ```
-https://concourse.${DEPLOY_ENV}.dev.cloudpipeline.digital/
+make dev <profile>-concourse showenv
 ```
 
 ### Destroy

--- a/concourse/pipelines/create.yml
+++ b/concourse/pipelines/create.yml
@@ -176,7 +176,7 @@ jobs:
             file: create-init-bucket/bucket.tfstate
 
       # FIXME: Remove this task when everything has migrated across.
-      - task: migrate-from-old-bucket
+      - task: migrate-from-old-buckets
         config:
           image: docker:///governmentpaas/awscli
           params:
@@ -192,12 +192,14 @@ jobs:
                 state_bucket={{state_bucket}}
                 old_state_bucket="${DEPLOY_ENV}-state"
 
-                if aws s3 ls "s3:///${state_bucket}/bucket-migrated.flag"; then
+                migration_flag_file=buckets-migrated.flag
+
+                if aws s3 ls "s3://${state_bucket}/${migration_flag_file}"; then
                   echo "Bucket already migrated. Skipping..."
                   exit 0
                 fi
 
-                if ! aws s3api head-bucket --bucket "${old_state_bucket}"; then
+                if ! aws s3 ls "s3://${old_state_bucket}/" > /dev/null; then
                   echo "Old state bucket does not exist, skipping migration"
                   exit 0
                 fi
@@ -210,11 +212,25 @@ jobs:
                 aws s3 mv "s3://${state_bucket}/generated-concourse-secrets.yml" "s3://${state_bucket}/concourse-secrets.yml"
 
                 echo "Fixing up tfstate files to handle renamed resources"
+
                 aws s3 cp "s3://${state_bucket}/vpc.tfstate" .
                 sed s/myvpc/paas/ < vpc.tfstate > vpc-updated.tfstate
                 aws s3 cp vpc-updated.tfstate "s3://${state_bucket}/vpc.tfstate"
 
-                echo "true" | aws s3 cp - "s3://${state_bucket}/bucket-migrated.flag"
+                aws s3 cp "s3://${state_bucket}/bosh.tfstate" .
+                sed "s/${DEPLOY_ENV}-bosh-blobstore/gds-paas-${DEPLOY_ENV}-bosh-blobstore/" < bosh.tfstate > bosh-updated.tfstate
+                aws s3 cp bosh-updated.tfstate "s3://${state_bucket}/bosh.tfstate"
+
+                echo "Syncing bosh bolbstore to new bucket"
+                bosh_blobstore_bucket="gds-paas-${DEPLOY_ENV}-bosh-blobstore"
+                old_bosh_blobstore_bucket="${DEPLOY_ENV}-bosh-blobstore"
+                aws s3 mb "s3://${bosh_blobstore_bucket}"
+                aws s3 sync "s3://${old_bosh_blobstore_bucket}/" "s3://${bosh_blobstore_bucket}"
+
+                echo "Data has been migrated from old blobstore bucket. Remember to delete it: aws s3 rb 's3://${old_bosh_blobstore_bucket}' --force "
+
+                # Flag to prevent this task re-running.
+                echo "true" | aws s3 cp - "s3://${state_bucket}/${migration_flag_file}"
 
       - task: s3init-concourse
         config:

--- a/concourse/pipelines/create.yml
+++ b/concourse/pipelines/create.yml
@@ -196,6 +196,11 @@ jobs:
               - -u
               - -c
               - |
+                if [ "{{concourse_hostname}}" != "deployer" ]; then
+                  echo "Migration only is required for deployer from paas-cf. Skipping..."
+                  exit 0
+                fi
+
                 state_bucket={{state_bucket}}
                 old_state_bucket="${DEPLOY_ENV}-state"
 
@@ -750,6 +755,11 @@ jobs:
               - -e
               - -c
               - |
+                if [ "{{concourse_hostname}}" != "deployer" ]; then
+                  echo "Migration only is required for deployer from paas-cf. Skipping..."
+                  exit 0
+                fi
+
                 if [ "$(cat vms-migrated-flag/vms-migrated.flag)" = "true" ]; then
                   echo "VMs already migrated to new blobstore. Skipping..."
                   echo 'true' > migration-flag/value
@@ -1042,6 +1052,11 @@ jobs:
               - -e
               - -c
               - |
+                if [ "{{concourse_hostname}}" != "deployer" ]; then
+                  echo "Migration only is required for deployer from paas-cf. Skipping..."
+                  exit 0
+                fi
+
                 apk -U add bash jq
                 ./paas-bootstrap/concourse/scripts/migrate_concourse_volume.sh step1
 
@@ -1130,6 +1145,11 @@ jobs:
               - -e
               - -c
               - |
+                if [ "{{concourse_hostname}}" != "deployer" ]; then
+                  echo "Migration only is required for deployer from paas-cf. Skipping..."
+                  exit 0
+                fi
+
                 apk -U add bash jq postgresql-client openssh-client ruby make
                 ./paas-bootstrap/concourse/scripts/migrate_concourse_volume.sh step2
 

--- a/concourse/pipelines/create.yml
+++ b/concourse/pipelines/create.yml
@@ -985,6 +985,7 @@ jobs:
               terraform-outputs/concourse-terraform-outputs.yml
               terraform-outputs/vpc-terraform-outputs.yml
               terraform-outputs/bosh-terraform-outputs.yml
+            CONCOURSE_INSTANCE_TYPE: {{concourse_instance_type}}
             CONCOURSE_INSTANCE_PROFILE: {{concourse_instance_profile}}
           inputs:
           - name: paas-bootstrap

--- a/concourse/pipelines/create.yml
+++ b/concourse/pipelines/create.yml
@@ -804,7 +804,7 @@ jobs:
             - |
               aws iam add-user-to-group --user-name git-${DEPLOY_ENV} --group-name concourse-pool-git-rw
 
-  - name: concourse-deploy
+  - name: generate-concourse-config
     serial: true
     plan:
       - aggregate:
@@ -812,7 +812,7 @@ jobs:
           passed: ['concourse-terraform']
         - get: pipeline-trigger
           trigger: true
-          passed: ['concourse-terraform', 'bosh-deploy']
+          passed: ['concourse-terraform']
         - get: vpc-tfstate
           passed: ['concourse-terraform']
         - get: concourse-tfstate
@@ -820,7 +820,6 @@ jobs:
         - get: concourse-secrets
         - get: bosh-tfstate
           passed: ['concourse-terraform']
-        - get: bosh-secrets
 
       - task: terraform-outputs-to-yaml
         config:
@@ -893,6 +892,19 @@ jobs:
           put: concourse-manifest
           params:
             file: concourse-manifest/concourse-manifest.yml
+
+  - name: concourse-deploy
+    serial: true
+    plan:
+      - aggregate:
+        - get: paas-bootstrap
+          passed: ['generate-concourse-config']
+        - get: pipeline-trigger
+          trigger: true
+          passed: ['generate-concourse-config', 'bosh-deploy']
+        - get: bosh-secrets
+        - get: concourse-manifest
+          passed: ['generate-concourse-config']
 
       - task: get-and-upload-stemcell
         config:

--- a/concourse/pipelines/create.yml
+++ b/concourse/pipelines/create.yml
@@ -209,6 +209,11 @@ jobs:
                 aws s3 mv "s3://${state_bucket}/create-bosh-cloudfoundry.trigger" "s3://${state_bucket}/create-cloudfoundry.trigger"
                 aws s3 mv "s3://${state_bucket}/generated-concourse-secrets.yml" "s3://${state_bucket}/concourse-secrets.yml"
 
+                echo "Fixing up tfstate files to handle renamed resources"
+                aws s3 cp "s3://${state_bucket}/vpc.tfstate" .
+                sed s/myvpc/paas/ < vpc.tfstate > vpc-updated.tfstate
+                aws s3 cp vpc-updated.tfstate "s3://${state_bucket}/vpc.tfstate"
+
                 echo "true" | aws s3 cp - "s3://${state_bucket}/bucket-migrated.flag"
 
       - task: s3init-concourse

--- a/concourse/pipelines/create.yml
+++ b/concourse/pipelines/create.yml
@@ -994,7 +994,8 @@ jobs:
             - |
               ./paas-bootstrap/concourse/scripts/bosh_login.sh {{bosh_fqdn_external}} bosh-secrets/bosh-secrets.yml
               bosh deployment updated-concourse-manifest/concourse-manifest.yml
-              bosh vms | tee vms.txt
+              DEPLOYMENT_NAME=$(./paas-bootstrap/concourse/scripts/val_from_yaml.rb name updated-concourse-manifest/concourse-manifest.yml)
+              bosh vms "${DEPLOYMENT_NAME}" | tee vms.txt
               [ $(grep '|' vms.txt | grep -cEv "(^\|\ \ |\-\-|VM|running)") -eq 0 ]
 
   - name: expunge-vagrant

--- a/concourse/pipelines/create.yml
+++ b/concourse/pipelines/create.yml
@@ -964,6 +964,23 @@ jobs:
         - get: concourse-manifest
           passed: ['generate-concourse-config']
 
+      - task: migrate-concourse-step1
+        config:
+          platform: linux
+          image: docker:///governmentpaas/awscli
+          inputs:
+            - name: paas-bootstrap
+          params:
+            DEPLOY_ENV: {{deploy_env}}
+          run:
+            path: sh
+            args:
+              - -e
+              - -c
+              - |
+                apk -U add bash jq
+                ./paas-bootstrap/concourse/scripts/migrate_concourse_volume.sh step1
+
       - task: get-and-upload-stemcell
         config:
           platform: linux
@@ -1034,6 +1051,23 @@ jobs:
                 ./paas-bootstrap/concourse/scripts/fly_sync_and_login.sh
                 echo y | ${FLY_CMD} -t ${FLY_TARGET} set-team -n ${FLY_TEAM} \
                            --basic-auth-username admin --basic-auth-password ${CONCOURSE_ATC_PASSWORD}
+
+      - task: migrate-concourse-step2
+        config:
+          platform: linux
+          image: docker:///governmentpaas/awscli
+          inputs:
+            - name: paas-bootstrap
+          params:
+            DEPLOY_ENV: {{deploy_env}}
+          run:
+            path: sh
+            args:
+              - -e
+              - -c
+              - |
+                apk -U add bash jq postgresql-client openssh-client ruby make
+                ./paas-bootstrap/concourse/scripts/migrate_concourse_volume.sh step2
 
   - name: post-deploy
     plan:

--- a/concourse/pipelines/create.yml
+++ b/concourse/pipelines/create.yml
@@ -125,6 +125,13 @@ resources:
       region_name: {{aws_region}}
       versioned_file: concourse-manifest.yml
 
+  - name: vms-migrated-flag
+    type: s3-iam
+    source:
+      bucket: {{state_bucket}}
+      region_name: {{aws_region}}
+      versioned_file: vms-migrated.flag
+
 jobs:
   - name: init-bucket
     serial: true
@@ -253,6 +260,7 @@ jobs:
               paas-bootstrap/concourse/scripts/s3init.sh {{state_bucket}} concourse.tfstate paas-bootstrap/concourse/init_files/terraform.tfstate.tpl
               paas-bootstrap/concourse/scripts/s3init.sh {{state_bucket}} concourse-cert.tar.gz paas-bootstrap/concourse/init_files/empty.tar.gz
               paas-bootstrap/concourse/scripts/s3init.sh {{state_bucket}} concourse-secrets.yml paas-bootstrap/concourse/init_files/zero_bytes
+              paas-bootstrap/concourse/scripts/s3init.sh {{state_bucket}} vms-migrated.flag paas-bootstrap/concourse/init_files/zero_bytes
 
           inputs:
           - name: paas-bootstrap
@@ -711,6 +719,58 @@ jobs:
           params:
             file: "bosh-init-working-dir/bosh-manifest-state.json"
 
+  # FIXME: Remove this once it's run everywhere
+  - name: migrate-deployed-vms
+    plan:
+      - aggregate:
+        - get: pipeline-trigger
+          passed: ['bosh-deploy']
+          trigger: true
+        - get: paas-bootstrap
+          passed: ['generate-bosh-config']
+        - get: bosh-secrets
+        - get: vms-migrated-flag
+
+      - task: migrate-deployed-vms
+        config:
+          platform: linux
+          image: docker:///governmentpaas/bosh-cli
+          inputs:
+            - name: paas-bootstrap
+            - name: bosh-secrets
+            - name: vms-migrated-flag
+          outputs:
+            - name: migration-flag
+          run:
+            path: sh
+            args:
+              - -e
+              - -c
+              - |
+                if [ "$(cat vms-migrated-flag/vms-migrated.flag)" = "true" ]; then
+                  echo "VMs already migrated to new blobstore. Skipping..."
+                  echo 'true' > migration-flag/value
+                  exit 0
+                fi
+
+                ./paas-bootstrap/concourse/scripts/bosh_login.sh {{bosh_fqdn_external}} bosh-secrets/bosh-secrets.yml
+
+                if ! bosh download manifest {{deploy_env}} manifest.yml; then
+                  echo "No CF deployment in this bosh. Nothing to migrate."
+                  echo 'true' > migration-flag/value
+                  exit 0
+                fi
+
+                bosh deployment manifest.yml
+
+                echo 'yes' | bosh recreate
+
+                echo 'true' > migration-flag/value
+        on_success:
+          put: vms-migrated-flag
+          params:
+            file: migration-flag/value
+
   - name: concourse-terraform
     serial: true
     plan:
@@ -1073,10 +1133,10 @@ jobs:
     plan:
       - aggregate:
         - get: pipeline-trigger
-          passed: ['bosh-deploy', 'concourse-deploy']
+          passed: ['migrate-deployed-vms', 'concourse-deploy']
           trigger: true
         - get: paas-bootstrap
-          passed: ['bosh-deploy', 'concourse-deploy']
+          passed: ['migrate-deployed-vms', 'concourse-deploy']
         - get: bosh-secrets
         - get: concourse-manifest
           passed: ['concourse-deploy']

--- a/concourse/pipelines/create.yml
+++ b/concourse/pipelines/create.yml
@@ -583,6 +583,7 @@ jobs:
           outputs:
             - name: bosh-manifest
           params:
+            DEPLOY_ENV: {{deploy_env}}
             AWS_ACCOUNT: {{aws_account}}
             DATADOG_API_KEY: {{datadog_api_key}}
             DATADOG_APP_KEY: {{datadog_app_key}}

--- a/concourse/pipelines/create.yml
+++ b/concourse/pipelines/create.yml
@@ -978,13 +978,25 @@ jobs:
                 echo y | ${FLY_CMD} -t ${FLY_TARGET} set-team -n ${FLY_TEAM} \
                            --basic-auth-username admin --basic-auth-password ${CONCOURSE_ATC_PASSWORD}
 
+  - name: post-deploy
+    plan:
+      - aggregate:
+        - get: pipeline-trigger
+          passed: ['bosh-deploy', 'concourse-deploy']
+          trigger: true
+        - get: paas-bootstrap
+          passed: ['bosh-deploy', 'concourse-deploy']
+        - get: bosh-secrets
+        - get: concourse-manifest
+          passed: ['concourse-deploy']
+
       - task: test-bosh-vms
         config:
           platform: linux
           image: docker:///governmentpaas/bosh-cli
           inputs:
           - name: paas-bootstrap
-          - name: updated-concourse-manifest
+          - name: concourse-manifest
           - name: bosh-secrets
           run:
             path: sh
@@ -993,6 +1005,8 @@ jobs:
             - -c
             - |
               ./paas-bootstrap/concourse/scripts/bosh_login.sh {{bosh_fqdn_external}} bosh-secrets/bosh-secrets.yml
+              mkdir -p updated-concourse-manifest
+              sed -e "s/^director_uuid:.*/director_uuid: $(bosh status --uuid)/" < concourse-manifest/concourse-manifest.yml > updated-concourse-manifest/concourse-manifest.yml
               bosh deployment updated-concourse-manifest/concourse-manifest.yml
               DEPLOYMENT_NAME=$(./paas-bootstrap/concourse/scripts/val_from_yaml.rb name updated-concourse-manifest/concourse-manifest.yml)
               bosh vms "${DEPLOYMENT_NAME}" | tee vms.txt
@@ -1003,10 +1017,10 @@ jobs:
     plan:
       - aggregate:
         - get: paas-bootstrap
-          passed: ['concourse-deploy']
+          passed: ['post-deploy']
         - get: pipeline-trigger
           trigger: true
-          passed: ['concourse-deploy']
+          passed: ['post-deploy']
         - get: vpc-tfstate
         - get: bosh-tfstate
         - get: concourse-tfstate

--- a/concourse/pipelines/create.yml
+++ b/concourse/pipelines/create.yml
@@ -175,6 +175,42 @@ jobs:
           params:
             file: create-init-bucket/bucket.tfstate
 
+      # FIXME: Remove this task when everything has migrated across.
+      - task: migrate-from-old-bucket
+        config:
+          image: docker:///governmentpaas/awscli
+          params:
+            AWS_DEFAULT_REGION: {{aws_region}}
+            DEPLOY_ENV: {{deploy_env}}
+          run:
+            path: sh
+            args:
+              - -e
+              - -u
+              - -c
+              - |
+                state_bucket={{state_bucket}}
+                old_state_bucket="${DEPLOY_ENV}-state"
+
+                if aws s3 ls "s3:///${state_bucket}/bucket-migrated.flag"; then
+                  echo "Bucket already migrated. Skipping..."
+                  exit 0
+                fi
+
+                if ! aws s3api head-bucket --bucket "${old_state_bucket}"; then
+                  echo "Old state bucket does not exist, skipping migration"
+                  exit 0
+                fi
+
+                echo "Syncing state from old bucket"
+                aws s3 sync "s3://${old_state_bucket}/" "s3://${state_bucket}/" --exclude bucket.tfstate
+
+                echo "Renaming files to match new pipelines"
+                aws s3 mv "s3://${state_bucket}/create-bosh-cloudfoundry.trigger" "s3://${state_bucket}/create-cloudfoundry.trigger"
+                aws s3 mv "s3://${state_bucket}/generated-concourse-secrets.yml" "s3://${state_bucket}/concourse-secrets.yml"
+
+                echo "true" | aws s3 cp - "s3://${state_bucket}/bucket-migrated.flag"
+
       - task: s3init-concourse
         config:
           image: docker:///governmentpaas/curl-ssl

--- a/concourse/pipelines/create.yml
+++ b/concourse/pipelines/create.yml
@@ -685,6 +685,8 @@ jobs:
         - get: pipeline-trigger
           passed: ['generate-bosh-config']
           trigger: true
+        - get: paas-bootstrap
+          passed: ['generate-bosh-config']
         - get: bosh-manifest
           passed: ['generate-bosh-config']
         - get: bosh-init-state
@@ -698,6 +700,7 @@ jobs:
             - name: bosh-manifest
             - name: bosh-init-state
             - name: bosh-ssh-private-key
+            - name: paas-bootstrap
           outputs:
             - name: bosh-init-working-dir
           params:

--- a/concourse/scripts/environment.sh
+++ b/concourse/scripts/environment.sh
@@ -36,7 +36,11 @@ esac
 
 CONCOURSE_ATC_USER=${CONCOURSE_ATC_USER:-admin}
 if [ -z "${CONCOURSE_ATC_PASSWORD:-}" ]; then
-  CONCOURSE_ATC_PASSWORD=$(hashed_password "${AWS_SECRET_ACCESS_KEY}:${DEPLOY_ENV}:atc")
+  if [ -n "${DECRYPT_CONCOURSE_ATC_PASSWORD:-}" ]; then
+    CONCOURSE_ATC_PASSWORD=$(pass "${DECRYPT_CONCOURSE_ATC_PASSWORD}/concourse_password")
+  else
+    CONCOURSE_ATC_PASSWORD=$(hashed_password "${AWS_SECRET_ACCESS_KEY}:${DEPLOY_ENV}:atc")
+  fi
 fi
 
 cat <<EOF

--- a/concourse/scripts/migrate_concourse_volume.sh
+++ b/concourse/scripts/migrate_concourse_volume.sh
@@ -1,0 +1,377 @@
+#!/usr/bin/env bash
+
+set -e -u
+
+AWS_REGION=eu-west-1
+BOSH_INIT_CONCOURSE_STATE="s3://gds-paas-${DEPLOY_ENV}-state/concourse-manifest-state.json"
+SCRIPT_NAME=$0
+
+build_aws_cli_tag_filter() {
+  local pair
+  local filter
+  filter=""
+  for pair in "$@"; do
+    filter="${filter:+${filter} }Name=tag:${pair%:*},Values=${pair#*:}"
+  done
+  echo "${filter}"
+}
+
+find_all_instances_by_tags() {
+  local tag_filter
+  tag_filter="$(build_aws_cli_tag_filter "$@")"
+  # shellcheck disable=SC2086
+  aws ec2 describe-instances \
+    --region "${AWS_REGION}" \
+    --filters ${tag_filter} \
+    --query 'Reservations[].Instances[].InstanceId' \
+    --output text | xargs
+}
+
+terminate_instance() {
+  local instance_id
+  instance_id="${1}"
+  aws ec2 terminate-instances \
+    --region "${AWS_REGION}" \
+    --instance-ids "${instance_id}" > /dev/null
+}
+
+stop_instance() {
+  local instance_id
+  instance_id="${1}"
+  aws ec2 stop-instances \
+    --region "${AWS_REGION}" \
+    --instance-ids "${instance_id}" > /dev/null
+}
+
+start_instance() {
+  local instance_id
+  instance_id="${1}"
+  aws ec2 start-instances \
+    --region "${AWS_REGION}" \
+    --instance-ids "${instance_id}" > /dev/null
+}
+
+get_instance_state() {
+  local instance_id
+  instance_id="${1}"
+  aws ec2 describe-instances \
+    --region "${AWS_REGION}" \
+    --instance-ids "${instance_id}" \
+    --query 'Reservations[].Instances[].State.Name' \
+    --output text
+}
+
+wait_instance_state() {
+  local instance_id
+  local expected_state
+  instance_id="${1}"
+  expected_state="${2}"
+
+  echo -n "Waiting ${instance_id} to be ${expected_state}..."
+  while ! [ "$(get_instance_state "${instance_id}")" == "${expected_state}" ]; do
+    echo -n .
+    sleep 5
+  done
+  echo "Ok."
+}
+
+
+find_instance_disk_by_device_name() {
+  local instance_id
+  local device_name
+  instance_id="${1}"
+  device_name="${2}"
+  aws ec2 describe-instances \
+    --region "${AWS_REGION}" \
+    --instance-ids "${instance_id}" \
+    --query "Reservations[].Instances[].BlockDeviceMappings[?DeviceName==\`${device_name}\`].Ebs.VolumeId" \
+    --output text
+}
+
+snapshot_volume() {
+  local volume_id
+  local description
+  volume_id="${1}"
+  description="${2}"
+
+  aws ec2 create-snapshot \
+    --region "${AWS_REGION}" \
+    --volume-id "${volume_id}" \
+    --description "${description}" \
+    --query "SnapshotId" \
+    --output text
+}
+
+get_snapshot_state() {
+  local snapshot_id
+  snapshot_id="${1}"
+  aws ec2 describe-snapshots \
+    --region "${AWS_REGION}" \
+    --snapshot-id "${snapshot_id}" \
+    --query 'Snapshots[].State' \
+    --output text
+}
+
+delete_snapshot() {
+  local snapshot_id
+  snapshot_id="${1}"
+  aws ec2 describe-snapshots \
+    --region "${AWS_REGION}" \
+    --snapshot-id "${snapshot_id}" > /dev/null
+}
+
+wait_snapshot_completed() {
+  local snapshot_id
+  snapshot_id="${1}"
+
+  echo -n "Waiting ${snapshot_id} to be completed..."
+  while ! [ "$(get_snapshot_state "${snapshot_id}")" == "completed" ]; do
+    echo -n .
+    sleep 5
+  done
+  echo "Ok."
+}
+
+create_volume_from_snapshot () {
+  local snapshot_id
+  local availability_zone
+  snapshot_id="${1}"
+  availability_zone="${2}"
+  aws ec2 create-volume \
+    --region "${AWS_REGION}" \
+    --availability-zone "${availability_zone}" \
+    --snapshot-id "${snapshot_id}" \
+    --query 'VolumeId' \
+    --output text
+}
+
+get_volume_state() {
+  local volume_id
+  volume_id="${1}"
+  aws ec2 describe-volumes \
+    --region "${AWS_REGION}" \
+    --volume-ids "${volume_id}" \
+    --query 'Volumes[].State' \
+    --output text
+}
+
+detach_volume() {
+  local volume_id
+  volume_id="${1}"
+  aws ec2 detach-volume \
+    --region "${AWS_REGION}" \
+    --volume-id "${volume_id}" > /dev/null
+}
+
+delete_volume() {
+  local volume_id
+  volume_id="${1}"
+  aws ec2 delete-volume \
+    --region "${AWS_REGION}" \
+    --volume-id "${volume_id}" > /dev/null
+}
+
+attach_volume() {
+  local volume_id
+  local instance_id
+  local device_name
+  volume_id="${1}"
+  instance_id="${2}"
+  device_name="${3}"
+  aws ec2 attach-volume \
+    --region "${AWS_REGION}" \
+    --volume-id "${volume_id}" \
+    --instance-id "${instance_id}" \
+    --device "${device_name}" > /dev/null
+}
+
+wait_volume_available() {
+  local volume_id
+  volume_id="${1}"
+
+  echo -n "Waiting ${volume_id} to be available..."
+  while ! [ "$(get_volume_state "${volume_id}")" == "available" ]; do
+    echo -n .
+    sleep 5
+  done
+  echo "Ok."
+}
+
+clone_volume_via_snapsot() {
+  local volume_id
+  volume_id="${1}"
+  snapshot_id="$(snapshot_volume "${volume_id}" "${DEPLOY_ENV} bosh-init concourse persistent disk")"
+  echo "Created snapshot ${snapshot_id}"
+  wait_snapshot_completed "${snapshot_id}"
+
+  new_volume_id="$(create_volume_from_snapshot "${snapshot_id}" "${AWS_REGION}a")" # Hardcoded AZ
+  wait_volume_available "${new_volume_id}"
+
+  echo "Deleting snapshot ${snapshot_id}"
+  delete_snapshot "${snapshot_id}"
+
+  echo "${new_volume_id}"
+}
+
+get_concourse_bosh_init_state () {
+  aws s3 cp \
+    --region "${AWS_REGION}" \
+    "${BOSH_INIT_CONCOURSE_STATE}" -
+}
+
+get_concourse_bosh_init_state_instance_id () {
+  get_concourse_bosh_init_state | jq -r '.current_vm_cid'
+}
+
+get_concourse_bosh_init_state_volume_id () {
+  get_concourse_bosh_init_state | jq -r '.disks[0].cid'
+}
+
+
+##########################################################################
+stop_old_concourse() {
+  origin_concourse_instance_id="$(get_concourse_bosh_init_state_instance_id)"
+  echo "bosh-init state origin concourse instance ID: ${origin_concourse_instance_id}"
+
+  origin_concourse_volume_id="$(get_concourse_bosh_init_state_volume_id)"
+  echo "bosh-init state persistent volume: ${origin_concourse_volume_id}"
+
+  found_origin_concourse_instance_id="$(find_all_instances_by_tags "deployment:${DEPLOY_ENV}" job:concourse index:0 director:bosh-init)"
+
+  if [ "${found_origin_concourse_instance_id}" ] && [ "$(get_instance_state "${found_origin_concourse_instance_id}")" != "terminated" ]; then
+    echo "Found existing concourse instance ID: ${found_origin_concourse_instance_id}"
+    found_origin_concourse_volume_id="$(find_instance_disk_by_device_name "${found_origin_concourse_instance_id}" "/dev/sdf")"
+    echo "Found existing persistent volume (/dev/sdf): ${found_origin_concourse_instance_id}"
+
+    if [ "${origin_concourse_instance_id}" != "${found_origin_concourse_instance_id}" ] || \
+        [ "${origin_concourse_volume_id}" != "${found_origin_concourse_volume_id}" ]; then
+        echo "Error: Instance ID or Volume ID in the state does not match with ones running."
+        echo "State file: ${BOSH_INIT_CONCOURSE_STATE}"
+        echo "State ids: ${origin_concourse_instance_id} ${origin_concourse_volume_id}"
+        echo "Running ids: ${found_origin_concourse_instance_id} ${found_origin_concourse_volume_id}"
+        exit 1
+    fi
+
+    echo "Terminating old concourse ${found_origin_concourse_instance_id}..."
+    terminate_instance "${found_origin_concourse_instance_id}"
+    wait_instance_state "${found_origin_concourse_instance_id}" "terminated"
+  else
+    echo "Unable to find a running bosh-init concourse. Has it been deleted already?"
+  fi
+}
+
+attach_old_volume_to_new_concourse() {
+  origin_concourse_instance_id="$(get_concourse_bosh_init_state_instance_id)"
+  echo "bosh-init state origin concourse instance ID: ${origin_concourse_instance_id}"
+
+  origin_concourse_volume_id="$(get_concourse_bosh_init_state_volume_id)"
+  echo "bosh-init state persistent volume: ${origin_concourse_volume_id}"
+
+  new_concourse_instance_id="$(find_all_instances_by_tags deployment:concourse job:concourse index:0 "director:${DEPLOY_ENV}")"
+  echo "New concourse instance ID: ${new_concourse_instance_id}"
+
+
+  new_concourse_volume_id="$(find_instance_disk_by_device_name "${new_concourse_instance_id}" "/dev/sdf")"
+  if [ "${new_concourse_volume_id}" ]; then
+    if [ "${new_concourse_volume_id}" == "${origin_concourse_volume_id}" ]; then
+      echo "The new concourse already has attached the volume ${origin_concourse_volume_id}. No need to update."
+    else
+      echo "Found existing persistent volume in new concourse (/dev/sdf): ${new_concourse_volume_id}"
+
+      echo "Stoping the new concourse instance ${new_concourse_instance_id}"
+      stop_instance "${new_concourse_instance_id}"
+      wait_instance_state "${new_concourse_instance_id}" "stopped"
+
+      echo "Detaching and deleting volume ${new_concourse_volume_id} from new concourse"
+      detach_volume "${new_concourse_volume_id}"
+      wait_volume_available "${new_concourse_volume_id}"
+      delete_volume "${new_concourse_volume_id}"
+
+      echo "Attaching ${origin_concourse_volume_id} to ${new_concourse_instance_id} as /dev/sdf"
+      attach_volume "${origin_concourse_volume_id}" "${new_concourse_instance_id}" "/dev/sdf"
+    fi
+  fi
+
+  echo "Starting again the new concourse instance ${new_concourse_instance_id}"
+  start_instance "${new_concourse_instance_id}"
+  wait_instance_state "${new_concourse_instance_id}" "running"
+
+  # TODO: Check if we need to do a monit restart all, not sure if it really starts :-m
+}
+
+update_db_in_bosh_db() {
+  origin_concourse_volume_id="$(get_concourse_bosh_init_state_volume_id)"
+  echo "bosh-init state persistent volume: ${origin_concourse_volume_id}"
+
+  bosh_db_address=$(aws s3 cp "s3://gds-paas-${DEPLOY_ENV}-state/bosh.tfstate" - | jq -r '.modules[0].outputs.bosh_db_address.value')
+  bosh_db_password=$(aws s3 cp "s3://gds-paas-${DEPLOY_ENV}-state/bosh-secrets.yml" - | awk '/bosh_postgres_password/ { print $2 }')
+
+  # We must use a SSH tunnel to be able to connect to the RDS db via concourse
+  (
+  cd "$(dirname "${SCRIPT_NAME}")/../.."
+  make dev tunnel TUNNEL="5432:${bosh_db_address}:5432"
+  )
+
+  bosh_db_url="postgresql://dbadmin:${bosh_db_password}@localhost:5432/bosh"
+
+  echo "Current volume disk associated in Bosh RDS:"
+  psql "${bosh_db_url}" -c "
+    select deployments.name, instances.job, instances.index, disk_cid
+    from instances, deployments, persistent_disks
+    where instances.deployment_id = deployments.id
+      and deployments.name = 'concourse'
+      and persistent_disks.instance_id = instances.id
+      and instances.job = 'concourse'
+      and instances.index=0;
+  "
+
+  echo "Updating volume:"
+  psql "${bosh_db_url}" -c "
+    update persistent_disks set disk_cid = '${origin_concourse_volume_id}'
+    from instances, deployments
+    where instances.deployment_id = deployments.id
+      and deployments.name = 'concourse'
+      and persistent_disks.instance_id = instances.id
+      and instances.job = 'concourse'
+      and instances.index=0;
+    "
+
+  disk_cid=$(psql "${bosh_db_url}" -ztA -c "
+    select disk_cid
+    from instances, deployments, persistent_disks
+    where instances.deployment_id = deployments.id
+      and deployments.name = 'concourse'
+      and persistent_disks.instance_id = instances.id
+      and instances.job = 'concourse'
+      and instances.index=0;
+  ")
+
+  (
+  cd "$(dirname "${SCRIPT_NAME}")/../.."
+  make dev stop-tunnel
+  )
+
+  if [ "${origin_concourse_volume_id}" == "${disk_cid}" ]; then
+    echo "Bosh RDS DB updated correctly"
+  else
+    echo "Error, Bosh RDS DB is not updated properly. Current disk_cid=${disk_cid}, expected ${origin_concourse_volume_id}"
+  fi
+}
+
+case "${1:-}" in
+  step1)
+    stop_old_concourse
+  ;;
+  step2)
+    attach_old_volume_to_new_concourse
+    update_db_in_bosh_db
+  ;;
+  *)
+    echo "Usage $0 <step1|step2>"
+    exit 0
+  ;;
+esac
+
+
+
+

--- a/concourse/scripts/pipelines.sh
+++ b/concourse/scripts/pipelines.sh
@@ -43,6 +43,7 @@ bosh_fqdn: bosh.${SYSTEM_DNS_ZONE_NAME}
 bosh_fqdn_external: bosh-external.${SYSTEM_DNS_ZONE_NAME}
 concourse_atc_password: ${CONCOURSE_ATC_PASSWORD}
 bosh_instance_profile: ${BOSH_INSTANCE_PROFILE}
+concourse_instance_type: ${CONCOURSE_INSTANCE_TYPE}
 concourse_instance_profile: ${CONCOURSE_INSTANCE_PROFILE}
 enable_datadog: ${ENABLE_DATADOG}
 datadog_api_key: ${datadog_api_key:-}

--- a/manifests/bosh-manifest/bosh-manifest.yml
+++ b/manifests/bosh-manifest/bosh-manifest.yml
@@ -57,7 +57,7 @@ jobs:
 
     director:
       address: 127.0.0.1
-      name: paas
+      name: (( grab $DEPLOY_ENV ))
       db: (( grab meta.rds ))
       disks:
         max_orphaned_age_in_days: 0

--- a/manifests/bosh-manifest/bosh-manifest.yml
+++ b/manifests/bosh-manifest/bosh-manifest.yml
@@ -149,8 +149,8 @@ resource_pools:
 - name: bosh
   network: private
   stemcell:
-    url: https://bosh.io/d/stemcells/bosh-aws-xen-hvm-ubuntu-trusty-go_agent?v=3263.12
-    sha1: b2e8ea8415dca3ab5826a39dcbe4ef760bcc7b05
+    url: https://bosh.io/d/stemcells/bosh-aws-xen-hvm-ubuntu-trusty-go_agent?v=3263.14
+    sha1: cc3377af8c0bf31d069b32d74ab01ab470b31c7a
   cloud_properties:
     instance_type: t2.medium
     ephemeral_disk: {size: 40000, type: gp2}

--- a/manifests/bosh-manifest/spec/properties_spec.rb
+++ b/manifests/bosh-manifest/spec/properties_spec.rb
@@ -36,4 +36,8 @@ RSpec.describe "manifest properties validations" do
   it "configures datadog tag bosh-job" do
     expect(bosh_properties["tags"]["bosh-job"]).to eq("bosh")
   end
+
+  it "sets the bosh director name to the value of DEPLOY_ENV" do
+    expect(bosh_properties["director"]["name"]).to eq(ManifestHelpers.deploy_env)
+  end
 end

--- a/manifests/bosh-manifest/spec/support/manifest_helpers.rb
+++ b/manifests/bosh-manifest/spec/support/manifest_helpers.rb
@@ -12,6 +12,10 @@ module ManifestHelpers
     Cache.instance.manifest_with_defaults ||= load_default_manifest
   end
 
+  def self.deploy_env
+    "spec"
+  end
+
 private
 
   def fake_env_vars
@@ -22,6 +26,7 @@ private
     ENV["DATADOG_API_KEY"] = "abcd1234"
     ENV["DATADOG_APP_KEY"] = "abcd4321"
     ENV["ENABLE_DATADOG"] = "true"
+    ENV["DEPLOY_ENV"] = ManifestHelpers.deploy_env
   end
 
   def load_default_manifest

--- a/manifests/concourse-manifest/concourse-base.yml
+++ b/manifests/concourse-manifest/concourse-base.yml
@@ -32,7 +32,7 @@ resource_pools:
       name: (( grab meta.stemcell.name ))
       version: (( grab meta.stemcell.version ))
     cloud_properties:
-      instance_type: m4.large
+      instance_type: (( grab $CONCOURSE_INSTANCE_TYPE ))
       availability_zone: (( grab meta.zone ))
       iam_instance_profile: (( grab $CONCOURSE_INSTANCE_PROFILE ))
       elbs:

--- a/manifests/concourse-manifest/concourse-base.yml
+++ b/manifests/concourse-manifest/concourse-base.yml
@@ -2,7 +2,7 @@
 meta:
   stemcell:
     name: bosh-aws-xen-hvm-ubuntu-trusty-go_agent
-    version: "3263.12"
+    version: "3263.14"
 
   zone: (( grab terraform_outputs.zone0 ))
 

--- a/manifests/concourse-manifest/spec/support/manifest_helpers.rb
+++ b/manifests/concourse-manifest/spec/support/manifest_helpers.rb
@@ -16,6 +16,7 @@ private
 
   def fake_env_vars
     ENV["AWS_ACCOUNT"] = "dev"
+    ENV["CONCOURSE_INSTANCE_TYPE"] = "t2.small"
     ENV["CONCOURSE_INSTANCE_PROFILE"] = "concourse-build"
     ENV["DATADOG_API_KEY"] = "abcd1234"
     ENV["DATADOG_APP_KEY"] = "abcd4321"

--- a/terraform/bosh/outputs.tf
+++ b/terraform/bosh/outputs.tf
@@ -65,3 +65,7 @@ output "key_pair_name" {
 output "bosh_api_client_security_group" {
   value = "${aws_security_group.bosh_api_client.name}"
 }
+
+output "default_security_group" {
+  value = "${aws_security_group.bosh_managed.name}"
+}

--- a/terraform/bosh/rds.tf
+++ b/terraform/bosh/rds.tf
@@ -35,23 +35,24 @@ resource "aws_db_parameter_group" "default" {
 }
 
 resource "aws_db_instance" "bosh" {
-  identifier                = "${var.env}-bosh"
-  name                      = "bosh"
-  allocated_storage         = 5
-  storage_type              = "gp2"
-  engine                    = "postgres"
-  engine_version            = "9.4.7"
-  instance_class            = "db.t2.medium"
-  username                  = "dbadmin"
-  password                  = "${var.secrets_bosh_postgres_password}"
-  db_subnet_group_name      = "${aws_db_subnet_group.bosh_rds.name}"
-  parameter_group_name      = "${aws_db_parameter_group.default.id}"
-  backup_window             = "01:00-02:00"
-  maintenance_window        = "Thu:03:00-Thu:04:00"
-  multi_az                  = "${var.bosh_db_multi_az}"
-  backup_retention_period   = "${var.bosh_db_backup_retention_period}"
-  final_snapshot_identifier = "${var.env}-bosh-rds-final-snapshot"
-  skip_final_snapshot       = "${var.bosh_db_skip_final_snapshot}"
+  identifier                 = "${var.env}-bosh"
+  name                       = "bosh"
+  allocated_storage          = 5
+  storage_type               = "gp2"
+  engine                     = "postgres"
+  engine_version             = "9.4.7"
+  instance_class             = "db.t2.medium"
+  username                   = "dbadmin"
+  password                   = "${var.secrets_bosh_postgres_password}"
+  db_subnet_group_name       = "${aws_db_subnet_group.bosh_rds.name}"
+  parameter_group_name       = "${aws_db_parameter_group.default.id}"
+  backup_window              = "01:00-02:00"
+  maintenance_window         = "Thu:03:00-Thu:04:00"
+  multi_az                   = "${var.bosh_db_multi_az}"
+  backup_retention_period    = "${var.bosh_db_backup_retention_period}"
+  final_snapshot_identifier  = "${var.env}-bosh-rds-final-snapshot"
+  skip_final_snapshot        = "${var.bosh_db_skip_final_snapshot}"
+  auto_minor_version_upgrade = false
 
   vpc_security_group_ids = ["${aws_security_group.bosh_rds.id}"]
 

--- a/terraform/bosh/rds.tf
+++ b/terraform/bosh/rds.tf
@@ -23,6 +23,14 @@ resource "aws_security_group" "bosh_rds" {
     ]
   }
 
+  # FIXME: Remove after the migration. Required to be able to connect.
+  ingress {
+    from_port   = 5432
+    to_port     = 5432
+    protocol    = "tcp"
+    cidr_blocks = ["${values(var.infra_cidrs)}"]
+  }
+
   tags {
     Name = "${var.env}-bosh-rds"
   }


### PR DESCRIPTION
[#131876783 Migrate paas-cf to paas-bootstrap](https://www.pivotaltracker.com/story/show/131876783)

**NB: Please review but do not merge over holiday period**

What?
-----

We want to use paas-bootstrap project to create the initial VPC, bosh and concourse deployer, and remove the required logic from paas-cf.

For that, apart of migrate the logic, we must also implement a procedure to migrate the existing environments.

In this PR we :
 * Move the basic configuration to get VPC, bosh and concourse running from paas-cf.
 * Implement logic to migrate an existing environment:
   * Copy blobstores across, as they get renamed.
   * Recreate the existing bosh VMs to allow change the blobstore.
   * Reattach the old volume from concourse into the new one.

All the migration steps are idempotent and the commits can be reverted later after the migration is done in all the environments.

Note: There are several features and small useful scripts that were not migrated yet. The change is big enough and will be done in follow up PRs.

Dependencies
-----------------

This PR must be reviewed, tested and applied in conjuction with https://github.com/alphagov/paas-cf/pull/688

How to review, test and apply it?
---------

Do a code review to check that makes sense.

To test it: 

 1. Deploy a CF environment using the master branch of  https://github.com/alphagov/paas-cf
 2. Apply the procedure described below.

Migration procedure
------------------------

This branch includes all the required logic almost do all the migration from a paas-cf deployment. The steps are in the commits prefixed with `migrate`.

The full migration process would be:

1. Optionally pause all pipelines in the Deployer Concourse. eg:
   ```
   TARGET=... # master, prod, staging...
   ./bin/fly -t ${TARGET} pipelines -a | grep main | awk '{print $1}' | xargs -n1 -I {} ./bin/fly -t ${TARGET} pause-pipeline -p {}
   ``` 
2. Bring up new Bootstrap Concourse from `alphagov/paas-bootstrap`
    ```
    DEPLOY_ENV=... BRANCH=$(git rev-parse --abbrev-ref HEAD) make dev deployer-concourse bootstrap
    ```
1. Run the `create` pipeline on the Bootstrap Concourse.
   This will automatically: 
   	 * Create the new buckets and sync them.
   	 * Update the terraform resources (eg. vpc name)
   	 * update BOSH (new blobstore bucket)
   	 * migrate CF VMs for new blobstore, 
   	 * delete old concourse
   	 * recreate Concourse (takes approx 1hr)
   	 * attach the old disk to concourse and update bosh DB.
    
   Note: This failed for me once when updating `parser_z2/0` because it was unable to connect to Elasticsearch. The simplest, but time consuming, solution is to re-run the job.

1. Delete the cookies from your deployer. We found out that you cannot login after re-deployment having the old cookie set (???).

1. Run the  migration from paas-cf PR https://github.com/alphagov/paas-cf/pull/688:  Run `BRANCH=$(git rev-parse --abbrev-ref HEAD) make dev pipelines DEPLOY_ENV=....` (in https://github.com/alphagov/paas-cf/pull/688) to update all the pipelines in the new concourse (this will unpause them as part of the deployment).

Once this is finished:

1. Clean up manually:
	* Delete old S3 state bucket `<env>-state`. It's versioned, so you'll need to use the AWS console.
	* Delete old S3 blobstore bucket. `aws s3api delete-bucket --bucket ${DEPLOY_ENV}-bosh-blobstore`
1. Once all environments have been migrated (all), we can revert all the commits prefixed with `migrate:` in paas-bootstrap and paas-cf
1. ???
1. Profit


Who?
----

Anyone but @keymon, @dcarley or @alext