### PR TITLE
[#139196683] Use latest paas-datadog-agent-boshrelease

### DIFF
--- a/manifests/runtime-config/addons-meta/datadog-agent.yml
+++ b/manifests/runtime-config/addons-meta/datadog-agent.yml
@@ -1,9 +1,9 @@
 ---
 releases:
   - name: datadog-agent
-    version: 0.1.1
-    url: https://s3-eu-west-1.amazonaws.com/gds-paas-build-releases/datadog-agent-0.1.1.tgz
-    sha1: 71c6e2f957b4381d44dedce1b1080cbfc5e8ef28
+    version: 0.1.3
+    url: https://s3-eu-west-1.amazonaws.com/gds-paas-build-releases/datadog-agent-0.1.3.tgz
+    sha1: f32ef05e24c06ba14a936570203f665d2396dc81
 
 meta:
   datadog:


### PR DESCRIPTION
# Depends on https://github.com/alphagov/paas-datadog-agent-boshrelease/pull/9

Currently using dev build from https://github.com/alphagov/paas-datadog-agent-boshrelease/pull/9
This commit should be updated to use final build once that PR is merged.

## What

Use latest paas-datadog-agent-boshrelease.

## How to review

Run bootstrap pipeline to apply new runtime config. This will also re-deploy bosh and concourse with latest agent. Then run main deployer pipeline and observe deploy-cf task update agent on all VMs. You can do this as a part of https://github.com/alphagov/paas-datadog-agent-boshrelease/pull/9 review. Once you use final build, BOSH should not need to update any VMs, because hashes of the files/config should be the same as in dev release this PR is using.

## Who can review

not @mtekel
