### PR TITLE
[#140853603] Fix CONCOURSE_IP in ssh.sh script

### DIFF
--- a/concourse/scripts/ssh.sh
+++ b/concourse/scripts/ssh.sh
@@ -11,7 +11,7 @@ download_key() {
   key=/tmp/concourse_id_rsa.$RANDOM
   trap 'rm -f $key' EXIT
 
-  eval "$(make dev showenv | grep CONCOURSE_IP=)"
+  eval "$(make "${AWS_ACCOUNT}" showenv | grep CONCOURSE_IP=)"
 
   aws s3 cp "s3://${state_bucket}/concourse_id_rsa" $key && chmod 400 $key
 }


### PR DESCRIPTION
## What
Story: [Fix ssh_concourse](https://www.pivotaltracker.com/story/show/140853603)

There was a typo that was really a problem because we don't check AWS credentials but this could bite us later on as we may do the same checks as in paas-cf.

We fixed it in https://github.com/alphagov/paas-cf/pull/811 so it makes sense to keep paas-bootstrap tidy as well.

## How to review
Try `ssh_concourse` on a non DEV environment

## Who can review
Not me