### PR TITLE
[#131876783] Allow SSH from concourse into BOSH

### DIFF
--- a/manifests/bosh-manifest/spec/fixtures/bosh-terraform-outputs.yml
+++ b/manifests/bosh-manifest/spec/fixtures/bosh-terraform-outputs.yml
@@ -19,3 +19,4 @@ terraform_outputs:
   bosh_ssh_key_pair_name: bosh_keypair
   key_pair_name: ssh_key_pair
   bosh_api_client_security_group: bosh_api_client_sg
+  bosh_ssh_client_security_group: bosh_ssh_client_sg

--- a/manifests/concourse-manifest/concourse-base.yml
+++ b/manifests/concourse-manifest/concourse-base.yml
@@ -46,6 +46,7 @@ resource_pools:
       - (( grab terraform_outputs.concourse_security_group ))
       - (( grab terraform_outputs.ssh_security_group ))
       - (( grab terraform_outputs.bosh_api_client_security_group ))
+      - (( grab terraform_outputs.bosh_ssh_client_security_group ))
     env:
       bosh:
         password: (( grab secrets.concourse_vcap_password ))

--- a/manifests/concourse-manifest/spec/fixtures/bosh-terraform-outputs.yml
+++ b/manifests/concourse-manifest/spec/fixtures/bosh-terraform-outputs.yml
@@ -18,3 +18,4 @@ terraform_outputs:
   bosh_ssh_key_pair_name: bosh_keypair
   key_pair_name: ssh_key_pair
   bosh_api_client_security_group: bosh_api_client_sg
+  bosh_ssh_client_security_group: bosh_ssh_client_sg

--- a/manifests/runtime-config/runtime-config-base.yml
+++ b/manifests/runtime-config/runtime-config-base.yml
@@ -1,3 +1,3 @@
 ---
-
+releases: []
 addons: []

--- a/terraform/bosh/outputs.tf
+++ b/terraform/bosh/outputs.tf
@@ -66,6 +66,10 @@ output "bosh_api_client_security_group" {
   value = "${aws_security_group.bosh_api_client.name}"
 }
 
+output "bosh_ssh_client_security_group" {
+  value = "${aws_security_group.bosh_ssh_client.name}"
+}
+
 output "default_security_group" {
   value = "${aws_security_group.bosh_managed.name}"
 }

--- a/terraform/bosh/security_groups.tf
+++ b/terraform/bosh/security_groups.tf
@@ -18,6 +18,16 @@ resource "aws_security_group" "bosh" {
   }
 
   ingress {
+    from_port = 22
+    to_port   = 22
+    protocol  = "tcp"
+
+    security_groups = [
+      "${aws_security_group.bosh_ssh_client.id}",
+    ]
+  }
+
+  ingress {
     from_port   = 6868
     to_port     = 6868
     protocol    = "tcp"
@@ -83,6 +93,16 @@ resource "aws_security_group" "bosh_api_client" {
 
   tags {
     Name = "${var.env}-bosh-api-client"
+  }
+}
+
+resource "aws_security_group" "bosh_ssh_client" {
+  name        = "${var.env}-bosh-ssh-client"
+  description = "Security group for VMs that can SSH into BOSH"
+  vpc_id      = "${var.vpc_id}"
+
+  tags {
+    Name = "${var.env}-bosh-ssh-client"
   }
 }
 


### PR DESCRIPTION
[#131876783 Migrate paas-cf to paas-bootstrap](https://www.pivotaltracker.com/story/show/131876783)


What?
-----

After migrating the bootstrap of bosh and concourse to paas-bootstrap in [1], we broke the `make <aws_account> ssh_bosh` feature. The reason is that concourse is not allow to connect to SSH of bosh anymore.

To fix that, we create a new security group bosh_ssh_client in the bosh terraform, to group the machines that are allowed to SSH to bosh. We pass the new group ID to the list of SG associated in the concourse manifest.

[1] https://github.com/alphagov/paas-bootstrap/pull/26

Dependencies
-----------

Merge https://github.com/alphagov/paas-bootstrap/pull/36 first and rebase this.

How to review?
--------------

Deploy this `BRANCH=$(git rev-parse --abbrev-ref HEAD) DEPLOY_ENV=hector make dev deployer-concourse bootstrap` and check in paas-cf if `make dev ssh_bosh DEPLOY_ENV=hector` works.

Who?
----

Anyone but @keymon