### PR TITLE
[#145211537] Pin all governmentpaas containers to a version

### DIFF
--- a/concourse/pipelines/concourse-lite-self-terminate.yml
+++ b/concourse/pipelines/concourse-lite-self-terminate.yml
@@ -21,6 +21,7 @@ jobs:
           type: docker-image
           source:
             repository: governmentpaas/awscli
+            tag: 895cf6752c8ec64af05a3a735186b90acd3db65a
         params:
           VAGRANT_SSH_KEY_NAME: {{vagrant_ssh_key_name}}
         run:

--- a/concourse/pipelines/create.yml
+++ b/concourse/pipelines/create.yml
@@ -24,11 +24,13 @@ resource_types:
   type: docker-image
   source:
     repository: governmentpaas/s3-resource
+    tag: 9e7cf1dd32699c091e22e46b349e050443d9ac1a
 
 - name: semver-iam
   type: docker-image
   source:
     repository: governmentpaas/semver-resource
+    tag: dc33fee5c9061263e83159a893340f46728d93b5
 
 resources:
   - name: paas-bootstrap
@@ -169,6 +171,7 @@ jobs:
             type: docker-image
             source:
               repository: governmentpaas/awscli
+              tag: 895cf6752c8ec64af05a3a735186b90acd3db65a
           params:
             AWS_DEFAULT_REGION: {{aws_region}}
           inputs:
@@ -192,6 +195,7 @@ jobs:
             type: docker-image
             source:
               repository: governmentpaas/terraform
+              tag: 895cf6752c8ec64af05a3a735186b90acd3db65a
           params:
             TF_VAR_env: {{deploy_env}}
             TF_VAR_state_bucket: {{state_bucket}}
@@ -222,6 +226,7 @@ jobs:
             type: docker-image
             source:
               repository: governmentpaas/curl-ssl
+              tag: 895cf6752c8ec64af05a3a735186b90acd3db65a
           run:
             path: sh
             args:
@@ -264,6 +269,7 @@ jobs:
             type: docker-image
             source:
               repository: governmentpaas/curl-ssl
+              tag: 895cf6752c8ec64af05a3a735186b90acd3db65a
           inputs:
           - name: paas-bootstrap
           params:
@@ -286,6 +292,7 @@ jobs:
             type: docker-image
             source:
               repository: governmentpaas/terraform
+              tag: 895cf6752c8ec64af05a3a735186b90acd3db65a
           inputs:
           - name: paas-bootstrap
           - name: vpc-tfstate
@@ -334,6 +341,7 @@ jobs:
             type: docker-image
             source:
               repository: governmentpaas/certstrap
+              tag: 895cf6752c8ec64af05a3a735186b90acd3db65a
           inputs:
             - name: paas-bootstrap
             - name: bosh-CA
@@ -398,6 +406,7 @@ jobs:
               type: docker-image
               source:
                 repository: governmentpaas/git-ssh
+                tag: 895cf6752c8ec64af05a3a735186b90acd3db65a
             inputs:
               - name: paas-bootstrap
               - name: bosh-ssh-private-key
@@ -439,6 +448,7 @@ jobs:
               type: docker-image
               source:
                 repository: governmentpaas/git-ssh
+                tag: 895cf6752c8ec64af05a3a735186b90acd3db65a
             inputs:
               - name: paas-bootstrap
               - name: ssh-private-key
@@ -551,6 +561,7 @@ jobs:
             type: docker-image
             source:
               repository: governmentpaas/terraform
+              tag: 895cf6752c8ec64af05a3a735186b90acd3db65a
           inputs:
             - name: paas-bootstrap
             - name: terraform-variables
@@ -638,6 +649,7 @@ jobs:
             type: docker-image
             source:
               repository: governmentpaas/certstrap
+              tag: 895cf6752c8ec64af05a3a735186b90acd3db65a
           inputs:
             - name: paas-bootstrap
             - name: bosh-CA
@@ -661,6 +673,7 @@ jobs:
             type: docker-image
             source:
               repository: governmentpaas/spruce
+              tag: 895cf6752c8ec64af05a3a735186b90acd3db65a
           inputs:
             - name: paas-bootstrap
             - name: terraform-outputs
@@ -715,6 +728,7 @@ jobs:
             type: docker-image
             source:
               repository: governmentpaas/spruce
+              tag: 895cf6752c8ec64af05a3a735186b90acd3db65a
           inputs:
             - name: paas-bootstrap
             - name: terraform-outputs
@@ -786,6 +800,7 @@ jobs:
             type: docker-image
             source:
               repository: governmentpaas/bosh-init
+              tag: 895cf6752c8ec64af05a3a735186b90acd3db65a
           inputs:
             - name: bosh-manifest
             - name: bosh-init-state
@@ -818,6 +833,7 @@ jobs:
             type: docker-image
             source:
               repository: governmentpaas/bosh-cli
+              tag: 895cf6752c8ec64af05a3a735186b90acd3db65a
           inputs:
             - name: paas-bootstrap
             - name: bosh-secrets
@@ -885,6 +901,7 @@ jobs:
             type: docker-image
             source:
               repository: governmentpaas/awscli
+              tag: 895cf6752c8ec64af05a3a735186b90acd3db65a
           inputs:
             - name: paas-bootstrap
           params:
@@ -901,6 +918,7 @@ jobs:
             type: docker-image
             source:
               repository: governmentpaas/curl-ssl
+              tag: 895cf6752c8ec64af05a3a735186b90acd3db65a
           inputs:
           - name: paas-bootstrap
           outputs:
@@ -926,6 +944,7 @@ jobs:
             type: docker-image
             source:
               repository: governmentpaas/terraform
+              tag: 895cf6752c8ec64af05a3a735186b90acd3db65a
           inputs:
           - name: paas-bootstrap
           - name: vpc-terraform-outputs
@@ -972,6 +991,7 @@ jobs:
             type: docker-image
             source:
               repository: governmentpaas/awscli
+              tag: 895cf6752c8ec64af05a3a735186b90acd3db65a
           inputs:
           - name: paas-bootstrap
           params:
@@ -1044,6 +1064,7 @@ jobs:
             type: docker-image
             source:
               repository: governmentpaas/spruce
+              tag: 895cf6752c8ec64af05a3a735186b90acd3db65a
           params:
             AWS_ACCOUNT: {{aws_account}}
             DATADOG_API_KEY: {{datadog_api_key}}
@@ -1103,6 +1124,7 @@ jobs:
             type: docker-image
             source:
               repository: governmentpaas/bosh-cli
+              tag: 895cf6752c8ec64af05a3a735186b90acd3db65a
           inputs:
             - name: bosh-secrets
             - name: paas-bootstrap
@@ -1128,6 +1150,7 @@ jobs:
             type: docker-image
             source:
               repository: governmentpaas/bosh-cli
+              tag: 895cf6752c8ec64af05a3a735186b90acd3db65a
           inputs:
           - name: concourse-manifest
           - name: bosh-secrets
@@ -1156,6 +1179,7 @@ jobs:
             type: docker-image
             source:
               repository: governmentpaas/self-update-pipelines
+              tag: 895cf6752c8ec64af05a3a735186b90acd3db65a
           inputs:
             - name: paas-bootstrap
             - name: concourse-manifest
@@ -1199,6 +1223,7 @@ jobs:
             type: docker-image
             source:
               repository: governmentpaas/bosh-cli
+              tag: 895cf6752c8ec64af05a3a735186b90acd3db65a
           inputs:
           - name: paas-bootstrap
           - name: concourse-manifest
@@ -1267,6 +1292,7 @@ jobs:
             type: docker-image
             source:
               repository: governmentpaas/terraform
+              tag: 895cf6752c8ec64af05a3a735186b90acd3db65a
           inputs:
           - name: paas-bootstrap
           - name: vpc-tfstate
@@ -1299,6 +1325,7 @@ jobs:
             type: docker-image
             source:
               repository: governmentpaas/terraform
+              tag: 895cf6752c8ec64af05a3a735186b90acd3db65a
           inputs:
           - name: paas-bootstrap
           - name: vpc-terraform-outputs
@@ -1336,6 +1363,7 @@ jobs:
             type: docker-image
             source:
               repository: governmentpaas/terraform
+              tag: 895cf6752c8ec64af05a3a735186b90acd3db65a
           inputs:
           - name: paas-bootstrap
           - name: vpc-terraform-outputs
@@ -1379,6 +1407,7 @@ jobs:
             type: docker-image
             source:
               repository: governmentpaas/spruce
+              tag: 895cf6752c8ec64af05a3a735186b90acd3db65a
           inputs:
             - name: paas-bootstrap
             - name: concourse-secrets
@@ -1418,6 +1447,7 @@ jobs:
             type: docker-image
             source:
               repository: governmentpaas/spruce
+              tag: 895cf6752c8ec64af05a3a735186b90acd3db65a
           inputs:
             - name: paas-bootstrap
             - name: bosh-secrets

--- a/concourse/pipelines/destroy.yml
+++ b/concourse/pipelines/destroy.yml
@@ -4,11 +4,13 @@ resource_types:
   type: docker-image
   source:
     repository: governmentpaas/s3-resource
+    tag: 9e7cf1dd32699c091e22e46b349e050443d9ac1a
 
 - name: semver-iam
   type: docker-image
   source:
     repository: governmentpaas/semver-resource
+    tag: dc33fee5c9061263e83159a893340f46728d93b5
 
 resources:
   - name: paas-bootstrap
@@ -120,6 +122,7 @@ jobs:
             type: docker-image
             source:
               repository: governmentpaas/terraform
+              tag: 895cf6752c8ec64af05a3a735186b90acd3db65a
           inputs:
             - name: paas-bootstrap
             - name: vpc-terraform-outputs
@@ -175,6 +178,7 @@ jobs:
             type: docker-image
             source:
               repository: governmentpaas/bosh-cli
+              tag: 895cf6752c8ec64af05a3a735186b90acd3db65a
           inputs:
           - name: paas-bootstrap
           - name: bosh-secrets
@@ -220,6 +224,7 @@ jobs:
             type: docker-image
             source:
               repository: governmentpaas/terraform
+              tag: 895cf6752c8ec64af05a3a735186b90acd3db65a
           inputs:
             - name: paas-bootstrap
             - name: vpc-terraform-outputs
@@ -256,6 +261,7 @@ jobs:
             type: docker-image
             source:
               repository: governmentpaas/awscli
+              tag: 895cf6752c8ec64af05a3a735186b90acd3db65a
           inputs:
             - name: paas-bootstrap
           params:
@@ -286,6 +292,7 @@ jobs:
             type: docker-image
             source:
               repository: governmentpaas/bosh-cli
+              tag: 895cf6752c8ec64af05a3a735186b90acd3db65a
           inputs:
             - name: paas-bootstrap
             - name: bosh-secrets
@@ -305,6 +312,7 @@ jobs:
             type: docker-image
             source:
               repository: governmentpaas/bosh-cli
+              tag: 895cf6752c8ec64af05a3a735186b90acd3db65a
           inputs:
             - name: paas-bootstrap
             - name: bosh-secrets
@@ -324,6 +332,7 @@ jobs:
             type: docker-image
             source:
               repository: governmentpaas/bosh-init
+              tag: 895cf6752c8ec64af05a3a735186b90acd3db65a
           inputs:
             - name: paas-bootstrap
             - name: bosh-manifest
@@ -382,6 +391,7 @@ jobs:
             type: docker-image
             source:
               repository: governmentpaas/terraform
+              tag: 895cf6752c8ec64af05a3a735186b90acd3db65a
           inputs:
             - name: paas-bootstrap
             - name: terraform-variables
@@ -432,6 +442,7 @@ jobs:
             type: docker-image
             source:
               repository: governmentpaas/terraform
+              tag: 895cf6752c8ec64af05a3a735186b90acd3db65a
           params:
               TF_VAR_env: {{deploy_env}}
               AWS_DEFAULT_REGION: {{aws_region}}
@@ -472,6 +483,7 @@ jobs:
             type: docker-image
             source:
               repository: governmentpaas/terraform
+              tag: 895cf6752c8ec64af05a3a735186b90acd3db65a
           params:
               TF_VAR_env: {{deploy_env}}
               TF_VAR_state_bucket: {{state_bucket}}

--- a/concourse/tasks/delete-ssh-keys.yml
+++ b/concourse/tasks/delete-ssh-keys.yml
@@ -4,6 +4,7 @@ image_resource:
   type: docker-image
   source:
     repository: governmentpaas/awscli
+    tag: 895cf6752c8ec64af05a3a735186b90acd3db65a
 inputs:
   - name: paas-bootstrap
 run:


### PR DESCRIPTION
## What

So that we can control how containers are updated between environments and
prevent forwards/backwards incompatibilities with code in the pipeline.

This will also prevent Concourse from re-downloading all of the containers
each time we merge a change to alphagov/paas-docker-cloudfoundry-tools
because Docker Hub rebuilds everything.

Using the functionality added in:

- alphagov/paas-docker-cloudfoundry-tools#93

## How to review

1. Eyeball the diff and make sure that it looks sensible
1. Run at least one pipeline and confirm that it still works

## Who can review

Not @dcarley