### PR TITLE
[#148059799] Update datadog-agent boshrelease

### DIFF
--- a/manifests/runtime-config/addons-meta/datadog-agent.yml
+++ b/manifests/runtime-config/addons-meta/datadog-agent.yml
@@ -1,9 +1,9 @@
 ---
 releases:
   - name: datadog-agent
-    version: 0.1.4
-    url: https://s3-eu-west-1.amazonaws.com/gds-paas-build-releases/datadog-agent-0.1.4.tgz
-    sha1: a1902a885ef465617eae4f1de184ecaed0d1feb8
+    version: 0.0.1498732925
+    url: https://s3-eu-west-1.amazonaws.com/gds-paas-build-releases/datadog-agent-0.0.1498732925.tgz
+    sha1: 90fe08de4f9023c732ffb7b0e7fd02f3d4d54b6e
 
 meta:
   datadog:


### PR DESCRIPTION
## What

We've applied some logrotate fixes to the boshrelease, which will no
longer prevent logrotate from rotating the logs on datadog-agent.

## How to review

- Code review
- Run the bootstrap from this branch - inb4 Dan: I have run that myself :)
- Experience no issues
- For bonus points: Check if logrotate does warn about permissions

## Before merging

This PR highly depends on the [`datadog-agent`](https://github.com/alphagov/paas-datadog-agent-boshrelease/pull/11) and [`collect`](alphagov/paas-collectd-boshrelease#3) being merged first. The changes here will need to be upgraded with new correct versions.