### PR TITLE
[#150010843] Upgrade BOSH and Concourse stemcells to 3421.18

### DIFF
--- a/manifests/bosh-manifest/bosh-manifest.yml
+++ b/manifests/bosh-manifest/bosh-manifest.yml
@@ -152,8 +152,8 @@ resource_pools:
 - name: bosh
   network: private
   stemcell:
-    url: https://bosh.io/d/stemcells/bosh-aws-xen-hvm-ubuntu-trusty-go_agent?v=3363.26
-    sha1: 92d5fb76df95a78e7e9aeacf037756420c31162d
+    url: https://bosh.io/d/stemcells/bosh-aws-xen-hvm-ubuntu-trusty-go_agent?v=3421.18
+    sha1: e954a64c549f6f8a0e7b49bfb409c29b4beaed17
   cloud_properties:
     instance_type: t2.medium
     ephemeral_disk: {size: 40000, type: gp2}

--- a/manifests/concourse-manifest/concourse-base.yml
+++ b/manifests/concourse-manifest/concourse-base.yml
@@ -2,7 +2,7 @@
 meta:
   stemcell:
     name: bosh-aws-xen-hvm-ubuntu-trusty-go_agent
-    version: "3363.26"
+    version: "3421.18"
 
   zone: (( grab terraform_outputs.zone0 ))
 


### PR DESCRIPTION
## What

To match alphagov/paas-cf@f890058aa57b006c3a7d9504d108c6f0916913b5

The series has been changed to also match paas-cf. The difference between
series appear to be summarised here:

- https://github.com/cloudfoundry/bosh-linux-stemcell-builder/releases/tag/v3421

## How to review

I tested this by updating the branch on my Deployer Concourse (rather than deploying a new Bootstrap):

    ./bin/fly -t ${DEPLOY_ENV} gp -p create-bosh-concourse > tmp.yml
    gsed -ri 's|(branch:) master|\1 bugfix/150010843-bump_stemcells|I' pipe.yml
    ./bin/fly -t ${DEPLOY_ENV} sp -p create-bosh-concourse -c tmp.yml

Then I ran the `create-bosh-concourse` pipeline. The `concourse-deploy` job is interrupted as Concourse is re-deployed, but it can be re-run when it comes back. Then I ran the full `create-cloudfoundry` pipeline to make sure that all the tests pass.

It's at the reviewer's discretion whether they repeat the same steps or just do code review.

🐝  after merging the `create-cloudfoundry` pipeline will need to be paused in each persistent environment and the `create-bosh-concourse` run - liaise with the person on support about who does it 🐝 

## Who can review

Anyone.