### PR TITLE
[#135224045] Remove FIXMEs from Bosh RDS upgrade.

### DIFF
--- a/terraform/bosh/rds.tf
+++ b/terraform/bosh/rds.tf
@@ -28,13 +28,6 @@ resource "aws_security_group" "bosh_rds" {
   }
 }
 
-# FIXME: Remove this once the upgrade to 9.5 has applied everywhere.
-resource "aws_db_parameter_group" "default" {
-  name        = "${var.env}-bosh"
-  family      = "postgres9.4"
-  description = "RDS Postgres default parameter group"
-}
-
 resource "aws_db_parameter_group" "bosh_pg_9_5" {
   name        = "${var.env}-pg95-bosh"
   family      = "postgres9.5"
@@ -60,9 +53,6 @@ resource "aws_db_instance" "bosh" {
   final_snapshot_identifier  = "${var.env}-bosh-rds-final-snapshot"
   skip_final_snapshot        = "${var.bosh_db_skip_final_snapshot}"
   auto_minor_version_upgrade = false
-
-  # FIXME: Remove this once the upgrade to 9.5 has applied everywhere.
-  allow_major_version_upgrade = true
 
   vpc_security_group_ids = ["${aws_security_group.bosh_rds.id}"]
 


### PR DESCRIPTION
🚨  **DO NOT MERGE** until the upgrade has applied to all environments - production is scheduled to be applied between 3-4am on Thursday 26th, and any pending dev environments will be applied the following Monday (30th)

## What

The parameter group had to be left in place from the upgrade (#42)
because the upgrade wasn't applied immediately, instead it was applied
in the defined maintenance window for the instance.

Now that the upgrade has been applied, the old parameter group can be
removed.

Similarly, we no longer need to set allow_major_version_upgrade because
the upgrade has completed.

## How to review

Code review.
Verify these changes apply cleanly to a deployed environment.

## Before merging

Verify the upgrade has applied to all environments.

## Who can review

Anyone but myself.