### PR TITLE
[#138486833] Revert "[TMP] test with upgraded terraform"

### DIFF
--- a/concourse/pipelines/create.yml
+++ b/concourse/pipelines/create.yml
@@ -159,7 +159,7 @@ jobs:
 
       - task: create-init-bucket
         config:
-          image: docker:///governmentpaas/terraform#update_terraform
+          image: docker:///governmentpaas/terraform
           params:
             TF_VAR_env: {{deploy_env}}
             TF_VAR_state_bucket: {{state_bucket}}
@@ -242,7 +242,7 @@ jobs:
       - task: deploy-vpc
         config:
           platform: linux
-          image: docker:///governmentpaas/terraform#update_terraform
+          image: docker:///governmentpaas/terraform
           inputs:
           - name: paas-bootstrap
           - name: vpc-tfstate
@@ -478,7 +478,7 @@ jobs:
       - task: terraform-apply
         config:
           platform: linux
-          image: docker:///governmentpaas/terraform#update_terraform
+          image: docker:///governmentpaas/terraform
           inputs:
             - name: paas-bootstrap
             - name: terraform-variables
@@ -837,7 +837,7 @@ jobs:
 
       - task: terraform-apply
         config:
-          image: docker:///governmentpaas/terraform#update_terraform
+          image: docker:///governmentpaas/terraform
           inputs:
           - name: paas-bootstrap
           - name: vpc-terraform-outputs
@@ -1142,7 +1142,7 @@ jobs:
       - task: remove-vagrant-IP-from-ssh-SG
         config:
           platform: linux
-          image: docker:///governmentpaas/terraform#update_terraform
+          image: docker:///governmentpaas/terraform
           inputs:
           - name: paas-bootstrap
           - name: vpc-tfstate
@@ -1168,7 +1168,7 @@ jobs:
       - task: remove-vagrant-IP-from-BOSH-SG
         config:
           platform: linux
-          image: docker:///governmentpaas/terraform#update_terraform
+          image: docker:///governmentpaas/terraform
           inputs:
           - name: paas-bootstrap
           - name: vpc-terraform-outputs
@@ -1199,7 +1199,7 @@ jobs:
       - task: remove-vagrant-IP-from-Concourse-SG
         config:
           platform: linux
-          image: docker:///governmentpaas/terraform#update_terraform
+          image: docker:///governmentpaas/terraform
           inputs:
           - name: paas-bootstrap
           - name: vpc-terraform-outputs

--- a/concourse/pipelines/destroy.yml
+++ b/concourse/pipelines/destroy.yml
@@ -101,7 +101,7 @@ jobs:
       - task: add-vagrant-IP-to-BOSH-SG
         config:
           platform: linux
-          image: docker:///governmentpaas/terraform#update_terraform
+          image: docker:///governmentpaas/terraform
           inputs:
           - name: paas-bootstrap
           - name: vpc-terraform-outputs
@@ -186,7 +186,7 @@ jobs:
 
       - task: destroy-concourse-terraform
         config:
-          image: docker:///governmentpaas/terraform#update_terraform
+          image: docker:///governmentpaas/terraform
           inputs:
           - name: paas-bootstrap
           - name: vpc-terraform-outputs
@@ -315,7 +315,7 @@ jobs:
       - task: destroy-terraform
         config:
           platform: linux
-          image: docker:///governmentpaas/terraform#update_terraform
+          image: docker:///governmentpaas/terraform
           inputs:
             - name: paas-bootstrap
             - name: terraform-variables
@@ -361,7 +361,7 @@ jobs:
 
       - task: tf-destroy-vpc
         config:
-          image: docker:///governmentpaas/terraform#update_terraform
+          image: docker:///governmentpaas/terraform
           params:
               TF_VAR_env: {{deploy_env}}
               AWS_DEFAULT_REGION: {{aws_region}}
@@ -394,7 +394,7 @@ jobs:
 
       - task: tf-destroy-init-bucket
         config:
-          image: docker:///governmentpaas/terraform#update_terraform
+          image: docker:///governmentpaas/terraform
           params:
               TF_VAR_env: {{deploy_env}}
               TF_VAR_state_bucket: {{state_bucket}}


### PR DESCRIPTION
This reverts commit 77fc814800184a4643deb47d5c3d271c1c29ffc0.

The commit was included because github did not detect the
changes from the `git push --force` and when clicking on the merge
button immediatelly, it got the previous commit.

We noticed that in https://status.github.com/ mean hook was too high
in that moment, 7.8s

We should wait before running merge after a git push -f