### PR TITLE
[Support] Use a terraform array for admin_cidrs

### DIFF
--- a/terraform/concourse/elb.tf
+++ b/terraform/concourse/elb.tf
@@ -62,7 +62,7 @@ resource "aws_security_group" "concourse-elb" {
     from_port   = 443
     to_port     = 443
     protocol    = "tcp"
-    cidr_blocks = ["${compact(concat(split(",", var.admin_cidrs), list("${aws_eip.concourse.public_ip}/32"), list(var.vagrant_cidr)))}"]
+    cidr_blocks = ["${compact(concat(var.admin_cidrs, list("${aws_eip.concourse.public_ip}/32"), list(var.vagrant_cidr)))}"]
   }
 
   tags {

--- a/terraform/concourse/security_group.tf
+++ b/terraform/concourse/security_group.tf
@@ -21,7 +21,7 @@ resource "aws_security_group" "concourse" {
     from_port   = 6868
     to_port     = 6868
     protocol    = "tcp"
-    cidr_blocks = ["${compact(concat(split(",", var.admin_cidrs), list(format("%s/32", var.microbosh_static_private_ip))))}"]
+    cidr_blocks = ["${compact(concat(var.admin_cidrs, list(format("%s/32", var.microbosh_static_private_ip))))}"]
   }
 
   tags {

--- a/terraform/globals.tf
+++ b/terraform/globals.tf
@@ -104,7 +104,12 @@ variable "microbosh_static_private_ip" {
 /* Operators will mainly be from the office. See https://sites.google.com/a/digital.cabinet-office.gov.uk/gds-internal-it/news/aviationhouse-sourceipaddresses for details. */
 variable "admin_cidrs" {
   description = "CSV of CIDR addresses with access to operator/admin endpoints"
-  default     = "80.194.77.90/32,80.194.77.100/32,85.133.67.244/32"
+
+  default = [
+    "80.194.77.90/32",
+    "80.194.77.100/32",
+    "85.133.67.244/32",
+  ]
 }
 
 /* See https://docs.aws.amazon.com/elasticloadbalancing/latest/classic/elb-security-policy-table.html */

--- a/terraform/vpc/security-group.tf
+++ b/terraform/vpc/security-group.tf
@@ -14,7 +14,7 @@ resource "aws_security_group" "office-access-ssh" {
     from_port   = 22
     to_port     = 22
     protocol    = "tcp"
-    cidr_blocks = ["${compact(concat(split(",", var.admin_cidrs), list(var.vagrant_cidr)))}"]
+    cidr_blocks = ["${compact(concat(var.admin_cidrs, list(var.vagrant_cidr)))}"]
   }
 
   tags {


### PR DESCRIPTION
## What

Makes it clearer and avoids an extra interpolation function. This also makes it consistent with paas-cf.

## How to review

Code review (compare with https://github.com/alphagov/paas-cf/commit/965ae1e).
You could run this through the pipeline and verify that the change is a no-op (other than the Vagrant IP being added and removed as usual).

## Who can review

Anyone but myself.