### PR TITLE
[#152507627] Upgrade stemcell for CVEs

### DIFF
--- a/manifests/bosh-manifest/bosh-manifest.yml
+++ b/manifests/bosh-manifest/bosh-manifest.yml
@@ -152,8 +152,8 @@ resource_pools:
 - name: bosh
   network: private
   stemcell:
-    url: https://bosh.io/d/stemcells/bosh-aws-xen-hvm-ubuntu-trusty-go_agent?v=3421.20
-    sha1: de64c59498b0c8e41801ac2fcf6e03ce898ba182
+    url: https://bosh.io/d/stemcells/bosh-aws-xen-hvm-ubuntu-trusty-go_agent?v=3445.16
+    sha1: 1c79efef420ad8943ff040a5d274209d2bf73539
   cloud_properties:
     instance_type: t2.medium
     ephemeral_disk: {size: 40000, type: gp2}

--- a/manifests/concourse-manifest/concourse-base.yml
+++ b/manifests/concourse-manifest/concourse-base.yml
@@ -2,7 +2,7 @@
 meta:
   stemcell:
     name: bosh-aws-xen-hvm-ubuntu-trusty-go_agent
-    version: "3421.20"
+    version: "3445.16"
 
   zone: (( grab terraform_outputs.zone0 ))
 


### PR DESCRIPTION
## What

To fix the following:

- https://www.cloudfoundry.org/usn-3424-1/
- https://www.cloudfoundry.org/usn-3434-1/
- https://www.cloudfoundry.org/usn-3444-2/
- https://www.cloudfoundry.org/usn-3454-1/
- https://www.cloudfoundry.org/usn-3441-1/
- https://www.cloudfoundry.org/usn-3432-1/

The series has been updated to match alphagov/paas-cf.

We're using 3445.16 instead of the recommended minimum of 3445.15 because
.15 doesn't have a "light" stemcell published. The same URL redirects to the
"fat" version, which needs to be mounted as an EBS volume on the host
running `bosh-init`, which doesn't work from a container:

    Starting registry... Finished (00:00:00)
    Uploading stemcell 'bosh-aws-xen-hvm-ubuntu-trusty-go_agent/3445.15'... Failed (00:01:23)
    Stopping registry... Finished (00:00:00)
    Cleaning up rendered CPI jobs... Finished (00:00:00)

    Command 'deploy' failed:
      creating stemcell (bosh-aws-xen-hvm-ubuntu-trusty-go_agent 3445.15):
        CPI 'create_stemcell' method responded with error: CmdError{"type":"Bosh::Clouds::CloudError","message":"Cannot find EBS volume on current instance","ok_to_retry":false}

I've been talking to some people on #bosh in the CF Slack about improving the
error message because at first I thought it was something I'd broken in my dev
environment when messing with manifests to test AZ failover.

## How to review

You can test without a Bootstrap Concourse by modifying the pipeline on your Deployer Concourse to use the branch:

```
git checkout bugfix/152507627-cves
./bin/fly sp -t ${DEPLOY_ENV} -p create-bosh-concourse -c <(./bin/fly gp -t ${DEPLOY_ENV} -p create-bosh-concourse | gsed -r "s|( +branch: ).*|\1 bugfix/152507627-cves|i")
```

Then run the `create-bosh-concourse` pipeline. You'll need to restart the `deploy-concourse` job after Concourse has been upgraded. Then everything should be green - it worked in my dev environment.

After merging it will need applying to all persistent environments. It's probably best to talk to me about who does this.

## Who can review

Anyone.