### PR TITLE
[#145756013] Restart containers if they exit

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,5 +1,6 @@
 concourse-db:
   image: postgres:9.6.2-alpine
+  restart: always
   environment:
     POSTGRES_DB: "${CONCOURSE_DATABASE_NAME}"
     POSTGRES_USER: "${CONCOURSE_DATABASE_USER}"
@@ -10,6 +11,7 @@ concourse-web:
   image: concourse/concourse:2.7.0
   links: [concourse-db]
   command: web
+  restart: always
   ports: ["8080:8080"]
   volumes: ["./keys/web:/concourse-keys"]
   environment:
@@ -24,6 +26,7 @@ concourse-worker:
   privileged: true
   links: [concourse-web]
   command: worker
+  restart: always
   volumes: ["./keys/worker:/concourse-keys"]
   environment:
     CONCOURSE_TSA_HOST: concourse-web


### PR DESCRIPTION
## What

We've seen a few anecdotal reports in the team of Bootstrap Concourse
machines not self-terminating and being found running days/months later.
Piotr also had problems during the last BOSH upgrade story with losing
access to Concourse - which I think is related.

This morning I went to bring up a new Bootstrap Concourse for my dev
environment and it hung on "Waiting for concourse to start for". I found an
existing VM that had been running for 2 weeks. But I could still use the
following command to access it:

    VAGRANT_CWD=vagrant VAGRANT_SSH_KEY="../${DEPLOY_ENV}-vagrant-bootstrap-concourse" vagrant ssh

I found in `/var/log/syslog` that Concourse had been killed because it used
too much memory. Which meant that the pipelines were no longer configured or
scheduled, so it didn't self-terminate:

    May 11 15:29:09 ip-172-31-15-5 kernel: [25444.294943] Out of memory: Kill process 4603 (concourse) score 53 or sacrifice child
    May 11 15:29:09 ip-172-31-15-5 kernel: [25444.298836] Killed process 4603 (concourse) total-vm:905864kB, anon-rss:419288kB, file-rss:15080kB

Telling Docker to always restart the containers if they die should prevent
this from happening and allow self-termination to happen. I tried using
`on-failure` instead of `always`, but killing a process doesn't necessarily
mean that it will exit with a non-zero code. It may have also helped to
increase the size of the Concourse instance but I don't think that the right
solution to this problem since it's already an `m4.large`.

## How to review

1. Checkout the branch:

        git fetch && git checkout bugfix/restart_containers
1. Bring up a Bootstrap Concourse:

        make dev deployer-concourse bootstrap
1. Check that you can access it on http://localhost:8080
1. Kill the `concourse-web` process:

        VAGRANT_CWD=vagrant VAGRANT_SSH_KEY="../${DEPLOY_ENV}-vagrant-bootstrap-concourse" vagrant ssh -c 'sudo pgrep -fx "/usr/local/bin/concourse web"'
1. Check that you can still access http://localhost:8080

## Who can review

Anyone.