### PR TITLE
[#135224045] Upgrade Bosh RDS instance to 9.5.4

### DIFF
--- a/terraform/bosh/rds.tf
+++ b/terraform/bosh/rds.tf
@@ -48,7 +48,7 @@ resource "aws_db_instance" "bosh" {
   storage_type               = "gp2"
   engine                     = "postgres"
   engine_version             = "9.5.4"
-  instance_class             = "db.t2.medium"
+  instance_class             = "db.t2.small"
   username                   = "dbadmin"
   password                   = "${var.secrets_bosh_postgres_password}"
   db_subnet_group_name       = "${aws_db_subnet_group.bosh_rds.name}"


### PR DESCRIPTION
## What

We've upgraded the CF RDS instance to 9.5, because it was running 9.4.5
and was going to be forcibly upgraded by Amazon soon anyway. It
therefore makes sense to keep this one in sync.

This also changes it from a t2.medium to a t2.small because it doesn't
need anything like that much resource (it's mostly idle at the moment).

## Suggestions for review

Use a temporary commit to set `apply_immediately = true` for this instance. Run the pipeline and verify that the changes apply successfully.

🚨 Note: This should only be merged and applied on a **Monday, Thursday or Friday** due to the way the maintenance windows are staggered (see #40).

## Who can review

Anyone but myself.