### PR TITLE
[#137364635] - Add self updating pipeline to concourses

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -131,11 +131,7 @@ deployer-concourse: ## Setup profiles for deploying a paas-cf deployer concourse
 
 ## Actions
 
-.PHONY: fly-login
-fly-login: ## Do a fly login and sync
-	$$("./concourse/scripts/environment.sh") && \
-		./concourse/scripts/fly_sync_and_login.sh
-
+.PHONY: pipelines
 pipelines:
 	$(eval export TARGET_CONCOURSE=${CONCOURSE_TYPE})
 	$(if ${TARGET_CONCOURSE},,$(error Must set CONCOURSE_TYPE=deployer-concourse|build-concourse. This can be done with the relevant make target.))

--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ You will need a working [Concourse Lite](#concourse-lite).
 
 ### Deploy
 
-Run the `create` pipeline from your *Concourse Lite*.
+Run the `create-bosh-concourse` pipeline from your *Concourse Lite*. The pipeline will upload itself to the Concourse it has created, which means future runs of the pipeline can be done from there. In theory, we should only need the *Concourse Lite* for the initial bootstrapping.
 
 When complete, you can access the new Concourse from your browser. The URL
 and credentials can be found from:
@@ -129,20 +129,10 @@ Login credentials can be shown by `make <env> showenv`.
 
 ### Destroy
 
-Run the `destroy` pipeline from your *Concourse Lite*.
+Run the `destroy-bosh-concourse` pipeline from your *Concourse Lite*.
 
 
 # Additional notes
-
-## Optionally override the branch used by pipelines
-
-All of the pipeline scripts (including `vagrant/deploy.sh`) honour a
-`BRANCH` environment variable which allows you to override the git branch
-used within the pipeline. This is useful for development and code review:
-
-```
-BRANCH=$(git rev-parse --abbrev-ref HEAD) make dev pipelines
-```
 
 ## Sharing your Bootstrap Concourse
 

--- a/concourse/pipelines/create-bosh-concourse.yml
+++ b/concourse/pipelines/create-bosh-concourse.yml
@@ -1139,6 +1139,7 @@ jobs:
 
   - name: concourse-deploy
     serial: true
+    interruptible: true
     plan:
       - aggregate:
         - get: paas-bootstrap

--- a/concourse/pipelines/create-bosh-concourse.yml
+++ b/concourse/pipelines/create-bosh-concourse.yml
@@ -13,7 +13,7 @@ groups:
       - generate-concourse-config
       - concourse-deploy
       - post-deploy
-      - expunge-vagrant
+      - expunge-concourse
 
   - name: credentials
     jobs:
@@ -239,7 +239,6 @@ jobs:
             SELF_UPDATE_PIPELINE: {{self_update_pipeline}}
             TARGET_CONCOURSE: {{target_concourse}}
             CONCOURSE_TYPE: {{concourse_type}}
-            VAGRANT_IP: {{vagrant_ip}}
           run:
             path: ./paas-bootstrap/concourse/scripts/self-update-pipeline.sh
 
@@ -330,7 +329,6 @@ jobs:
           outputs:
           - name: updated-vpc-tfstate
           params:
-            VAGRANT_IP: {{vagrant_ip}}
             TF_VAR_env: {{deploy_env}}
             AWS_DEFAULT_REGION: {{aws_region}}
           run:
@@ -339,7 +337,8 @@ jobs:
             - -e
             - -c
             - |
-              terraform_params=${VAGRANT_IP:+-var vagrant_cidr=$VAGRANT_IP/32}
+              CONCOURSE_EGRESS_IP=$(wget -q -O - http://169.254.169.254/latest/meta-data/public-ipv4)
+              terraform_params="-var concourse_egress_cidr=${CONCOURSE_EGRESS_IP}/32"
               terraform apply ${terraform_params} -var-file=paas-bootstrap/terraform/{{aws_account}}.tfvars \
                 -state=vpc-tfstate/vpc.tfstate \
                 -state-out=updated-vpc-tfstate/vpc.tfstate \
@@ -604,7 +603,6 @@ jobs:
           params:
             DEPLOY_ENV: {{deploy_env}}
             AWS_DEFAULT_REGION: {{aws_region}}
-            VAGRANT_IP: {{vagrant_ip}}
             TF_VAR_system_dns_zone_name: {{system_dns_zone_name}}
             TF_VAR_bosh_az: {{bosh_az}}
             TF_VAR_bosh_fqdn: {{bosh_fqdn}}
@@ -620,7 +618,8 @@ jobs:
 
                 cp ssh-public-key/id_rsa.pub paas-bootstrap/terraform/bosh
                 cp bosh-ssh-public-key/bosh_id_rsa.pub paas-bootstrap/terraform/bosh
-                terraform_params=${VAGRANT_IP:+-var vagrant_cidr=$VAGRANT_IP/32}
+                CONCOURSE_EGRESS_IP=$(wget -q -O - http://169.254.169.254/latest/meta-data/public-ipv4)
+                terraform_params="-var concourse_egress_cidr=${CONCOURSE_EGRESS_IP}/32"
                 terraform apply ${terraform_params} -var env={{deploy_env}} -var-file=paas-bootstrap/terraform/{{aws_account}}.tfvars \
                   -state=bosh-tfstate/bosh.tfstate -state-out=updated-bosh-tfstate/bosh.tfstate paas-bootstrap/terraform/bosh
         ensure:
@@ -727,7 +726,6 @@ jobs:
               ./terraform-outputs/vpc.terraform-outputs.yml
             BOSH_FQDN: {{bosh_fqdn}}
             BOSH_FQDN_EXTERNAL: {{bosh_fqdn_external}}
-            BOSH_LOGIN_HOST: {{bosh_login_host}}
             BOSH_INSTANCE_PROFILE: {{bosh_instance_profile}}
           run:
             path: sh
@@ -870,15 +868,13 @@ jobs:
             - name: paas-bootstrap
             - name: bosh-secrets
             - name: runtime-config
-          params:
-            BOSH_LOGIN_HOST: {{bosh_login_host}}
           run:
             path: sh
             args:
               - -e
               - -c
               - |
-                ./paas-bootstrap/concourse/scripts/bosh_login.sh "${BOSH_LOGIN_HOST}" bosh-secrets/bosh-secrets.yml
+                ./paas-bootstrap/concourse/scripts/bosh_login.sh {{bosh_fqdn_external}} bosh-secrets/bosh-secrets.yml
                 bosh update runtime-config runtime-config/runtime-config.yml
                 ./paas-bootstrap/concourse/scripts/bosh_upload_releases_from_manifest.rb runtime-config/runtime-config.yml
 
@@ -989,7 +985,6 @@ jobs:
           outputs:
           - name: updated-concourse-tfstate
           params:
-            VAGRANT_IP: {{vagrant_ip}}
             TF_VAR_env: {{deploy_env}}
             TF_VAR_concourse_hostname: {{concourse_hostname}}
             TF_VAR_system_dns_zone_name: {{system_dns_zone_name}}
@@ -1005,8 +1000,8 @@ jobs:
               . bosh-terraform-outputs/tfvars.sh
               export TF_VAR_git_rsa_id_pub
               TF_VAR_git_rsa_id_pub=$(cat git-ssh-public-key/git_id_rsa.pub)
-
-              terraform_params=${VAGRANT_IP:+-var vagrant_cidr=$VAGRANT_IP/32}
+              CONCOURSE_EGRESS_IP=$(wget -q -O - http://169.254.169.254/latest/meta-data/public-ipv4)
+              terraform_params="-var concourse_egress_cidr=${CONCOURSE_EGRESS_IP}/32"
               terraform apply ${terraform_params} \
                 -var-file=paas-bootstrap/terraform/{{aws_account}}.tfvars \
                 -state=concourse-tfstate/concourse.tfstate \
@@ -1163,8 +1158,6 @@ jobs:
           inputs:
             - name: bosh-secrets
             - name: paas-bootstrap
-          params:
-            BOSH_LOGIN_HOST: {{bosh_login_host}}
           run:
             path: sh
             args:
@@ -1177,7 +1170,7 @@ jobs:
                 STEMCELL_NAME=$($VAL_FROM_YAML meta.stemcell.name paas-bootstrap/manifests/concourse-manifest/concourse-base.yml)
 
                 wget https://bosh.io/d/stemcells/${STEMCELL_NAME}?v=${STEMCELL_VERSION} -O stemcell.tgz
-                ./paas-bootstrap/concourse/scripts/bosh_login.sh "${BOSH_LOGIN_HOST}" bosh-secrets/bosh-secrets.yml
+                ./paas-bootstrap/concourse/scripts/bosh_login.sh {{bosh_fqdn_external}} bosh-secrets/bosh-secrets.yml
                 bosh upload stemcell stemcell.tgz --skip-if-exists
 
       - task: deploy-concourse
@@ -1194,15 +1187,13 @@ jobs:
           - name: paas-bootstrap
           outputs:
           - name: updated-concourse-manifest
-          params:
-            BOSH_LOGIN_HOST: {{bosh_login_host}}
           run:
             path: sh
             args:
             - -e
             - -c
             - |
-              ./paas-bootstrap/concourse/scripts/bosh_login.sh "${BOSH_LOGIN_HOST}" bosh-secrets/bosh-secrets.yml
+              ./paas-bootstrap/concourse/scripts/bosh_login.sh {{bosh_fqdn_external}} bosh-secrets/bosh-secrets.yml
               sed -e "s/^director_uuid:.*/director_uuid: $(bosh status --uuid)/" < concourse-manifest/concourse-manifest.yml > updated-concourse-manifest/concourse-manifest.yml
               bosh deployment updated-concourse-manifest/concourse-manifest.yml
               bosh -n deploy
@@ -1267,15 +1258,13 @@ jobs:
           - name: paas-bootstrap
           - name: concourse-manifest
           - name: bosh-secrets
-          params:
-            BOSH_LOGIN_HOST: {{bosh_login_host}}
           run:
             path: sh
             args:
             - -e
             - -c
             - |
-              ./paas-bootstrap/concourse/scripts/bosh_login.sh "${BOSH_LOGIN_HOST}" bosh-secrets/bosh-secrets.yml
+              ./paas-bootstrap/concourse/scripts/bosh_login.sh {{bosh_fqdn_external}} bosh-secrets/bosh-secrets.yml
               mkdir -p updated-concourse-manifest
               sed -e "s/^director_uuid:.*/director_uuid: $(bosh status --uuid)/" < concourse-manifest/concourse-manifest.yml > updated-concourse-manifest/concourse-manifest.yml
               bosh deployment updated-concourse-manifest/concourse-manifest.yml
@@ -1308,7 +1297,7 @@ jobs:
             - |
               make -C ./paas-bootstrap "${AWS_ACCOUNT}" "${CONCOURSE_TYPE}" pipelines
 
-  - name: expunge-vagrant
+  - name: expunge-concourse
     serial: true
     plan:
       - aggregate:
@@ -1351,7 +1340,7 @@ jobs:
               > bosh-terraform-outputs/tfvars.sh
               ls -l bosh-terraform-outputs/tfvars.sh
 
-      - task: remove-vagrant-IP-from-ssh-SG
+      - task: remove-concourse-IP-from-ssh-SG
         config:
           platform: linux
           image_resource:
@@ -1384,7 +1373,7 @@ jobs:
           params:
             file: updated-vpc-tfstate/vpc.tfstate
 
-      - task: remove-vagrant-IP-from-BOSH-SG
+      - task: remove-concourse-IP-from-BOSH-SG
         config:
           platform: linux
           image_resource:
@@ -1422,7 +1411,7 @@ jobs:
           params:
             file: updated-bosh-tfstate/bosh.tfstate
 
-      - task: remove-vagrant-IP-from-Concourse-SG
+      - task: remove-concourse-IP-from-Concourse-SG
         config:
           platform: linux
           image_resource:

--- a/concourse/pipelines/create-bosh-concourse.yml
+++ b/concourse/pipelines/create-bosh-concourse.yml
@@ -3,6 +3,7 @@ groups:
   - name: all
     jobs:
       - init-bucket
+      - s3init
       - vpc
       - generate-secrets
       - bosh-terraform
@@ -220,7 +221,39 @@ jobs:
           params:
             file: updated-bucket-state/bucket.tfstate
 
-      - task: s3init-concourse
+      - task: self-update-pipelines
+        config:
+          platform: linux
+          image_resource:
+            type: docker-image
+            source:
+              repository: governmentpaas/self-update-pipelines
+              tag: 895cf6752c8ec64af05a3a735186b90acd3db65a
+          inputs:
+            - name: paas-bootstrap
+          params:
+            DEPLOY_ENV: {{deploy_env}}
+            BRANCH: {{branch_name}}
+            AWS_ACCOUNT: {{aws_account}}
+            SKIP_COMMIT_VERIFICATION: {{skip_commit_verification}}
+            SELF_UPDATE_PIPELINE: {{self_update_pipeline}}
+            TARGET_CONCOURSE: {{target_concourse}}
+            CONCOURSE_TYPE: {{concourse_type}}
+            VAGRANT_IP: {{vagrant_ip}}
+          run:
+            path: ./paas-bootstrap/concourse/scripts/self-update-pipeline.sh
+
+      - put: pipeline-trigger
+        params: {bump: patch}
+
+  - name: s3init
+    serial: true
+    plan:
+      - get: pipeline-trigger
+        trigger: true
+        passed: ['init-bucket']
+      - get: paas-bootstrap
+      - task: s3init
         config:
           platform: linux
           image_resource:
@@ -228,6 +261,8 @@ jobs:
             source:
               repository: governmentpaas/curl-ssl
               tag: 895cf6752c8ec64af05a3a735186b90acd3db65a
+          inputs:
+            - name: paas-bootstrap
           run:
             path: sh
             args:
@@ -246,21 +281,16 @@ jobs:
               paas-bootstrap/concourse/scripts/s3init.sh {{state_bucket}} concourse.tfstate paas-bootstrap/concourse/init_files/terraform.tfstate.tpl
               paas-bootstrap/concourse/scripts/s3init.sh {{state_bucket}} concourse-secrets.yml paas-bootstrap/concourse/init_files/zero_bytes
 
-          inputs:
-          - name: paas-bootstrap
-      - put: pipeline-trigger
-        params: {bump: patch}
-
   - name: vpc
     serial: true
     plan:
       - aggregate:
         - get: paas-bootstrap
           trigger: true
-          passed: ['init-bucket']
+          passed: ['s3init']
         - get: pipeline-trigger
           trigger: true
-          passed: ['init-bucket']
+          passed: ['s3init']
         - get: vpc-tfstate
 
       - task: generate-git-ssh-key
@@ -323,9 +353,9 @@ jobs:
     plan:
       - aggregate:
         - get: paas-bootstrap
-          passed: ['init-bucket']
+          passed: ['s3init']
         - get: pipeline-trigger
-          passed: ['init-bucket']
+          passed: ['s3init']
           trigger: true
         - get: bosh-CA
         - get: bosh-secrets
@@ -697,6 +727,7 @@ jobs:
               ./terraform-outputs/vpc.terraform-outputs.yml
             BOSH_FQDN: {{bosh_fqdn}}
             BOSH_FQDN_EXTERNAL: {{bosh_fqdn_external}}
+            BOSH_LOGIN_HOST: {{bosh_login_host}}
             BOSH_INSTANCE_PROFILE: {{bosh_instance_profile}}
           run:
             path: sh
@@ -839,13 +870,15 @@ jobs:
             - name: paas-bootstrap
             - name: bosh-secrets
             - name: runtime-config
+          params:
+            BOSH_LOGIN_HOST: {{bosh_login_host}}
           run:
             path: sh
             args:
               - -e
               - -c
               - |
-                ./paas-bootstrap/concourse/scripts/bosh_login.sh {{bosh_fqdn_external}} bosh-secrets/bosh-secrets.yml
+                ./paas-bootstrap/concourse/scripts/bosh_login.sh "${BOSH_LOGIN_HOST}" bosh-secrets/bosh-secrets.yml
                 bosh update runtime-config runtime-config/runtime-config.yml
                 ./paas-bootstrap/concourse/scripts/bosh_upload_releases_from_manifest.rb runtime-config/runtime-config.yml
 
@@ -1129,6 +1162,8 @@ jobs:
           inputs:
             - name: bosh-secrets
             - name: paas-bootstrap
+          params:
+            BOSH_LOGIN_HOST: {{bosh_login_host}}
           run:
             path: sh
             args:
@@ -1141,7 +1176,7 @@ jobs:
                 STEMCELL_NAME=$($VAL_FROM_YAML meta.stemcell.name paas-bootstrap/manifests/concourse-manifest/concourse-base.yml)
 
                 wget https://bosh.io/d/stemcells/${STEMCELL_NAME}?v=${STEMCELL_VERSION} -O stemcell.tgz
-                ./paas-bootstrap/concourse/scripts/bosh_login.sh {{bosh_fqdn_external}} bosh-secrets/bosh-secrets.yml
+                ./paas-bootstrap/concourse/scripts/bosh_login.sh "${BOSH_LOGIN_HOST}" bosh-secrets/bosh-secrets.yml
                 bosh upload stemcell stemcell.tgz --skip-if-exists
 
       - task: deploy-concourse
@@ -1158,13 +1193,15 @@ jobs:
           - name: paas-bootstrap
           outputs:
           - name: updated-concourse-manifest
+          params:
+            BOSH_LOGIN_HOST: {{bosh_login_host}}
           run:
             path: sh
             args:
             - -e
             - -c
             - |
-              ./paas-bootstrap/concourse/scripts/bosh_login.sh {{bosh_fqdn_external}} bosh-secrets/bosh-secrets.yml
+              ./paas-bootstrap/concourse/scripts/bosh_login.sh "${BOSH_LOGIN_HOST}" bosh-secrets/bosh-secrets.yml
               sed -e "s/^director_uuid:.*/director_uuid: $(bosh status --uuid)/" < concourse-manifest/concourse-manifest.yml > updated-concourse-manifest/concourse-manifest.yml
               bosh deployment updated-concourse-manifest/concourse-manifest.yml
               bosh -n deploy
@@ -1229,19 +1266,46 @@ jobs:
           - name: paas-bootstrap
           - name: concourse-manifest
           - name: bosh-secrets
+          params:
+            BOSH_LOGIN_HOST: {{bosh_login_host}}
           run:
             path: sh
             args:
             - -e
             - -c
             - |
-              ./paas-bootstrap/concourse/scripts/bosh_login.sh {{bosh_fqdn_external}} bosh-secrets/bosh-secrets.yml
+              ./paas-bootstrap/concourse/scripts/bosh_login.sh "${BOSH_LOGIN_HOST}" bosh-secrets/bosh-secrets.yml
               mkdir -p updated-concourse-manifest
               sed -e "s/^director_uuid:.*/director_uuid: $(bosh status --uuid)/" < concourse-manifest/concourse-manifest.yml > updated-concourse-manifest/concourse-manifest.yml
               bosh deployment updated-concourse-manifest/concourse-manifest.yml
               DEPLOYMENT_NAME=$(./paas-bootstrap/concourse/scripts/val_from_yaml.rb name updated-concourse-manifest/concourse-manifest.yml)
               bosh vms "${DEPLOYMENT_NAME}" | tee vms.txt
               [ $(grep '|' vms.txt | grep -cEv "(^\|\ \ |\-\-|VM|running)") -eq 0 ]
+
+      - task: upload-pipeline
+        config:
+          platform: linux
+          image_resource:
+            type: docker-image
+            source:
+              repository: governmentpaas/self-update-pipelines
+              tag: 895cf6752c8ec64af05a3a735186b90acd3db65a
+          inputs:
+            - name: paas-bootstrap
+          params:
+            DEPLOY_ENV: {{deploy_env}}
+            BRANCH: {{branch_name}}
+            AWS_ACCOUNT: {{aws_account}}
+            SKIP_COMMIT_VERIFICATION: {{skip_commit_verification}}
+            SELF_UPDATE_PIPELINE: {{self_update_pipeline}}
+            CONCOURSE_TYPE: {{concourse_type}}
+          run:
+            path: sh
+            args:
+            - -e
+            - -c
+            - |
+              make -C ./paas-bootstrap "${AWS_ACCOUNT}" "${CONCOURSE_TYPE}" pipelines
 
   - name: expunge-vagrant
     serial: true

--- a/concourse/pipelines/destroy-bosh-concourse.yml
+++ b/concourse/pipelines/destroy-bosh-concourse.yml
@@ -106,7 +106,6 @@ jobs:
             SELF_UPDATE_PIPELINE: {{self_update_pipeline}}
             TARGET_CONCOURSE: {{target_concourse}}
             CONCOURSE_TYPE: {{concourse_type}}
-            VAGRANT_IP: {{vagrant_ip}}
           run:
             path: ./paas-bootstrap/concourse/scripts/self-update-pipeline.sh
       - put: pipeline-trigger
@@ -147,7 +146,7 @@ jobs:
               > vpc-terraform-outputs/tfvars.sh
               ls -l vpc-terraform-outputs/tfvars.sh
 
-      - task: add-vagrant-IP-to-BOSH-SG
+      - task: add-concourse-IP-to-BOSH-SG
         config:
           platform: linux
           image_resource:
@@ -167,7 +166,6 @@ jobs:
             TF_VAR_bosh_fqdn: {{bosh_fqdn}}
             TF_VAR_bosh_fqdn_external: {{bosh_fqdn_external}}
             AWS_DEFAULT_REGION: {{aws_region}}
-            VAGRANT_IP: {{vagrant_ip}}
           run:
             path: sh
             args:
@@ -177,7 +175,8 @@ jobs:
               . vpc-terraform-outputs/tfvars.sh
               export TF_VAR_secrets_bosh_postgres_password=""
               export TF_VAR_bosh_az=""
-              terraform_params=${VAGRANT_IP:+-var vagrant_cidr=$VAGRANT_IP/32}
+              CONCOURSE_EGRESS_IP=$(wget -q -O - http://169.254.169.254/latest/meta-data/public-ipv4)
+              terraform_params="-var concourse_egress_cidr=${CONCOURSE_EGRESS_IP}/32"
               terraform apply ${terraform_params} -target=aws_security_group.bosh \
                 -state=bosh-tfstate/bosh.tfstate -state-out=updated-bosh-tfstate/bosh.tfstate \
                 -var-file=paas-bootstrap/terraform/{{aws_account}}.tfvars paas-bootstrap/terraform/bosh
@@ -436,7 +435,6 @@ jobs:
           params:
             DEPLOY_ENV: {{deploy_env}}
             AWS_DEFAULT_REGION: {{aws_region}}
-            VAGRANT_IP: {{vagrant_ip}}
             TF_VAR_system_dns_zone_name: {{system_dns_zone_name}}
             TF_VAR_bosh_az: {{bosh_az}}
             TF_VAR_bosh_fqdn: {{bosh_fqdn}}
@@ -451,7 +449,8 @@ jobs:
                 . terraform-variables/bosh-secrets.tfvars.sh
 
                 touch paas-bootstrap/terraform/bosh/id_rsa.pub paas-bootstrap/terraform/bosh/bosh_id_rsa.pub
-                terraform_params=${VAGRANT_IP:+-var vagrant_cidr=$VAGRANT_IP/32}
+                CONCOURSE_EGRESS_IP=$(wget -q -O - http://169.254.169.254/latest/meta-data/public-ipv4)
+                terraform_params="-var concourse_egress_cidr=${CONCOURSE_EGRESS_IP}/32"
                 terraform destroy ${terraform_params} -force -var env={{deploy_env}} -var-file=paas-bootstrap/terraform/{{aws_account}}.tfvars \
                   -state=bosh-tfstate/bosh.tfstate -state-out=updated-bosh-tfstate/bosh.tfstate paas-bootstrap/terraform/bosh
         ensure:

--- a/concourse/pipelines/destroy-bosh-concourse.yml
+++ b/concourse/pipelines/destroy-bosh-concourse.yml
@@ -84,10 +84,41 @@ resources:
       versioned_file: concourse-manifest.yml
 
 jobs:
+  - name: self-update-pipeline
+    serial: true
+    plan:
+      - get: paas-bootstrap
+      - task: upload-pipeline
+        config:
+          platform: linux
+          image_resource:
+            type: docker-image
+            source:
+              repository: governmentpaas/self-update-pipelines
+              tag: 895cf6752c8ec64af05a3a735186b90acd3db65a
+          inputs:
+            - name: paas-bootstrap
+          params:
+            DEPLOY_ENV: {{deploy_env}}
+            BRANCH: {{branch_name}}
+            AWS_ACCOUNT: {{aws_account}}
+            SKIP_COMMIT_VERIFICATION: {{skip_commit_verification}}
+            SELF_UPDATE_PIPELINE: {{self_update_pipeline}}
+            TARGET_CONCOURSE: {{target_concourse}}
+            CONCOURSE_TYPE: {{concourse_type}}
+            VAGRANT_IP: {{vagrant_ip}}
+          run:
+            path: ./paas-bootstrap/concourse/scripts/self-update-pipeline.sh
+      - put: pipeline-trigger
+        params: {bump: patch}
+
   - name: enable-bosh-access
     serial: true
     plan:
       - aggregate:
+        - get: pipeline-trigger
+          trigger: true
+          passed: ['self-update-pipeline']
         - get: paas-bootstrap
         - get: vpc-tfstate
         - get: bosh-tfstate
@@ -155,9 +186,6 @@ jobs:
           params:
             file: updated-bosh-tfstate/bosh.tfstate
 
-      - put: pipeline-trigger
-        params: {bump: patch}
-
   - name: destroy-concourse
     serial: true
     plan:
@@ -184,13 +212,15 @@ jobs:
           - name: paas-bootstrap
           - name: bosh-secrets
           - name: concourse-manifest
+          params:
+            BOSH_LOGIN_HOST: {{bosh_login_host}}
           run:
             path: sh
             args:
             - -e
             - -c
             - |
-              ./paas-bootstrap/concourse/scripts/bosh_login.sh {{bosh_fqdn_external}} bosh-secrets/bosh-secrets.yml
+              ./paas-bootstrap/concourse/scripts/bosh_login.sh "${BOSH_LOGIN_HOST}" bosh-secrets/bosh-secrets.yml
               DEPLOYMENT_NAME=$(./paas-bootstrap/concourse/scripts/val_from_yaml.rb name concourse-manifest/concourse-manifest.yml)
               bosh -n delete deployment --force "$DEPLOYMENT_NAME"
 
@@ -297,13 +327,15 @@ jobs:
           inputs:
             - name: paas-bootstrap
             - name: bosh-secrets
+          params:
+            BOSH_LOGIN_HOST: {{bosh_login_host}}
           run:
             path: sh
             args:
               - -e
               - -c
               - |
-                ./paas-bootstrap/concourse/scripts/bosh_login.sh {{bosh_fqdn_external}} bosh-secrets/bosh-secrets.yml
+                ./paas-bootstrap/concourse/scripts/bosh_login.sh "${BOSH_LOGIN_HOST}" bosh-secrets/bosh-secrets.yml
                 ./paas-bootstrap/concourse/scripts/bosh_pre_destroy.rb
 
       - task: cleanup-orphaned-disks
@@ -317,13 +349,15 @@ jobs:
           inputs:
             - name: paas-bootstrap
             - name: bosh-secrets
+          params:
+            BOSH_LOGIN_HOST: {{bosh_login_host}}
           run:
             path: sh
             args:
               - -e
               - -c
               - |
-                ./paas-bootstrap/concourse/scripts/bosh_login.sh {{bosh_fqdn_external}} bosh-secrets/bosh-secrets.yml
+                ./paas-bootstrap/concourse/scripts/bosh_login.sh "${BOSH_LOGIN_HOST}" bosh-secrets/bosh-secrets.yml
                 bosh cleanup --all
 
       - task: destroy-bosh-instance

--- a/concourse/scripts/environment.sh
+++ b/concourse/scripts/environment.sh
@@ -17,15 +17,36 @@ fi
 
 AWS_ACCOUNT=${AWS_ACCOUNT:-dev}
 
-CONCOURSE_URL="${CONCOURSE_URL:-http://localhost:8080}"
-FLY_TARGET="${FLY_TARGET:-${DEPLOY_ENV}-bootstrap}"
-FLY_CMD="${PROJECT_DIR}/bin/fly-bootstrap"
-
+BOSH_FQDN="bosh.${SYSTEM_DNS_ZONE_NAME}"
+BOSH_FQDN_EXTERNAL="bosh-external.${SYSTEM_DNS_ZONE_NAME}"
 CONCOURSE_ATC_USER=${CONCOURSE_ATC_USER:-admin}
-if [ -z "${CONCOURSE_ATC_PASSWORD:-}" ]; then
-    user_id=$(aws sts get-caller-identity | awk '$1 ~ /UserId/ {print $2}')
-    CONCOURSE_ATC_PASSWORD=$(hashed_password "${user_id}")
-fi
+case "${TARGET_CONCOURSE}" in
+  bootstrap)
+    CONCOURSE_URL="${CONCOURSE_URL:-http://localhost:8080}"
+    FLY_TARGET="${FLY_TARGET:-${DEPLOY_ENV}-bootstrap}"
+    FLY_CMD="${PROJECT_DIR}/bin/fly-bootstrap"
+
+    if [ -z "${CONCOURSE_ATC_PASSWORD:-}" ]; then
+        user_id=$(aws sts get-caller-identity | awk '$1 ~ /UserId/ {print $2}')
+        CONCOURSE_ATC_PASSWORD=$(hashed_password "${user_id}")
+    fi
+    BOSH_LOGIN_HOST=${BOSH_FQDN_EXTERNAL}
+    ;;
+  deployer-concourse|build-concourse)
+    CONCOURSE_URL="https://${CONCOURSE_HOSTNAME}.${SYSTEM_DNS_ZONE_NAME}"
+    FLY_TARGET="${FLY_TARGET:-$DEPLOY_ENV}"
+    FLY_CMD="${PROJECT_DIR}/bin/fly"
+
+    if [ -z "${CONCOURSE_ATC_PASSWORD:-}" ]; then
+      CONCOURSE_ATC_PASSWORD=$(concourse/scripts/val_from_yaml.rb secrets.concourse_atc_password <(aws s3 cp "s3://gds-paas-${DEPLOY_ENV}-state/concourse-secrets.yml" -))
+    fi
+    BOSH_LOGIN_HOST=${BOSH_FQDN}
+    ;;
+  *)
+    echo "Unrecognized TARGET_CONCOURSE: '${TARGET_CONCOURSE}'. Must be (bootstrap|deployer-concourse|build-concourse)" 1>&2
+    exit 1
+    ;;
+esac
 
 CONCOURSE_DATABASE_NAME="concourse"
 CONCOURSE_DATABASE_USER="$(openssl rand -hex 10)"
@@ -40,6 +61,9 @@ export CONCOURSE_URL=${CONCOURSE_URL}
 export CONCOURSE_DATABASE_NAME=${CONCOURSE_DATABASE_NAME}
 export CONCOURSE_DATABASE_USER=${CONCOURSE_DATABASE_USER}
 export CONCOURSE_DATABASE_PASS=${CONCOURSE_DATABASE_PASS}
+export BOSH_LOGIN_HOST=${BOSH_LOGIN_HOST}
+export BOSH_FQDN=${BOSH_FQDN}
+export BOSH_FQDN_EXTERNAL=${BOSH_FQDN_EXTERNAL}
 export VAGRANT_SSH_KEY=${PROJECT_DIR}/${DEPLOY_ENV}-vagrant-bootstrap-concourse
 export FLY_CMD=${FLY_CMD}
 export FLY_TARGET=${FLY_TARGET}

--- a/concourse/scripts/pipelines.sh
+++ b/concourse/scripts/pipelines.sh
@@ -18,12 +18,18 @@ branch_name: ${BRANCH:-master}
 aws_region: ${AWS_DEFAULT_REGION:-eu-west-1}
 log_level: ${LOG_LEVEL:-}
 concourse_hostname: ${CONCOURSE_HOSTNAME}
+concourse_url: ${CONCOURSE_URL}
 system_dns_zone_name: ${SYSTEM_DNS_ZONE_NAME}
 bosh_az: ${BOSH_AZ:-eu-west-1a}
 bosh_manifest_state: bosh-manifest-state-${BOSH_AZ:-eu-west-1a}.json
-bosh_fqdn: bosh.${SYSTEM_DNS_ZONE_NAME}
-bosh_fqdn_external: bosh-external.${SYSTEM_DNS_ZONE_NAME}
+bosh_fqdn: ${BOSH_FQDN}
+bosh_fqdn_external: ${BOSH_FQDN_EXTERNAL}
+bosh_login_host: ${BOSH_LOGIN_HOST}
 bosh_instance_profile: ${BOSH_INSTANCE_PROFILE}
+skip_commit_verification: ${SKIP_COMMIT_VERIFICATION}
+self_update_pipeline: ${SELF_UPDATE_PIPELINE:-true}
+target_concourse: ${TARGET_CONCOURSE}
+concourse_type: ${CONCOURSE_TYPE}
 concourse_instance_type: ${CONCOURSE_INSTANCE_TYPE}
 concourse_instance_profile: ${CONCOURSE_INSTANCE_PROFILE}
 enable_datadog: ${ENABLE_DATADOG}
@@ -49,13 +55,43 @@ generate_vars_file > /dev/null # Check for missing vars
 
 generate_manifest_file() {
   sed -e "s/{{gpg_ids}}/${gpg_ids}/" \
-      < "${SCRIPT_DIR}/../pipelines/${ACTION}.yml"
+      < "${SCRIPT_DIR}/../pipelines/${pipeline_name}.yml"
+}
+
+upload_pipeline() {
+  bash "${SCRIPT_DIR}/deploy-pipeline.sh" \
+    "${pipeline_name}" \
+    <(generate_manifest_file) \
+    <(generate_vars_file)
+}
+
+remove_pipeline() {
+  yes y | ${FLY_CMD} -t "${FLY_TARGET}" destroy-pipeline --pipeline "${pipeline_name}" || true
+}
+
+update_pipeline() {
+  pipeline_name="$1"
+
+  case "$pipeline_name" in
+    create-bosh-concourse)
+      upload_pipeline
+    ;;
+    destroy-bosh-concourse)
+      if [ "${ENABLE_DESTROY:-}" == 'true' ] && [ "${TARGET_CONCOURSE}" == 'bootstrap' ]; then
+        upload_pipeline
+      else
+        remove_pipeline
+      fi
+    ;;
+    *)
+      echo "ERROR: Unknown pipeline definition: $pipeline_name"
+      exit 1
+    ;;
+  esac
 }
 
 export EXPOSE_PIPELINE=1
-for ACTION in create destroy; do
-  bash "${SCRIPT_DIR}/deploy-pipeline.sh" \
-    "${ACTION}" \
-    <(generate_manifest_file) \
-    <(generate_vars_file)
+pipelines_to_update="create-bosh-concourse destroy-bosh-concourse"
+for p in $pipelines_to_update; do
+  update_pipeline "$p"
 done

--- a/concourse/scripts/pipelines.sh
+++ b/concourse/scripts/pipelines.sh
@@ -11,7 +11,6 @@ generate_vars_file() {
    cat <<EOF
 ---
 aws_account: ${AWS_ACCOUNT}
-vagrant_ip: ${VAGRANT_IP}
 deploy_env: ${DEPLOY_ENV}
 state_bucket: ${state_bucket}
 branch_name: ${BRANCH:-master}

--- a/concourse/scripts/self-update-pipeline.sh
+++ b/concourse/scripts/self-update-pipeline.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+#
+# Required variables are:
+# - DEPLOY_ENV
+# - AWS_ACCOUNT
+# - SELF_UPDATE_PIPELINE
+#
+# Optional variables:
+# - BRANCH
+
+set -u
+set -e
+
+if [ "${TARGET_CONCOURSE}" == "bootstrap" ]; then
+  echo "Bootstrap Concourse should not self-update, as this requires access to \`aws sts get-caller-identity\`. Skipping."
+  exit 0
+fi
+
+if [ "${SELF_UPDATE_PIPELINE}" == "true" ]; then
+  echo "Self update pipeline is enabled. Updating. (set SELF_UPDATE_PIPELINE=false to disable)"
+
+  make -C ./paas-bootstrap "${AWS_ACCOUNT}" "${CONCOURSE_TYPE}" pipelines
+else
+  echo "Self update pipeline is disabled. Skipping. (set SELF_UPDATE_PIPELINE=true to enable)"
+fi

--- a/manifests/bosh-manifest/bosh-manifest.yml
+++ b/manifests/bosh-manifest/bosh-manifest.yml
@@ -122,12 +122,12 @@ cloud_provider:
     release: bosh-aws-cpi
 
   ssh_tunnel:
-    host: (( grab $BOSH_LOGIN_HOST ))
+    host: (( grab $BOSH_FQDN_EXTERNAL ))
     port: 22
     user: vcap
     private_key: .ssh/bosh_id_rsa
 
-  mbus: (( concat "https://mbus:" secrets.bosh_nats_password "@" $BOSH_LOGIN_HOST ":6868" ))
+  mbus: (( concat "https://mbus:" secrets.bosh_nats_password "@" $BOSH_FQDN_EXTERNAL ":6868" ))
 
   properties:
     agent:

--- a/manifests/bosh-manifest/bosh-manifest.yml
+++ b/manifests/bosh-manifest/bosh-manifest.yml
@@ -122,12 +122,12 @@ cloud_provider:
     release: bosh-aws-cpi
 
   ssh_tunnel:
-    host: (( grab $BOSH_FQDN_EXTERNAL ))
+    host: (( grab $BOSH_LOGIN_HOST ))
     port: 22
     user: vcap
     private_key: .ssh/bosh_id_rsa
 
-  mbus: (( concat "https://mbus:" secrets.bosh_nats_password "@" $BOSH_FQDN_EXTERNAL ":6868" ))
+  mbus: (( concat "https://mbus:" secrets.bosh_nats_password "@" $BOSH_LOGIN_HOST ":6868" ))
 
   properties:
     agent:

--- a/terraform/bosh/security_groups.tf
+++ b/terraform/bosh/security_groups.tf
@@ -14,7 +14,7 @@ resource "aws_security_group" "bosh" {
     from_port   = 22
     to_port     = 22
     protocol    = "tcp"
-    cidr_blocks = ["${compact(list(var.vagrant_cidr))}"]
+    cidr_blocks = ["${compact(list(var.concourse_egress_cidr))}"]
   }
 
   ingress {
@@ -31,7 +31,7 @@ resource "aws_security_group" "bosh" {
     from_port   = 6868
     to_port     = 6868
     protocol    = "tcp"
-    cidr_blocks = ["${compact(list(var.vagrant_cidr))}"]
+    cidr_blocks = ["${compact(list(var.concourse_egress_cidr))}"]
   }
 
   ingress {
@@ -48,7 +48,7 @@ resource "aws_security_group" "bosh" {
     from_port   = 25555
     to_port     = 25555
     protocol    = "tcp"
-    cidr_blocks = ["${compact(list(var.vagrant_cidr))}"]
+    cidr_blocks = ["${compact(list(var.concourse_egress_cidr))}"]
   }
 
   ingress {

--- a/terraform/bosh/security_groups.tf
+++ b/terraform/bosh/security_groups.tf
@@ -35,6 +35,16 @@ resource "aws_security_group" "bosh" {
   }
 
   ingress {
+    from_port = 6868
+    to_port   = 6868
+    protocol  = "tcp"
+
+    security_groups = [
+      "${aws_security_group.bosh_api_client.id}",
+    ]
+  }
+
+  ingress {
     from_port   = 25555
     to_port     = 25555
     protocol    = "tcp"

--- a/terraform/concourse/elb.tf
+++ b/terraform/concourse/elb.tf
@@ -57,7 +57,7 @@ resource "aws_security_group" "concourse-elb" {
     from_port   = 443
     to_port     = 443
     protocol    = "tcp"
-    cidr_blocks = ["${compact(concat(var.admin_cidrs, list("${aws_eip.concourse.public_ip}/32"), list(var.vagrant_cidr)))}"]
+    cidr_blocks = ["${compact(distinct(concat(var.admin_cidrs, list("${aws_eip.concourse.public_ip}/32"), list(var.concourse_egress_cidr))))}"]
   }
 
   tags {

--- a/terraform/globals.tf
+++ b/terraform/globals.tf
@@ -91,8 +91,8 @@ variable "infra_subnet_ids" {
   default     = ""
 }
 
-variable "vagrant_cidr" {
-  description = "IP address of the AWS Vagrant bootstrap concourse"
+variable "concourse_egress_cidr" {
+  description = "Public egress IP address of concourse running the pipeline"
   default     = ""
 }
 

--- a/terraform/vpc/security-group.tf
+++ b/terraform/vpc/security-group.tf
@@ -14,7 +14,7 @@ resource "aws_security_group" "office-access-ssh" {
     from_port   = 22
     to_port     = 22
     protocol    = "tcp"
-    cidr_blocks = ["${compact(concat(var.admin_cidrs, list(var.vagrant_cidr)))}"]
+    cidr_blocks = ["${compact(concat(var.admin_cidrs, list(var.concourse_egress_cidr)))}"]
   }
 
   tags {

--- a/vagrant/Vagrantfile
+++ b/vagrant/Vagrantfile
@@ -32,7 +32,18 @@ Vagrant.configure(2) do |config|
     config.vm.provision "shell" do |s|
       s.privileged = true
       s.env = ENV.select { |key|
-        %w(CONCOURSE_ATC_PASSWORD CONCOURSE_ATC_USER CONCOURSE_DATABASE_NAME CONCOURSE_URL BRANCH DEPLOY_ENV).include? key
+        %w(
+          CONCOURSE_ATC_PASSWORD
+          CONCOURSE_ATC_USER
+          CONCOURSE_DATABASE_NAME
+          CONCOURSE_URL
+          BRANCH
+          DEPLOY_ENV
+          TARGET_CONCOURSE
+          SYSTEM_DNS_ZONE_NAME
+          BOSH_FQDN
+          BOSH_FQDN_EXTERNAL
+          BOSH_LOGIN_HOST).include? key
       }
       s.name = post_deploy_file
       s.path = post_deploy_file

--- a/vagrant/deploy.sh
+++ b/vagrant/deploy.sh
@@ -29,9 +29,6 @@ fi
 
 vagrant up
 
-VAGRANT_IP=$(vagrant ssh -- curl -qs http://169.254.169.254/latest/meta-data/public-ipv4)
-export VAGRANT_IP
-
 # Try to start a SSH tunnel to localhost
 echo "Setting up SSH tunnel to concourse..."
 if ! ( [ -a .vagrant/tunnel-ctrl-socket ] && \


### PR DESCRIPTION
## What

Previously we applied any changes from this repo to persistent environments using a bootstrap concourse lite spun up for the purpose.

In order to reduce the amount of human time required to make deployment changes, we will apply those changes directly from the build or deployer concourse.

When this PR is merged:
- Bootstrap concourse will be used to create and destroy build/deployer concourse and their BOSH
- Changes will be applied to persistent environments by logging into the build or deployer concourse and starting a pipeline run

## How to review

This change is dependent on [IAM changes in a corresponding PR](https://github.digital.cabinet-office.gov.uk/government-paas/aws-account-wide-terraform/pull/96) which should be merged first. 

The most important path to test is how persistent environments will behave when we apply these changes.

### Deployer concourse

- Create a deployer concourse from master and then destroy the bootstrap concourse OR use your existing one.
- Spin up a bootstrap concourse from this branch: `DEPLOY_ENV=<env> BRANCH=add-self-update-pipeline make dev deployer-concourse bootstrap`
- Run the [create-bosh-concourse](pipeline) which should add a new pipeline to your deployer concourse.
- Run the same pipeline on your deployer concourse

### Build concourse

- Create a build concourse from master and then destroy the bootstrap concourse
- Spin up a bootstrap concourse from this branch: `DEPLOY_ENV=<env> BRANCH=add-self-update-pipeline make dev build-concourse bootstrap`
- Run the [create-bosh-concourse](pipeline) which should add a new pipeline to your build concourse.
- Run the same pipeline on your build concourse

### Merging & rolling out

- Check that the [account-wide-terraform PR](https://github.digital.cabinet-office.gov.uk/government-paas/aws-account-wide-terraform/pull/96) has been merged & applied
- [Merge using a signed commit](https://government-paas-team-manual.readthedocs.io/en/latest/team/working_practices/#merging-pull-requests)
- In each of CI master, CI build, staging, prod:
  - create a bootstrap concourse and run the `create-bosh-concourse` pipeline from it
  - run the same pipeline on the persistent concourse

## Who can review

Not @bleach or @henrytk 
