### PR TITLE
[#145266177] Update the URL for GitHub Enterprise

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ these are defined in the repo [aws-account-wide-terraform][]
 (not public because it also contains state files).
 
 [instance profiles]: http://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_use_switch-role-ec2_instance-profiles.html
-[aws-account-wide-terraform]: https://github.gds/government-paas/aws-account-wide-terraform
+[aws-account-wide-terraform]: https://github.digital.cabinet-office.gov.uk/government-paas/aws-account-wide-terraform
 
 * Declare your environment name using the variable DEPLOY_ENV.
 


### PR DESCRIPTION
## What

It moved to a "real" hostname with a real certificate on the evening of
2017-05-11 as described in this announcement:

- https://sites.google.com/a/digital.cabinet-office.gov.uk/gds-internal-it/github-enterprise-change-5-30pm-6pm-11th-may-2017/githubdigitalcabinet-officegovuk

## How to review

Code review only.

## Who can review

Not @dcarley