### PR TITLE
[#141423205] Use ACM to create a real cert for concourse.

### DIFF
--- a/concourse/pipelines/create.yml
+++ b/concourse/pipelines/create.yml
@@ -142,13 +142,6 @@ resources:
       versioned_file: git_id_rsa.pub
       region_name: {{aws_region}}
 
-  - name: concourse-cert
-    type: s3-iam
-    source:
-      bucket: {{state_bucket}}
-      versioned_file: concourse-cert.tar.gz
-      region_name: {{aws_region}}
-
   - name: concourse-secrets
     type: s3-iam
     source:
@@ -245,7 +238,6 @@ jobs:
               paas-bootstrap/concourse/scripts/s3init.sh {{state_bucket}} id_rsa paas-bootstrap/concourse/init_files/zero_bytes
               paas-bootstrap/concourse/scripts/s3init.sh {{state_bucket}} id_rsa.pub paas-bootstrap/concourse/init_files/zero_bytes
               paas-bootstrap/concourse/scripts/s3init.sh {{state_bucket}} concourse.tfstate paas-bootstrap/concourse/init_files/terraform.tfstate.tpl
-              paas-bootstrap/concourse/scripts/s3init.sh {{state_bucket}} concourse-cert.tar.gz paas-bootstrap/concourse/init_files/empty.tar.gz
               paas-bootstrap/concourse/scripts/s3init.sh {{state_bucket}} concourse-secrets.yml paas-bootstrap/concourse/init_files/zero_bytes
 
           inputs:
@@ -854,7 +846,6 @@ jobs:
         - get: bosh-tfstate
           passed: ['bosh-terraform']
         - get: concourse-tfstate
-        - get: concourse-cert
         - get: git-ssh-public-key
 
       - task: terraform-outputs-to-sh
@@ -893,34 +884,15 @@ jobs:
           image_resource:
             type: docker-image
             source:
-              repository: governmentpaas/curl-ssl
+              repository: governmentpaas/awscli
           inputs:
-          - name: concourse-cert
-          outputs:
-          - name: generated-concourse-cert
+            - name: paas-bootstrap
           params:
             CONCOURSE_HOSTNAME: {{concourse_hostname}}
             SYSTEM_DNS_ZONE_NAME: {{system_dns_zone_name}}
+            AWS_DEFAULT_REGION: {{aws_region}}
           run:
-            path: sh
-            args:
-            - -e
-            - -c
-            - |
-              tar xzvf concourse-cert/concourse-cert.tar.gz
-              if [ -f concourse.crt ] && [ -f concourse.key ]; then
-                echo "Certificate and private key already created, nothing to do"
-                cp concourse-cert/concourse-cert.tar.gz generated-concourse-cert/
-                exit 0
-              fi
-              openssl req -x509 -newkey rsa:2048 -keyout concourse.key \
-                -out concourse.crt -days 365 -nodes -subj \
-                "/C=UK/ST=London/L=London/O=GDS/CN=${CONCOURSE_HOSTNAME}.${SYSTEM_DNS_ZONE_NAME}"
-              tar czvf generated-concourse-cert/concourse-cert.tar.gz concourse.crt concourse.key
-        on_success:
-          put: concourse-cert
-          params:
-            file: generated-concourse-cert/concourse-cert.tar.gz
+            path: ./paas-bootstrap/concourse/scripts/create_concourse_cert.sh
 
       - task: generate-concourse-ssh-key
         config:
@@ -959,7 +931,6 @@ jobs:
           - name: vpc-terraform-outputs
           - name: bosh-terraform-outputs
           - name: concourse-tfstate
-          - name: generated-concourse-cert
           - name: git-ssh-public-key
           - name: concourse-ssh-key
           outputs:
@@ -977,7 +948,6 @@ jobs:
             - -c
             - |
               cp concourse-ssh-key/concourse_id_rsa.pub paas-bootstrap/terraform/concourse
-              tar xzvf generated-concourse-cert/concourse-cert.tar.gz
               . vpc-terraform-outputs/tfvars.sh
               . bosh-terraform-outputs/tfvars.sh
               export TF_VAR_git_rsa_id_pub

--- a/concourse/pipelines/destroy.yml
+++ b/concourse/pipelines/destroy.yml
@@ -249,6 +249,22 @@ jobs:
           params:
             file: updated-concourse-tfstate/concourse.tfstate
 
+      - task: delete-concourse-cert
+        config:
+          platform: linux
+          image_resource:
+            type: docker-image
+            source:
+              repository: governmentpaas/awscli
+          inputs:
+            - name: paas-bootstrap
+          params:
+            CONCOURSE_HOSTNAME: {{concourse_hostname}}
+            SYSTEM_DNS_ZONE_NAME: {{system_dns_zone_name}}
+            AWS_DEFAULT_REGION: {{aws_region}}
+          run:
+            path: ./paas-bootstrap/concourse/scripts/delete_concourse_cert.sh
+
   - name: destroy-bosh
     serial: true
     plan:

--- a/concourse/scripts/create_concourse_cert.sh
+++ b/concourse/scripts/create_concourse_cert.sh
@@ -1,0 +1,48 @@
+#!/bin/sh
+
+set -eu
+
+concourse_fqdn="${CONCOURSE_HOSTNAME}.${SYSTEM_DNS_ZONE_NAME}"
+
+arn=$(aws acm list-certificates --query "CertificateSummaryList[?DomainName==\`${concourse_fqdn}\`].CertificateArn" --output text)
+
+created_cert="false"
+if [ -z "${arn}" ] || [ "${arn}" = "None" ]; then
+  echo "Requesting certificate for ${concourse_fqdn}"
+  arn=$(aws acm request-certificate --domain-name "${concourse_fqdn}" --output text)
+  created_cert="true"
+fi
+
+cert_status=$(aws acm describe-certificate --certificate-arn "${arn}" --query 'Certificate.Status' --output text)
+if [ "${cert_status}" = "ISSUED" ]; then
+  echo "Certificate already issued for ${concourse_fqdn}. Exiting..."
+  exit 0
+fi
+
+if [ "${created_cert}" = "false" ]; then
+  echo "Resending validation email for ${concourse_fqdn} certificate"
+  aws acm resend-validation-email --certificate-arn "${arn}" --domain "${concourse_fqdn}" --validation-domain "${SYSTEM_DNS_ZONE_NAME}"
+fi
+
+cat <<EOT
+The certificate for ${concourse_fqdn} has been requested. To verify this,
+emails will be sent to the paas-domain-admins containing a link to validate
+this request. Once that is done, the certificate can be used.
+
+This script will now poll for up to 10 mins waiting for this to happen.
+EOT
+
+for _ in $(seq 40); do
+  sleep 15
+  printf "."
+  cert_status=$(aws acm describe-certificate --certificate-arn "${arn}" --query 'Certificate.Status' --output text)
+  if [ "${cert_status}" = "ISSUED" ]; then
+    echo
+    echo "Cert issued successfully."
+    exit 0
+  fi
+done
+echo
+
+echo "Certificate still not approved. Giving up waiting."
+exit 1

--- a/concourse/scripts/delete_concourse_cert.sh
+++ b/concourse/scripts/delete_concourse_cert.sh
@@ -1,0 +1,15 @@
+#!/bin/sh
+
+set -eu
+
+concourse_fqdn="${CONCOURSE_HOSTNAME}.${SYSTEM_DNS_ZONE_NAME}"
+
+arn=$(aws acm list-certificates --query "CertificateSummaryList[?DomainName==\`${concourse_fqdn}\`].CertificateArn" --output text)
+
+if [ -z "${arn}" ] || [ "${arn}" = "None" ]; then
+  echo "No cert found for ${concourse_fqdn}. Skipping..."
+  exit 0
+fi
+
+echo "Deleting cert for ${concourse_fqdn} - arn: ${arn}"
+aws acm delete-certificate --certificate-arn "${arn}"

--- a/terraform/concourse/elb.tf
+++ b/terraform/concourse/elb.tf
@@ -1,11 +1,6 @@
-resource "aws_iam_server_certificate" "concourse" {
-  name_prefix      = "${var.env}-concourse-"
-  certificate_body = "${file("concourse.crt")}"
-  private_key      = "${file("concourse.key")}"
-
-  lifecycle {
-    create_before_destroy = true
-  }
+data "aws_acm_certificate" "concourse" {
+  domain   = "${var.concourse_hostname}.${var.system_dns_zone_name}"
+  statuses = ["ISSUED"]
 }
 
 resource "aws_elb" "concourse" {
@@ -27,7 +22,7 @@ resource "aws_elb" "concourse" {
     instance_protocol  = "tcp"
     lb_port            = 443
     lb_protocol        = "ssl"
-    ssl_certificate_id = "${aws_iam_server_certificate.concourse.arn}"
+    ssl_certificate_id = "${data.aws_acm_certificate.concourse.arn}"
   }
 
   tags {

--- a/vagrant/post-deploy.d/00-run-docker.sh
+++ b/vagrant/post-deploy.d/00-run-docker.sh
@@ -1,4 +1,7 @@
-#!/bin/sh -eu
+#!/bin/sh
+
+set -eu
+
 sudo apt-get update && sudo apt-get install docker-compose -y
 
 cd /vagrant


### PR DESCRIPTION
## What

This uses Amazon Certificate Manager to create a valid signed cert to use for the concourse instance this deploys.

## How to review

🚨  Note: this depends on https://github.gds/government-paas/aws-account-wide-terraform/pull/91

* Run the bootstrap pipeline from this branch.
* The `cf-terraform` job will create a certificate request, and then pause waiting for it to be approved.
* Persuade someone on the paas-domain-admins list (currently @alext, @dcarley and @timmow) to approve the certificate request.
* Observe the pipeline continue and update the concourse to use this cert.
* Verify that your concourse now has a valid cert (Note: chrome seems to cache SSL connections, so it may require a restart/incognito mode to pickup the change).

You could also test that the destroy pipeline works correctly and cleans up the cert.

## Who can review

Not me.