### PR TITLE
README, Add note regarding DEPLOY_ENV

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,8 @@ these are defined in the repo [aws-account-wide-terraform][]
 $ export DEPLOY_ENV=environment-name
 ```
 
+It is important that you do not use the same `DEPLOY_ENV` for both build and deployer concourse environments, this is to avoid conflicts in resource allocation.
+
 ### Deploy
 
 Create Concourse Lite with `make`. There are targets to select the target AWS account, and to select the profiles to apply. For instance for a DEV build concourse bootstrap:


### PR DESCRIPTION
## What

A few of us have been caught out by using the same `DEPLOY_ENV` for both
build and deployer concourse environments. This adds a note to inform
the reader to use a different one to prevent resource allocation
conflicts.

## How to review

Code review.

## Who can review

Not me
