### PR TITLE
[#150512756] Fix typo in SSH key generation

### DIFF
--- a/concourse/pipelines/create-bosh-concourse.yml
+++ b/concourse/pipelines/create-bosh-concourse.yml
@@ -450,7 +450,7 @@ jobs:
                 - -e
                 - -c
                 - |
-                  if [ -s bosh-ssh-private-key/bosh_id_rsa ] && [ -s bosh-ssh-private-key/bosh_id_rsa.pub ]; then
+                  if [ -s bosh-ssh-private-key/bosh_id_rsa ] && [ -s bosh-ssh-public-key/bosh_id_rsa.pub ]; then
                     echo "BOSH keys non-zero size, skipping generation..."
                     cp bosh-ssh-private-key/bosh_id_rsa bosh-ssh-private-key-to-upload
                     cp bosh-ssh-public-key/bosh_id_rsa.pub bosh-ssh-public-key-to-upload
@@ -492,7 +492,7 @@ jobs:
                 - -e
                 - -c
                 - |
-                  if [ -s ssh-private-key/id_rsa ] && [ -s ssh-private-key/id_rsa.pub ]; then
+                  if [ -s ssh-private-key/id_rsa ] && [ -s ssh-public-key/id_rsa.pub ]; then
                     echo "Deployment keys non-zero size, skipping generation..."
                     cp ssh-private-key/id_rsa ssh-private-key-to-upload
                     cp ssh-public-key/id_rsa.pub ssh-public-key-to-upload


### PR DESCRIPTION
## What

Checking in the wrong directory/resource caused the SSH keys to be recreated
each time these two tasks were run.

I noticed this problem working while testing the instructions to access BOSH
without Concourse, after I had run the `create-bosh-concourse` pipeline to
test the Concourse upgrade. Although Terraform upload the new keypair to
AWS, it doesn't take effect if `bosh-init` doesn't recreate the BOSH VM.

I've tested the persistent environments and it looks like the key in the
state bucket still works at the moment, probably because we upgraded the
BOSH VM the last time this was run. However we need to fix this before the
Concourse upgrade is applied to those environments.

## How to review

1. Checkout this branch:

       git fetch && git checkout bugfix/150512756-bosh_ssh_keygen
1. Bring up a Bootstrap Concourse with this branch:

       BRANCH=$(git rev-parse --abbrev-ref HEAD) make dev deployer-concourse bootstrap`
1. Run the `create-bosh-concourse` pipeline.
1. Confirm that the `generate-bosh-ssh-keypair` task in the `generate-secrets` job says:

       BOSH keys non-zero size, skipping generation...
    And not:

       Generating new ssh key pair for BOSH...
       Generating public/private rsa key pair.
       …
1. Confirm that `make dev ssh_bosh` from `alphagov/paas-cf` still works.

## Who can review

Not @dcarley or @alext (who found the typo).