### PR TITLE
[#147124125] Increase max number of retries

### DIFF
--- a/manifests/bosh-manifest/bosh-manifest.yml
+++ b/manifests/bosh-manifest/bosh-manifest.yml
@@ -13,6 +13,7 @@ meta:
     default_security_groups:
     - (( grab terraform_outputs.bosh_managed_security_group ))
     region: (( grab terraform_outputs.region ))
+    max_retries: 16
 
   bosh_private_ip: (( grab terraform_outputs.microbosh_static_private_ip ))
   bosh_public_ip: (( grab terraform_outputs.microbosh_static_public_ip ))
@@ -111,6 +112,7 @@ jobs:
       default_security_groups: (( grab meta.aws.default_security_groups ))
       default_iam_instance_profile: bosh-managed
       region: (( grab meta.aws.region ))
+      max_retries: (( grab meta.aws.max_retries ))
 
 properties: ~
 
@@ -138,6 +140,7 @@ cloud_provider:
       default_key_name: (( grab terraform_outputs.bosh_ssh_key_pair_name ))
       default_security_groups: (( grab meta.aws.default_security_groups ))
       region: (( grab meta.aws.region ))
+      max_retries: (( grab meta.aws.max_retries ))
 
 disk_pools:
 - name: disks


### PR DESCRIPTION
## What
We're implementing a functionality that'll kick-off the
dev `create-cloudfoundry` pipeline every morning. Starting many
environments at roughly the same time, will cause increased amount of
calls made towards AWS.

Increasing the number of max retries, should help us a little with the
potential issue of being caught out by the limit established upstream.

It is set to 16, as previously (a while ago), we had it set to 8. We
have more people on the team and 16 felt like a safe bet to play with.

I have ran the bootstrap on my `dev` environment, which didn't cause any
issues with regards to the change.

## How to review

I don't think it is something easy to review.

- Check if the value is correct
- Run `make dev bootstrap`
- Be aware of its existence and monitor the behaviour over time
