### PR TITLE
Fix Travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+dist: trusty
 sudo: false
 rvm:
   - 2.2.6

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 sudo: false
 rvm:
-  - 2.2.3
+  - 2.2.6
 env:
   global:
     - TF_VERSION="0.7.10"


### PR DESCRIPTION
This is acopy of: https://github.com/alphagov/paas-cf/pull/712

What
----

The default container in travis is based on Ubuntu Precise, and at
present doesn't include the necessary libraries to connect to TLS-1.2
HTTPS servers. Since Fastly have [started switching off TLS 1.1 and
earlier](https://www.fastly.com/blog/phase-two-our-tls-10-and-11-deprecation-plan), we've been unable to download the terraform binary from
releases.hashicorp.com with errors like the following (from wget):

```
--2017-01-10 09:41:45--
https://releases.hashicorp.com/terraform/0.7.10/terraform_0.7.10_linux_amd64.zip
Resolving releases.hashicorp.com (releases.hashicorp.com)...
151.101.33.183
Connecting to releases.hashicorp.com
(releases.hashicorp.com)|151.101.33.183|:443... connected.
Unable to establish SSL connection.
```

This updates to use Travis' [Trusty Beta containers](https://docs.travis-ci.com/user/trusty-ci-environment/) which don't experience this issue.

As part of this update I've also updated the version of ruby used in the tests to the latest point release for consistency with the pipelines.

I also improved the failure output for the git version test (see commit message for details).

How to review
----
Code review
Verify that the travis build succeeds.

Who can review
----

Anyone but myself.