### PR TITLE
[#138486833] Terraform 0.8.5 upgrade

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ rvm:
   - 2.2.6
 env:
   global:
-    - TF_VERSION="0.7.10"
+    - TF_VERSION="0.8.5"
     - SPRUCE_VERSION="1.5.0"
 
 addons:

--- a/concourse/pipelines/create.yml
+++ b/concourse/pipelines/create.yml
@@ -159,7 +159,7 @@ jobs:
 
       - task: create-init-bucket
         config:
-          image: docker:///governmentpaas/terraform
+          image: docker:///governmentpaas/terraform#update_terraform
           params:
             TF_VAR_env: {{deploy_env}}
             TF_VAR_state_bucket: {{state_bucket}}
@@ -242,7 +242,7 @@ jobs:
       - task: deploy-vpc
         config:
           platform: linux
-          image: docker:///governmentpaas/terraform
+          image: docker:///governmentpaas/terraform#update_terraform
           inputs:
           - name: paas-bootstrap
           - name: vpc-tfstate
@@ -478,7 +478,7 @@ jobs:
       - task: terraform-apply
         config:
           platform: linux
-          image: docker:///governmentpaas/terraform
+          image: docker:///governmentpaas/terraform#update_terraform
           inputs:
             - name: paas-bootstrap
             - name: terraform-variables
@@ -837,7 +837,7 @@ jobs:
 
       - task: terraform-apply
         config:
-          image: docker:///governmentpaas/terraform
+          image: docker:///governmentpaas/terraform#update_terraform
           inputs:
           - name: paas-bootstrap
           - name: vpc-terraform-outputs
@@ -1142,7 +1142,7 @@ jobs:
       - task: remove-vagrant-IP-from-ssh-SG
         config:
           platform: linux
-          image: docker:///governmentpaas/terraform
+          image: docker:///governmentpaas/terraform#update_terraform
           inputs:
           - name: paas-bootstrap
           - name: vpc-tfstate
@@ -1168,7 +1168,7 @@ jobs:
       - task: remove-vagrant-IP-from-BOSH-SG
         config:
           platform: linux
-          image: docker:///governmentpaas/terraform
+          image: docker:///governmentpaas/terraform#update_terraform
           inputs:
           - name: paas-bootstrap
           - name: vpc-terraform-outputs
@@ -1199,7 +1199,7 @@ jobs:
       - task: remove-vagrant-IP-from-Concourse-SG
         config:
           platform: linux
-          image: docker:///governmentpaas/terraform
+          image: docker:///governmentpaas/terraform#update_terraform
           inputs:
           - name: paas-bootstrap
           - name: vpc-terraform-outputs

--- a/concourse/pipelines/destroy.yml
+++ b/concourse/pipelines/destroy.yml
@@ -101,7 +101,7 @@ jobs:
       - task: add-vagrant-IP-to-BOSH-SG
         config:
           platform: linux
-          image: docker:///governmentpaas/terraform
+          image: docker:///governmentpaas/terraform#update_terraform
           inputs:
           - name: paas-bootstrap
           - name: vpc-terraform-outputs
@@ -186,7 +186,7 @@ jobs:
 
       - task: destroy-concourse-terraform
         config:
-          image: docker:///governmentpaas/terraform
+          image: docker:///governmentpaas/terraform#update_terraform
           inputs:
           - name: paas-bootstrap
           - name: vpc-terraform-outputs
@@ -315,7 +315,7 @@ jobs:
       - task: destroy-terraform
         config:
           platform: linux
-          image: docker:///governmentpaas/terraform
+          image: docker:///governmentpaas/terraform#update_terraform
           inputs:
             - name: paas-bootstrap
             - name: terraform-variables
@@ -361,7 +361,7 @@ jobs:
 
       - task: tf-destroy-vpc
         config:
-          image: docker:///governmentpaas/terraform
+          image: docker:///governmentpaas/terraform#update_terraform
           params:
               TF_VAR_env: {{deploy_env}}
               AWS_DEFAULT_REGION: {{aws_region}}
@@ -394,7 +394,7 @@ jobs:
 
       - task: tf-destroy-init-bucket
         config:
-          image: docker:///governmentpaas/terraform
+          image: docker:///governmentpaas/terraform#update_terraform
           params:
               TF_VAR_env: {{deploy_env}}
               TF_VAR_state_bucket: {{state_bucket}}


### PR DESCRIPTION
## What

We ran into a "diffs didn't match during apply" error in paas-cf. Upgrading Terraform there (https://github.com/alphagov/paas-cf/pull/744) resolved the issue. We're therefore updating it here to be consistent.

## How to review

Review alongside https://github.com/alphagov/paas-cf/pull/744.

- Run from this branch to verify terraform works correctly.
- Remove TMP commit
- Merge once https://github.com/alphagov/paas-docker-cloudfoundry-tools/pull/86 has been merged and build in Docker Hub.

## Who can review

Anyone but myself.