### PR TITLE
[#137364635] Fix pipelines.sh when SKIP_COMMIT_VERIFICATION unset.

### DIFF
--- a/concourse/scripts/pipelines.sh
+++ b/concourse/scripts/pipelines.sh
@@ -25,7 +25,7 @@ bosh_fqdn: ${BOSH_FQDN}
 bosh_fqdn_external: ${BOSH_FQDN_EXTERNAL}
 bosh_login_host: ${BOSH_LOGIN_HOST}
 bosh_instance_profile: ${BOSH_INSTANCE_PROFILE}
-skip_commit_verification: ${SKIP_COMMIT_VERIFICATION}
+skip_commit_verification: ${SKIP_COMMIT_VERIFICATION:-}
 self_update_pipeline: ${SELF_UPDATE_PIPELINE:-true}
 target_concourse: ${TARGET_CONCOURSE}
 concourse_type: ${CONCOURSE_TYPE}


### PR DESCRIPTION
## What

This was erroring when this variable isn't set. It's only typically set
in dev environments.

On line 47 of this script we're using ${SKIP_COMMIT_VERIFICATION:-}, but
this hadn't been repeated in the generate_vars_file block, leading to
the error:
```
.../paas-bootstrap/concourse/scripts/pipelines.sh:
line 11: SKIP_COMMIT_VERIFICATION: unbound variable
```

## How to review

* Delete the `$(eval export SKIP_COMMIT_VERIFICATION=true)` line from `dev` target in the `Makefile` locally.
* Create a bootstrap concourse (`make dev deployer-concourse bootstrap`)
* Verify that it doesn't error when pushing the pipelines to this concourse.

## Who can review

Not me.