### PR TITLE
[#144515851] Add a btrfs process count metric on concourse

### DIFF
--- a/manifests/runtime-config/addons-meta/datadog-agent.yml
+++ b/manifests/runtime-config/addons-meta/datadog-agent.yml
@@ -15,3 +15,10 @@ meta:
     tags:
       aws_account: (( grab $AWS_ACCOUNT ))
       deploy_env: (( grab terraform_outputs.environment ))
+    integrations:
+      process:
+        init_config:
+
+        instances:
+          - name: btrfs
+            search_string: ["btrfs"]


### PR DESCRIPTION
## What

This causes the datadog agent to track all btrfs processes running on the concourse machines, which we then use in https://github.com/alphagov/paas-cf/pull/906 to alert when it gets out of control.

## How to review

1. Deploy to your deployer concourse (with `ENABLE_DATADOG=true`)
1. Check that your concourse is emitting a new `system.processes.number` metric for `process_name:btrfs`

## After this is merged

This must be deployed to our ci/staging/prod concourses.