### PR TITLE
Add boostrap concourse ssh target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -147,6 +147,9 @@ showenv: ## Display environment information
 ssh_concourse: check-env-vars ## SSH to the concourse server
 	@./concourse/scripts/ssh.sh
 
+ssh_bootstrap_concourse: check-env-vars ## SSH to the bootstrap concourse server
+	@cd vagrant ; vagrant ssh -- -i ../${VAGRANT_SSH_KEY_NAME}
+
 tunnel: check-env-vars ## SSH tunnel to internal IPs
 	$(if ${TUNNEL},,$(error Must pass TUNNEL=SRC_PORT:HOST:DST_PORT))
 	@./concourse/scripts/ssh.sh ${TUNNEL}

--- a/Makefile
+++ b/Makefile
@@ -140,6 +140,9 @@ showenv: ## Display environment information
 	@echo export CONCOURSE_IP=$$(aws ec2 describe-instances \
 		--filters 'Name=tag:Name,Values=concourse/*' "Name=key-name,Values=${DEPLOY_ENV}_concourse_key_pair" \
 		--query 'Reservations[].Instances[].PublicIpAddress' --output text)
+	@echo export BOOTSTRAP_CONCOURSE_IP=$$(aws ec2 describe-instances \
+		--filters 'Name=tag:Name,Values=*concourse' "Name=key-name,Values=${VAGRANT_SSH_KEY_NAME}" \
+                --query 'Reservations[].Instances[].PublicIpAddress' --output text)
 
 ssh_concourse: check-env-vars ## SSH to the concourse server
 	@./concourse/scripts/ssh.sh


### PR DESCRIPTION
## What

Add makefile target to ssh to bootstrap concourse. Display bootstrap concourse IP in showenv.

## How to review



Deploy your bootstrap server if you don't have one already. Run `make dev ssh_bootstrap_concourse`. 
Run `make dev showenv`. Check that the it also contains bootstrap concourse IP.

## Who can review

not @mtekel