### PR TITLE
[#132565531] Bosh upgrade 261.4

### DIFF
--- a/concourse/pipelines/create.yml
+++ b/concourse/pipelines/create.yml
@@ -800,7 +800,7 @@ jobs:
             type: docker-image
             source:
               repository: governmentpaas/bosh-init
-              tag: 895cf6752c8ec64af05a3a735186b90acd3db65a
+              tag: 4268307611a4b787e837801b6889890495004618
           inputs:
             - name: bosh-manifest
             - name: bosh-init-state

--- a/concourse/pipelines/create.yml
+++ b/concourse/pipelines/create.yml
@@ -420,8 +420,8 @@ jobs:
                 - -e
                 - -c
                 - |
-                  if [ -s bosh-ssh-private-key/bosh_id_rsa ] ; then
-                    echo "BOSH private key non-zero size, skipping generation..."
+                  if [ -s bosh-ssh-private-key/bosh_id_rsa ] && [ -s bosh-ssh-private-key/bosh_id_rsa.pub ]; then
+                    echo "BOSH keys non-zero size, skipping generation..."
                     cp bosh-ssh-private-key/bosh_id_rsa bosh-ssh-private-key-to-upload
                     cp bosh-ssh-public-key/bosh_id_rsa.pub bosh-ssh-public-key-to-upload
                     exit 0
@@ -462,8 +462,8 @@ jobs:
                 - -e
                 - -c
                 - |
-                  if [ -s ssh-private-key/id_rsa ] ; then
-                    echo "Deployments private key non-zero size, skipping generation..."
+                  if [ -s ssh-private-key/id_rsa ] && [ -s ssh-private-key/id_rsa.pub ]; then
+                    echo "Deployment keys non-zero size, skipping generation..."
                     cp ssh-private-key/id_rsa ssh-private-key-to-upload
                     cp ssh-public-key/id_rsa.pub ssh-public-key-to-upload
                     exit 0

--- a/manifests/bosh-manifest/bosh-manifest.yml
+++ b/manifests/bosh-manifest/bosh-manifest.yml
@@ -19,8 +19,8 @@ meta:
 
 releases:
 - name: bosh
-  url: https://bosh.io/d/github.com/cloudfoundry/bosh?v=258
-  sha1: 66f7ce02eda71d63fc13e86a6d49fa5a8398c906
+  url: https://bosh.io/d/github.com/cloudfoundry/bosh?v=261.4
+  sha1: 4da9cedbcc8fbf11378ef439fb89de08300ad091
 - name: bosh-aws-cpi
   version: 62
   url: https://bosh.io/d/github.com/cloudfoundry-incubator/bosh-aws-cpi-release?v=62
@@ -149,8 +149,8 @@ resource_pools:
 - name: bosh
   network: private
   stemcell:
-    url: https://bosh.io/d/stemcells/bosh-aws-xen-hvm-ubuntu-trusty-go_agent?v=3263.14
-    sha1: cc3377af8c0bf31d069b32d74ab01ab470b31c7a
+    url: https://bosh.io/d/stemcells/bosh-aws-xen-hvm-ubuntu-trusty-go_agent?v=3363.20
+    sha1: 16f1aa2a272befe87a9f0805ae9d367c8e2802ea
   cloud_properties:
     instance_type: t2.medium
     ephemeral_disk: {size: 40000, type: gp2}


### PR DESCRIPTION
## What

Story: [Upgrade to BOSH >= 261.3](https://www.pivotaltracker.com/story/show/132565531)

Upgrade BOSH to most recent version. This is required for the next CF release.
It also updates the BOSH stemcell. bosh-init must be updated as well as a bug was encountered with our current version.
Finally, a check in key generation has been added to cover a case where a zero byte key was uploaded.

Depends on: https://github.com/alphagov/paas-docker-cloudfoundry-tools/pull/94

## How to review

* Deploy an environment based on master to simulate prod
* Run paas-bootstrap from this branch
* Run the CF pipeline
* Wait for all tests to pass
* Destroy CF and bootrstrap

## Before merging

* Review https://github.com/alphagov/paas-docker-cloudfoundry-tools/pull/94
* Merge it
* Update the TEMP commit in this PR as described in the commit message

## Who can review

Not @combor or me
