### PR TITLE
[#150711834] Add scripting and security groups for SSHing directly to Bosh

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -163,6 +163,10 @@ showenv: ## Display environment information
 		--filters 'Name=tag:Name,Values=*concourse' "Name=key-name,Values=${VAGRANT_SSH_KEY_NAME}" \
                 --query 'Reservations[].Instances[].PublicIpAddress' --output text)
 
+.PHONY: bosh-cli
+bosh-cli:
+	@./scripts/bosh-cli.sh
+
 .PHONY: ssh_bosh
 ssh_bosh: check-env-vars ## SSH to the bosh server
 	@./scripts/ssh_bosh.sh

--- a/Makefile
+++ b/Makefile
@@ -171,18 +171,18 @@ bosh-cli:
 ssh_bosh: check-env-vars ## SSH to the bosh server
 	@./scripts/ssh_bosh.sh
 
-ssh_concourse: check-env-vars ## SSH to the concourse server
-	@./concourse/scripts/ssh.sh
+ssh_concourse: check-env-vars ## SSH to the concourse server. Set SSH_CMD to pass a command to execute.
+	@./concourse/scripts/ssh.sh ssh ${SSH_CMD}
 
 ssh_bootstrap_concourse: check-env-vars ## SSH to the bootstrap concourse server
 	@cd vagrant ; vagrant ssh -- -i ../${VAGRANT_SSH_KEY_NAME}
 
 tunnel: check-env-vars ## SSH tunnel to internal IPs
 	$(if ${TUNNEL},,$(error Must pass TUNNEL=SRC_PORT:HOST:DST_PORT))
-	@./concourse/scripts/ssh.sh ${TUNNEL}
+	@./concourse/scripts/ssh.sh tunnel ${TUNNEL}
 
 stop-tunnel: check-env-vars ## Stop SSH tunnel
-	@./concourse/scripts/ssh.sh stop
+	@./concourse/scripts/ssh.sh tunnel stop
 
 .PHONY: upload-datadog-secrets
 upload-datadog-secrets: check-env-vars ## Decrypt and upload Datadog credentials to S3

--- a/Makefile
+++ b/Makefile
@@ -163,6 +163,10 @@ showenv: ## Display environment information
 		--filters 'Name=tag:Name,Values=*concourse' "Name=key-name,Values=${VAGRANT_SSH_KEY_NAME}" \
                 --query 'Reservations[].Instances[].PublicIpAddress' --output text)
 
+.PHONY: ssh_bosh
+ssh_bosh: check-env-vars ## SSH to the bosh server
+	@./scripts/ssh_bosh.sh
+
 ssh_concourse: check-env-vars ## SSH to the concourse server
 	@./concourse/scripts/ssh.sh
 

--- a/README.md
+++ b/README.md
@@ -201,13 +201,13 @@ providing them to the interactive configure command.
 
 ## SSH to concourse and tunnel
 
-You can ssh to Concourse using the command: `make <env> ssh_concourse`
+You can ssh to Concourse using the command: `make ssh_concourse`
 This will automatically get the right key and log you in as vcap user.
 
 You can open an SSH tunnel to any TCP socket in the VPC with the command:
-`make <env> tunnel TUNNEL=<local_port>:<remote_host>:<remote_port>`
+`make tunnel TUNNEL=<local_port>:<remote_host>:<remote_port>`
 
-Stop the tunnel with: `make <env> stop-tunnel`
+Stop the tunnel with: `make stop-tunnel`
 
 ## Other useful commands
 

--- a/concourse/scripts/ssh.sh
+++ b/concourse/scripts/ssh.sh
@@ -1,32 +1,65 @@
 #!/bin/bash
 
 set -euo pipefail
-TUNNEL=${1:-}
+SCRIPT=$0
+
 SOCKET_DIR=~/.ssh
 SOCKET_DEF=%r@%h:%p
 SOCKET=$SOCKET_DIR/$SOCKET_DEF
-state_bucket=gds-paas-${DEPLOY_ENV}-state
+
+usage() {
+  if [ ! -z "${1:-}" ]; then
+    echo "$@"
+    echo
+  fi
+  cat <<EOF
+Usage:
+
+  $SCRIPT <action> [-- action_params]
+
+SSH/SCP to concourse.
+
+actions:
+  ssh [command]     (default) SSH to concourse.
+                    Optionally run the provided command
+
+  scp <from> <to>   Copy 'from' local file to 'to' location on Concourse.
+
+  tunnel <tunnel>   Configure a TCP ssh tunnel for the given port
+                    Syntax: <local_port>:<remote_ip>:<remote_port>
+
+                    Use 'tunnel stop' to stop the tunnel.
+
+EOF
+}
 
 download_key() {
   key=/tmp/concourse_id_rsa.$RANDOM
   trap 'rm -f $key' EXIT
 
   eval "$(make "${AWS_ACCOUNT}" showenv | grep CONCOURSE_IP=)"
-
-  aws s3 cp "s3://${state_bucket}/concourse_id_rsa" $key && chmod 400 $key
+  aws s3 cp "s3://gds-paas-${DEPLOY_ENV}-state/concourse_id_rsa" $key && chmod 400 $key
 }
 
 ssh_concourse() {
   echo
-  aws s3 cp "s3://${state_bucket}/concourse-secrets.yml" - | \
+  aws s3 cp "s3://gds-paas-${DEPLOY_ENV}-state/concourse-secrets.yml" - | \
     ruby -ryaml -e 'puts "Sudo password is " + YAML.load(STDIN)["secrets"]["concourse_vcap_password_orig"]'
   echo
 
-  ssh -i $key -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o ServerAliveInterval=60 \
-    vcap@"$CONCOURSE_IP"
+  # shellcheck disable=SC2029
+  ssh -t -i $key -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o ServerAliveInterval=60 \
+    vcap@"$CONCOURSE_IP" "$@"
+}
+
+scp_concourse() {
+  # shellcheck disable=SC2029
+  scp -i $key -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o ServerAliveInterval=60 \
+    "$1" vcap@"$CONCOURSE_IP":"$2"
 }
 
 create_tunnel() {
+  TUNNEL=$1
   echo "Creating tunnel at socket $(print_socket) to ${TUNNEL}"
   ssh -i $key -fNTM -o ControlPath=${SOCKET} -o "ExitOnForwardFailure yes" \
     -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o ServerAliveInterval=60 \
@@ -39,15 +72,42 @@ stop_tunnel() {
 }
 
 print_socket() {
-  echo -n $SOCKET_DIR/vcap@"${CONCOURSE_IP}"
+  echo -n "$SOCKET_DIR/vcap@${CONCOURSE_IP}"
 }
 
-download_key
 
-if [[ -z "${TUNNEL}" ]]; then
-  ssh_concourse
-elif [[ "${TUNNEL}" != "stop" ]]; then
-  create_tunnel
-else
-  stop_tunnel
-fi
+case ${1:-} in
+  ssh|"")
+    shift || true
+    download_key
+    ssh_concourse "$@"
+    ;;
+  scp)
+    shift
+    if [ "$#" -ne 2 ]; then
+      usage "Wrong number of arguments for scp"
+    fi
+    download_key
+    scp_concourse "$1" "$2"
+    ;;
+  tunnel)
+    shift
+    case "$1" in
+      ?*:?*:?*)
+        download_key
+        create_tunnel "$1"
+        ;;
+      stop)
+        download_key
+        stop_tunnel
+        ;;
+      *)
+        usage "Invalid format for the tunnel option: '$1'"
+        ;;
+    esac
+    ;;
+  *)
+    usage "Unknown action '$1'"
+    exit 1
+    ;;
+esac

--- a/manifests/bosh-manifest/bosh-manifest.yml
+++ b/manifests/bosh-manifest/bosh-manifest.yml
@@ -174,5 +174,6 @@ networks:
       subnet: (( grab terraform_outputs.bosh_subnet_id ))
       security_groups:
       - (( grab terraform_outputs.bosh_security_group ))
+      - (( grab terraform_outputs.ssh_security_group ))
 - name: public
   type: vip

--- a/scripts/bosh-cli.sh
+++ b/scripts/bosh-cli.sh
@@ -20,4 +20,4 @@ docker run \
     --env "BOSH_ID_RSA" \
     --env "BOSH_IP" \
     --env "BOSH_ADMIN_PASSWORD" \
-    governmentpaas/bosh-shell
+    governmentpaas/bosh-shell:f804160a7e6f455ef206b56eab25063908703dd5

--- a/scripts/bosh-cli.sh
+++ b/scripts/bosh-cli.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+set -eu
+
+BOSH_ID_RSA="$(aws s3 cp "s3://gds-paas-${DEPLOY_ENV}-state/bosh_id_rsa" - | base64)"
+export BOSH_ID_RSA
+
+BOSH_IP=$(aws ec2 describe-instances \
+    --filters "Name=key-name,Values=${DEPLOY_ENV}_bosh_ssh_key_pair" \
+    --query 'Reservations[].Instances[].PublicIpAddress' --output text)
+export BOSH_IP
+
+BOSH_ADMIN_PASSWORD=$(aws s3 cp "s3://gds-paas-${DEPLOY_ENV}-state/bosh-secrets.yml" - | \
+    ruby -ryaml -e 'print YAML.load(STDIN)["secrets"]["bosh_admin_password"]')
+export BOSH_ADMIN_PASSWORD
+
+docker run \
+    -it \
+    --rm \
+    --env "BOSH_ID_RSA" \
+    --env "BOSH_IP" \
+    --env "BOSH_ADMIN_PASSWORD" \
+    governmentpaas/bosh-shell

--- a/scripts/ssh_bosh.sh
+++ b/scripts/ssh_bosh.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+set -euo pipefail
+
+BOSH_KEY=/tmp/bosh_id_rsa.$RANDOM
+BOSH_IP=$(aws ec2 describe-instances \
+    --filters "Name=key-name,Values=${DEPLOY_ENV}_bosh_ssh_key_pair" \
+    --query 'Reservations[].Instances[].PublicIpAddress' --output text)
+
+trap 'rm -f ${BOSH_KEY}' EXIT
+
+aws s3 cp "s3://gds-paas-${DEPLOY_ENV}-state/bosh_id_rsa" ${BOSH_KEY} && chmod 400 ${BOSH_KEY}
+
+aws s3 cp "s3://gds-paas-${DEPLOY_ENV}-state/bosh-secrets.yml" - | \
+  ruby -ryaml -e 'puts "Sudo password is " + YAML.load(STDIN)["secrets"]["bosh_vcap_password_orig"]'
+echo
+
+# shellcheck disable=SC2029
+ssh \
+    -i "$BOSH_KEY" \
+    -o ServerAliveInterval=60 \
+    -o StrictHostKeyChecking=no \
+    -o UserKnownHostsFile=/dev/null \
+    "vcap@$BOSH_IP"

--- a/terraform/globals.tf
+++ b/terraform/globals.tf
@@ -106,8 +106,6 @@ variable "admin_cidrs" {
   description = "CSV of CIDR addresses with access to operator/admin endpoints"
 
   default = [
-    "80.194.77.90/32",
-    "80.194.77.100/32",
     "85.133.67.244/32",
     "213.86.153.212/32",
     "213.86.153.213/32",


### PR DESCRIPTION
## What

https://www.pivotaltracker.com/story/show/150711834

Add the security group for accessing Bosh via SSH directly and the script for using a container to operate the Bosh Director.

## How to review

Review in conjunction with https://github.com/alphagov/paas-docker-cloudfoundry-tools/pull/101, which _**must**_ be merged first.

* Deploy a Bosh from this branch and check it gets the usual `<env>-bosh` security and the new `office-access-ssh` one we have added.
* Run `DEPLOY_ENV=<deploy_env> make bosh-cli` with your AWS credentials loaded.
  * If the above pull request above has been merged and Docker Hub has built the image then you can remove the temporary commit and run against the latest image. Otherwise, keep the temporary commit and it will point to the dev version of the image.
* The Bosh checks you need to run to confirm it works are detailed in the description of the other pull request: https://github.com/alphagov/paas-docker-cloudfoundry-tools/pull/101
* Check the updated IP whitelist is correct.

### Before merging

* the above pull request needs to be merged and Docker Hub needs to build the image from master.
* the temporary commit from this branch needs to be removed.

### After merging

This needs to be applied to persistent environments. The `create-bosh-concourse` pipeline is present on the persistent environment concourses, so you can do the manual clicky clicky.

## Who can review

Anyone but me or @camelpunch 
