### PR TITLE
[#150881142] Remove gpg_ids sed replace hack when generating the Concourse manifest

### DIFF
--- a/concourse/scripts/pipelines.sh
+++ b/concourse/scripts/pipelines.sh
@@ -37,6 +37,7 @@ datadog_app_key: ${DATADOG_APP_KEY:-}
 enable_collectd_addon: ${ENABLE_COLLECTD_ADDON}
 enable_syslog_addon: ${ENABLE_SYSLOG_ADDON}
 concourse_auth_duration: ${CONCOURSE_AUTH_DURATION:-5m}
+gpg_ids: ${gpg_ids}
 EOF
 }
 
@@ -52,15 +53,10 @@ fi
 
 generate_vars_file > /dev/null # Check for missing vars
 
-generate_manifest_file() {
-  sed -e "s/((gpg_ids))/${gpg_ids}/" \
-      < "${SCRIPT_DIR}/../pipelines/${pipeline_name}.yml"
-}
-
 upload_pipeline() {
   bash "${SCRIPT_DIR}/deploy-pipeline.sh" \
     "${pipeline_name}" \
-    <(generate_manifest_file) \
+    "${SCRIPT_DIR}/../pipelines/${pipeline_name}.yml" \
     <(generate_vars_file)
 }
 


### PR DESCRIPTION
## What

Removes a sed hack during the manifest generation which is not needed anymore because the new parameter format is able to handle arrays properly.

## How to review

* Spin up the bootstrap Concourse from master
* Update the pipelines from this branch with ```SKIP_COMMIT_VERIFICATION=false``` and check for manifest changes (it should be none).
* I think running the create-cloudfoundry pipeline is unnecessary in this case.

## Who can review

not me
