### PR TITLE
[#150512756] Upgrade concourse

### DIFF
--- a/concourse/pipelines/create-bosh-concourse.yml
+++ b/concourse/pipelines/create-bosh-concourse.yml
@@ -25,13 +25,13 @@ resource_types:
   type: docker-image
   source:
     repository: governmentpaas/s3-resource
-    tag: 9e7cf1dd32699c091e22e46b349e050443d9ac1a
+    tag: 594eaa9f4d93b2ed32a7e5e1cdea5b380e2f6682
 
 - name: semver-iam
   type: docker-image
   source:
     repository: governmentpaas/semver-resource
-    tag: dc33fee5c9061263e83159a893340f46728d93b5
+    tag: ecbdd201e122b44de99a40ac9f24407c1a43b9a2
 
 resources:
   - name: paas-bootstrap

--- a/concourse/pipelines/create-bosh-concourse.yml
+++ b/concourse/pipelines/create-bosh-concourse.yml
@@ -1231,8 +1231,8 @@ jobs:
                 export CONCOURSE_ATC_PASSWORD
                 CONCOURSE_ATC_PASSWORD=$(./paas-bootstrap/concourse/scripts/val_from_yaml.rb secrets.concourse_atc_password concourse-secrets/concourse-secrets.yml)
                 ./paas-bootstrap/concourse/scripts/fly_sync_and_login.sh
-                echo y | ${FLY_CMD} -t ${FLY_TARGET} set-team -n ${FLY_TEAM} \
-                           --basic-auth-username admin --basic-auth-password ${CONCOURSE_ATC_PASSWORD}
+                ${FLY_CMD} -t ${FLY_TARGET} set-team -n ${FLY_TEAM} \
+                  --basic-auth-username admin --basic-auth-password ${CONCOURSE_ATC_PASSWORD} --non-interactive
 
   - name: post-deploy
     plan:

--- a/concourse/pipelines/destroy-bosh-concourse.yml
+++ b/concourse/pipelines/destroy-bosh-concourse.yml
@@ -4,13 +4,13 @@ resource_types:
   type: docker-image
   source:
     repository: governmentpaas/s3-resource
-    tag: 9e7cf1dd32699c091e22e46b349e050443d9ac1a
+    tag: 594eaa9f4d93b2ed32a7e5e1cdea5b380e2f6682
 
 - name: semver-iam
   type: docker-image
   source:
     repository: governmentpaas/semver-resource
-    tag: dc33fee5c9061263e83159a893340f46728d93b5
+    tag: ecbdd201e122b44de99a40ac9f24407c1a43b9a2
 
 resources:
   - name: paas-bootstrap
@@ -533,4 +533,3 @@ jobs:
             - |
               terraform destroy -force -var-file=paas-bootstrap/terraform/{{aws_account}}.tfvars \
                 -state=bucket-terraform-state/bucket.tfstate paas-bootstrap/terraform/bucket
-

--- a/concourse/scripts/deploy-pipeline.sh
+++ b/concourse/scripts/deploy-pipeline.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -eu
+set -euo pipefail
 
 SCRIPT=$0
 
@@ -31,12 +31,12 @@ echo "Concourse API target ${FLY_TARGET}"
 echo "Pipeline ${pipeline}"
 echo "Config file ${config}"
 
-yes y | \
-   $FLY_CMD -t "${FLY_TARGET}" \
-   set-pipeline \
-   --config "${config}" \
-   --pipeline "${pipeline}" \
-   --load-vars-from "${varsfile}"
+$FLY_CMD -t "${FLY_TARGET}" \
+  set-pipeline \
+  --config "${config}" \
+  --pipeline "${pipeline}" \
+  --load-vars-from "${varsfile}" \
+  --non-interactive
 
 $FLY_CMD -t "${FLY_TARGET}" \
   unpause-pipeline \

--- a/concourse/scripts/fly_sync_and_login.sh
+++ b/concourse/scripts/fly_sync_and_login.sh
@@ -14,8 +14,7 @@ curl "$FLY_CMD_URL" -# -L -f -z "$FLY_CMD" -o "$FLY_CMD" -u "${CONCOURSE_ATC_USE
 chmod +x "$FLY_CMD"
 
 echo "Doing fly login"
-echo -e "${CONCOURSE_ATC_USER}\n${CONCOURSE_ATC_PASSWORD}" | \
-  $FLY_CMD -t "${FLY_TARGET}" login --concourse-url "${CONCOURSE_URL}"
+$FLY_CMD -t "${FLY_TARGET}" login --concourse-url "${CONCOURSE_URL}" -u "${CONCOURSE_ATC_USER}" -p "${CONCOURSE_ATC_PASSWORD}"
 
 echo "Doing fly sync"
 $FLY_CMD -t "${FLY_TARGET}" sync

--- a/concourse/scripts/pipelines.sh
+++ b/concourse/scripts/pipelines.sh
@@ -65,7 +65,7 @@ upload_pipeline() {
 }
 
 remove_pipeline() {
-  yes y | ${FLY_CMD} -t "${FLY_TARGET}" destroy-pipeline --pipeline "${pipeline_name}" || true
+  ${FLY_CMD} -t "${FLY_TARGET}" destroy-pipeline --pipeline "${pipeline_name}" --non-interactive || true
 }
 
 update_pipeline() {

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,5 +1,5 @@
 concourse-db:
-  image: postgres:9.6.2-alpine
+  image: postgres:9.6.5-alpine
   restart: always
   environment:
     POSTGRES_DB: "${CONCOURSE_DATABASE_NAME}"
@@ -8,21 +8,25 @@ concourse-db:
     PGDATA: /database
 
 concourse-web:
-  image: concourse/concourse:2.7.0
+  image: concourse/concourse:3.4.1
   links: [concourse-db]
   command: web
-  restart: always
+  restart: unless-stopped
   ports: ["8080:8080"]
   volumes: ["./keys/web:/concourse-keys"]
   environment:
     CONCOURSE_BASIC_AUTH_USERNAME: "${CONCOURSE_ATC_USER}"
     CONCOURSE_BASIC_AUTH_PASSWORD: "${CONCOURSE_ATC_PASSWORD}"
     CONCOURSE_EXTERNAL_URL: "${CONCOURSE_URL}"
+    CONCOURSE_POSTGRES_HOST: concourse-db
+    CONCOURSE_POSTGRES_USER: "${CONCOURSE_DATABASE_USER}"
+    CONCOURSE_POSTGRES_PASSWORD: "${CONCOURSE_DATABASE_PASS}"
+    CONCOURSE_POSTGRES_DATABASE: "${CONCOURSE_DATABASE_NAME}"
     CONCOURSE_POSTGRES_DATA_SOURCE: |-
       postgres://${CONCOURSE_DATABASE_USER}:${CONCOURSE_DATABASE_PASS}@concourse-db:5432/${CONCOURSE_DATABASE_NAME}?sslmode=disable
 
 concourse-worker:
-  image: concourse/concourse:2.7.0
+  image: concourse/concourse:3.4.1
   privileged: true
   links: [concourse-web]
   command: worker
@@ -30,4 +34,3 @@ concourse-worker:
   volumes: ["./keys/worker:/concourse-keys"]
   environment:
     CONCOURSE_TSA_HOST: concourse-web
-

--- a/manifests/concourse-manifest/concourse-base.yml
+++ b/manifests/concourse-manifest/concourse-base.yml
@@ -12,13 +12,13 @@ director_uuid: ~
 
 releases:
   - name: concourse
-    version: 2.4.0
-    url: https://bosh.io/d/github.com/concourse/concourse?v=2.4.0
-    sha1: 8eb1e707594b47adc7bfa10c89fe17524caf8461
+    version: 3.4.1
+    url: https://bosh.io/d/github.com/concourse/concourse?v=3.4.1
+    sha1: b9c3cd85caccf0dae7406f8d7dfc237b4c698ce6
   - name: garden-runc
-    version: 0.8.0
-    url: https://bosh.io/d/github.com/cloudfoundry/garden-runc-release?v=0.8.0
-    sha1: 20e98ea84c8f4426bba00bbca17d931e27d3c07d
+    version: 1.6.0
+    url: https://bosh.io/d/github.com/cloudfoundry/garden-runc-release?v=1.6.0
+    sha1: 58fbc64aff303e6d76899441241dd5dacef50cb7
 
 properties:
   aws:

--- a/manifests/concourse-manifest/concourse-base.yml
+++ b/manifests/concourse-manifest/concourse-base.yml
@@ -96,13 +96,7 @@ jobs:
           basic_auth_username: admin
           basic_auth_password: (( grab secrets.concourse_atc_password ))
           auth_duration: (( grab $CONCOURSE_AUTH_DURATION ))
-
-          postgresql:
-            address: 127.0.0.1:5432
-            database: atc
-            role:
-              name: atc
-              password: (( grab secrets.concourse_postgres_password ))
+          postgresql_database: atc
 
       - name: groundcrew
         release: concourse


### PR DESCRIPTION
## What

We'd like to catchup with the releases of deployer and bootstrap Concourse, and estimated upgrading to the latest one will satisfy us best.

- We're far behind
- We're not upgrading as often as we'd wish to
- It contains a lot of fixes reported over time, including a change to container volumes that we think should prevent the need to "shake" Concourse

## How to review

These instructions rely on self-updating pipelines. Please ensure that you are not disabling them in your dev environment.

:bee: :bee: :bee:
1. You must review #88 first

1. There is a `WIP` commit which must not be merged as is. It will need to be updated after the alphagov/paas-semver-resource#7 and alphagov/paas-s3-resource#6 are merged.

1. After merging you will need to run the `create-bosh-concourse` pipeline on the Deployer Concourse of all the persistent environments (CI, staging, production). Please co-ordinate doing this with the person on support.

:bee: :bee: :bee:

### Self-update from Deployer Concourse

- Download your current `create-bosh-concourse` pipeline from the Deployer Concourse:
  ```
  ./bin/fly gp -t ${DEPLOY_ENV} -p create-bosh-concourse > create-bosh-concourse.yml
  ```
- Override the branch name from `master` to `upgrade-concourse-150512756` (you may need to `brew install gnu-sed`):
  ```
  gsed -ri 's|(branch:) master|\1 upgrade-concourse-150512756|I' create-bosh-concourse.yml
  ```
- Push modified pipeline back to the Deployer Concourse:
  ```
  ./bin/fly sp -t ${DEPLOY_ENV} -p create-bosh-concourse -c create-bosh-concourse.yml
  ```
- Run the `create-bosh-concourse` pipeline and eventually the `concourse-deploy` job will go into an orange "error" state, which is expected
- You may need to clean your cookies in order to be able to log back in
- Make sure the version has changed and retrigger the `concourse-deploy` job for a noop run. It may take a few minutes for all of the resource to refresh and change from "error" state.

### Deployment from scratch

You may wish to use a different `DEPLOY_ENV` for this so that you don't affect your existing dev environment.

- Deploy bootstrap from `upgrade-concourse-150512756` branch of `paas-bootstrap`
- Log into the Bootstrap Concourse and confirm that the version in the bottom right corner says `3.4.1`
- Run the `create-bosh-concourse` pipeline
- Log into the new Deployer Concourse and confirm that the version in the bottom right corner says `3.4.1`

## Who can review

Neither of @LeePorte, @dcarley nor @paroxp