### PR TITLE
[#141423205] Specify validation_domain when requesting ACM cert.

### DIFF
--- a/concourse/scripts/create_concourse_cert.sh
+++ b/concourse/scripts/create_concourse_cert.sh
@@ -9,7 +9,7 @@ arn=$(aws acm list-certificates --query "CertificateSummaryList[?DomainName==\`$
 created_cert="false"
 if [ -z "${arn}" ] || [ "${arn}" = "None" ]; then
   echo "Requesting certificate for ${concourse_fqdn}"
-  arn=$(aws acm request-certificate --domain-name "${concourse_fqdn}" --output text)
+  arn=$(aws acm request-certificate --domain-name "${concourse_fqdn}" --domain-validation-options "DomainName=${concourse_fqdn},ValidationDomain=${SYSTEM_DNS_ZONE_NAME}" --output text)
   created_cert="true"
 fi
 


### PR DESCRIPTION
## What

This controls where the non-whois emails get sent to. We're using these
as a workaround while ACM are getting whois support for gov.uk working.
We need this to use the bare system domain because we can't put MX
records alongside the CNAME for the deployer domain name.

## How to review

* Use the AWS console to update the concourse ELB to use a different cert.
* Delete the deployer cert in ACM.
* Run the bootstrap pipeline
* Verify that the cert request uses the system domain for the postmaster@ etc email verifications.

## Who can review

Not me.