### PR TITLE
[#150512756] Enable IPv6 support in Concourse VM

### DIFF
--- a/concourse/pipelines/create-bosh-concourse.yml
+++ b/concourse/pipelines/create-bosh-concourse.yml
@@ -40,7 +40,6 @@ resources:
       uri: https://github.com/alphagov/paas-bootstrap.git
       branch: {{branch_name}}
       commit_verification_key_ids: {{gpg_ids}}
-      gpg_keyserver: hkp://ipv4.pool.sks-keyservers.net/
 
   - name: bucket-terraform-state
     type: s3-iam

--- a/concourse/pipelines/destroy-bosh-concourse.yml
+++ b/concourse/pipelines/destroy-bosh-concourse.yml
@@ -19,7 +19,6 @@ resources:
       uri: https://github.com/alphagov/paas-bootstrap.git
       branch: {{branch_name}}
       commit_verification_key_ids: {{gpg_ids}}
-      gpg_keyserver: hkp://ipv4.pool.sks-keyservers.net/
 
   - name: bucket-terraform-state
     type: s3-iam

--- a/manifests/concourse-manifest/concourse-base.yml
+++ b/manifests/concourse-manifest/concourse-base.yml
@@ -50,6 +50,8 @@ resource_pools:
     env:
       bosh:
         password: (( grab secrets.concourse_vcap_password ))
+        ipv6:
+          enable: true
 
 disk_pools:
   - name: db


### PR DESCRIPTION
## What

IPv6 is disabled by default in the stemcell. A control has been [added to
bosh-agent](https://github.com/cloudfoundry/bosh-agent/pull/129) to re-enable this. This has the effect of removing the
"ipv6.disable=1" flag from the kernel commandline.

We hit a [bug in gpg](https://dev.gnupg.org/T3331) where it will fail to connect to a keyserver if
IPv6 support is not enabled in the kernel. The error returned is:
```
gpg: keyserver receive failed: Address family not supported by protocol
```
We've worked around this by explicitly specifying a keyserver that only
has IPv4 addresses in 7866ee6.

Enabling IPv6 support in the kernel avoids the need for this workaround.
It's not necessary for the IPv6 stack to be configured, it merely needs
to be present.

## How to review

* Run the `create-bosh-concourse` from the `enable_gpg_dev` branch (this will enable GPG verification for your dev environment).
* Run the `create-bosh-concourse` pipeline from this branch. This will enable IPv6 for the Concourse VM, and revert the change to use ipv4-only keyservers.
* Make a signed no-op commit to the branch.
* Run the pipeline again and verify that it successfully verifies the commit.

## Before merging

Rebase out the `[TMP]` commit and any others you've added.

## Who can review

Not me.