### PR TITLE
[#119379405] Fix destroy pipeline

### DIFF
--- a/concourse/pipelines/destroy.yml
+++ b/concourse/pipelines/destroy.yml
@@ -95,7 +95,7 @@ jobs:
           image_resource:
             type: docker-image
             source:
-              repository: governmentpaas/git-ssh
+              repository: ruby
               tag: "2.2-slim"
           inputs:
           - name: paas-bootstrap
@@ -195,7 +195,7 @@ jobs:
           image_resource:
             type: docker-image
             source:
-              repository: governmentpaas/git-ssh
+              repository: ruby
               tag: "2.2-slim"
           inputs:
           - name: paas-bootstrap
@@ -340,7 +340,7 @@ jobs:
           image_resource:
             type: docker-image
             source:
-              repository: governmentpaas/git-ssh
+              repository: ruby
               tag: "2.2-slim"
           inputs:
             - name: paas-bootstrap

--- a/concourse/pipelines/destroy.yml
+++ b/concourse/pipelines/destroy.yml
@@ -1,4 +1,15 @@
 ---
+resource_types:
+- name: s3-iam
+  type: docker-image
+  source:
+    repository: governmentpaas/s3-resource
+
+- name: semver-iam
+  type: docker-image
+  source:
+    repository: governmentpaas/semver-resource
+
 resources:
   - name: paas-bootstrap
     type: git


### PR DESCRIPTION
## What

#48 Updated this repo to use Concourse 2.7. However that update has left the destroy pipeline in a broken state. This fixes it by adding in the `resource_types` block, and fixing container definition for the `extract-terraform-outputs` jobs.

## How to review

Test that the destroy pipeline works.

## Who can review

Anyone but myself.