### PR TITLE
Add missing jq dependancy to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,8 @@ or by using [`virtualenv`](https://virtualenv.pypa.io/en/latest/) and pip `pip i
 * a recent version of [Vagrant installed][]. The exact version
 requirements are listed in the [`Vagrantfile`](vagrant/Vagrantfile).
 
+* a recent version of [jq](https://stedolan.github.io/jq/). 
+
 [Vagrant installed]: https://docs.vagrantup.com/v2/installation/index.html
 
 Install the AWS plugin for Vagrant:


### PR DESCRIPTION
Missing jq dependancy found during initial setup of paas-bootstrap.

## What

The bootstrap scripts expect a version of `jq` to be installed.

## How to review

Check the perquisites section in README.md make sense and link to correct dep. 

## Who can review

Anyone other than @chrisfarms 
