### PR TITLE
[#150512756] IPv4 Keyservers

### DIFF
--- a/concourse/pipelines/create-bosh-concourse.yml
+++ b/concourse/pipelines/create-bosh-concourse.yml
@@ -40,6 +40,7 @@ resources:
       uri: https://github.com/alphagov/paas-bootstrap.git
       branch: {{branch_name}}
       commit_verification_key_ids: {{gpg_ids}}
+      gpg_keyserver: hkp://ipv4.pool.sks-keyservers.net/
 
   - name: bucket-terraform-state
     type: s3-iam

--- a/concourse/pipelines/destroy-bosh-concourse.yml
+++ b/concourse/pipelines/destroy-bosh-concourse.yml
@@ -19,6 +19,7 @@ resources:
       uri: https://github.com/alphagov/paas-bootstrap.git
       branch: {{branch_name}}
       commit_verification_key_ids: {{gpg_ids}}
+      gpg_keyserver: hkp://ipv4.pool.sks-keyservers.net/
 
   - name: bucket-terraform-state
     type: s3-iam


### PR DESCRIPTION
## What

We're experiencing an intermittent problem since we've upgraded
Concourse and garden-runc where gpg will intermittently return an error:
```
gpg: keyserver receive failed: Address family not supported by protocol
```
Switching to an IPv4-only pool works around this, and will unblock the
pipeline while we investigate further.

## How to review

Code review is probably enough if you've already reviewed alphagov/paas-cf#1035

## Who can review

Not me.