### PR TITLE
[#139196683] Use latest final build of datadog-agent release

### DIFF
--- a/manifests/runtime-config/addons-meta/datadog-agent.yml
+++ b/manifests/runtime-config/addons-meta/datadog-agent.yml
@@ -1,9 +1,9 @@
 ---
 releases:
   - name: datadog-agent
-    version: 0.1.3
-    url: https://s3-eu-west-1.amazonaws.com/gds-paas-build-releases/datadog-agent-0.1.3.tgz
-    sha1: f32ef05e24c06ba14a936570203f665d2396dc81
+    version: 0.1.4
+    url: https://s3-eu-west-1.amazonaws.com/gds-paas-build-releases/datadog-agent-0.1.4.tgz
+    sha1: a1902a885ef465617eae4f1de184ecaed0d1feb8
 
 meta:
   datadog:


### PR DESCRIPTION
## What
Use latest final build of datadog-agent release

To deploy fix for handling hostname definitions from
https://github.com/alphagov/paas-datadog-agent-boshrelease/pull/10

## How to review

Deploy. Observe no `no_data` errors on TCP and HTTP datadog checks for your environment for say at least 4 hours.

## Who can review

not @mtekel