### PR TITLE
[#13435058] Enable TLS for syslog

### DIFF
--- a/manifests/runtime-config/addons/syslog-forwarder.yml
+++ b/manifests/runtime-config/addons/syslog-forwarder.yml
@@ -13,6 +13,8 @@ addons:
     properties:
       syslog:
         address: (( concat "logsearch-ingestor." $SYSTEM_DNS_ZONE_NAME ))
-        port: 5514
+        port: 6514
         transport: 'tcp'
         log_template: 'metron_agent'
+        tls_enabled: true
+        permitted_peer: (( concat "*." $SYSTEM_DNS_ZONE_NAME ))

--- a/manifests/runtime-config/spec/runtime_config_spec.rb
+++ b/manifests/runtime-config/spec/runtime_config_spec.rb
@@ -41,5 +41,19 @@ RSpec.describe "Runtime config" do
 
       expect(syslog_forwarder_address).to eq "logsearch-ingestor.#{ManifestHelpers::SYSTEM_DNS_ZONE_NAME}"
     end
+
+    it "has syslog_forwarder configured with tls enabled" do
+      syslog_forwarder_addon = runtime_config.fetch("addons").find { |addon| addon["name"] == "syslog_forwarder" }
+      syslog_forwarder_tls_enabled = syslog_forwarder_addon.fetch("properties").fetch("syslog").fetch("tls_enabled")
+
+      expect(syslog_forwarder_tls_enabled).to be true
+    end
+
+    it "has syslog_forwarder configured with a permitted_peer based on the variable $SYSTEM_DNS_ZONE_NAME" do
+      syslog_forwarder_addon = runtime_config.fetch("addons").find { |addon| addon["name"] == "syslog_forwarder" }
+      syslog_forwarder_permitted_peer = syslog_forwarder_addon.fetch("properties").fetch("syslog").fetch("permitted_peer")
+
+      expect(syslog_forwarder_permitted_peer).to eq "*.#{ManifestHelpers::SYSTEM_DNS_ZONE_NAME}"
+    end
   end
 end


### PR DESCRIPTION
# What

As we would like to have be compliant with AWS Trusded advisor
recommendations we need to enable TLS communication to syslog ingestor
ELB.

## How to review

- Review https://github.com/alphagov/paas-cf/pull/776 first and deploy it on top of master. It creates new ELB listeners for TLS syslog.
- run  bootstrap from this branch and check if logs are still visible in Kibana

## Who can review

Not @paroxp or @combor