### PR TITLE
[#130020741] Concourse PW: don't generate nats password

### DIFF
--- a/manifests/concourse-manifest/scripts/generate-concourse-secrets.rb
+++ b/manifests/concourse-manifest/scripts/generate-concourse-secrets.rb
@@ -5,7 +5,6 @@ require 'yaml'
 require File.expand_path("../../../shared/lib/secret_generator", __FILE__)
 
 generator = SecretGenerator.new(
-  "concourse_nats_password" => :simple,
   "concourse_vcap_password" => :sha512_crypted,
   "concourse_atc_password" => :simple,
   "concourse_postgres_password" => :simple,


### PR DESCRIPTION
## What

The "nats" password was used when concourse was deployed by bosh init. But
we deploy it bosh now and this password is not being used anywhere any more.
Clean it up.

## How to review

Verify that password is not being used anywhere. You can for example grep for it.

## Who can review

not @mtekel
