### PR TITLE
[#152143894] Use oAuth for logging into concourse

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -82,6 +82,7 @@ dev: globals check-env-vars ## Set Environment to DEV
 	$(eval export AWS_ACCOUNT=dev)
 	$(eval export ENABLE_DESTROY=true)
 	$(eval export ENABLE_DATADOG ?= false)
+	$(eval export ENABLE_GITHUB ?= false)
 	$(eval export CONCOURSE_AUTH_DURATION=48h)
 	$(eval export SKIP_COMMIT_VERIFICATION=true)
 
@@ -90,18 +91,21 @@ ci: globals check-env-vars ## Set Environment to CI
 	$(eval export SYSTEM_DNS_ZONE_NAME=${DEPLOY_ENV}.ci.cloudpipeline.digital)
 	$(eval export AWS_ACCOUNT=ci)
 	$(eval export ENABLE_DATADOG=true)
+	$(eval export ENABLE_GITHUB=true)
 
 .PHONY: staging
 staging: globals check-env-vars ## Set Environment to Staging
 	$(eval export SYSTEM_DNS_ZONE_NAME=staging.cloudpipeline.digital)
 	$(eval export AWS_ACCOUNT=staging)
 	$(eval export ENABLE_DATADOG=true)
+	$(eval export ENABLE_GITHUB=true)
 
 .PHONY: prod
 prod: globals check-env-vars ## Set Environment to Production
 	$(eval export SYSTEM_DNS_ZONE_NAME=cloud.service.gov.uk)
 	$(eval export AWS_ACCOUNT=prod)
 	$(eval export ENABLE_DATADOG=true)
+	$(eval export ENABLE_GITHUB=true)
 
 ## Concourse profiles
 
@@ -182,6 +186,13 @@ upload-datadog-secrets: check-env-vars ## Decrypt and upload Datadog credentials
 	$(if ${DATADOG_PASSWORD_STORE_DIR},,$(error Must pass DATADOG_PASSWORD_STORE_DIR=<path_to_password_store>))
 	$(if $(wildcard ${DATADOG_PASSWORD_STORE_DIR}),,$(error Password store ${DATADOG_PASSWORD_STORE_DIR} does not exist))
 	@scripts/manage-datadog-secrets.sh upload
+
+.PHONY: upload-github-oauth
+upload-github-oauth: check-env-vars ## Decrypt and upload github OAuth credentials to S3
+	$(if ${AWS_ACCOUNT},,$(error Must set environment to dev/ci/staging/prod))
+	$(if ${GITHUB_PASSWORD_STORE_DIR},,$(error Must pass GITHUB_PASSWORD_STORE_DIR=<path_to_password_store>))
+	$(if $(wildcard ${GITHUB_PASSWORD_STORE_DIR}),,$(error Password store ${GITHUB_PASSWORD_STORE_DIR} does not exist))
+	@scripts/manage-github-secrets.sh upload
 
 merge_pr: ## Merge a PR. Must specify number in a PR=<number> form.
 	$(if ${PR},,$(error Must pass PR=<number>))

--- a/concourse/pipelines/create-bosh-concourse.yml
+++ b/concourse/pipelines/create-bosh-concourse.yml
@@ -160,6 +160,13 @@ resources:
       region_name: ((aws_region))
       versioned_file: concourse-manifest.yml
 
+  - name: github-oauth-secrets
+    type: s3-iam
+    source:
+      bucket: ((state_bucket))
+      region_name: ((aws_region))
+      versioned_file: github-oauth-secrets.yml
+
 jobs:
   - name: init-bucket
     serial: true
@@ -279,6 +286,7 @@ jobs:
               paas-bootstrap/concourse/scripts/s3init.sh "((state_bucket))" id_rsa.pub paas-bootstrap/concourse/init_files/zero_bytes
               paas-bootstrap/concourse/scripts/s3init.sh "((state_bucket))" concourse.tfstate paas-bootstrap/concourse/init_files/terraform.tfstate.tpl
               paas-bootstrap/concourse/scripts/s3init.sh "((state_bucket))" concourse-secrets.yml paas-bootstrap/concourse/init_files/zero_bytes
+              paas-bootstrap/concourse/scripts/s3init.sh "((state_bucket))" github-oauth-secrets.yml paas-bootstrap/concourse/init_files/zero_bytes
 
   - name: vpc
     serial: true
@@ -1153,6 +1161,7 @@ jobs:
         - get: concourse-manifest
           passed: ['generate-concourse-config']
         - get: concourse-secrets
+        - get: github-oauth-secrets
 
       - task: get-and-upload-stemcell
         config:
@@ -1221,6 +1230,7 @@ jobs:
             - name: paas-bootstrap
             - name: concourse-manifest
             - name: concourse-secrets
+            - name: github-oauth-secrets
           params:
             CONCOURSE_HOSTNAME: ((concourse_hostname))
             SYSTEM_DNS_ZONE_NAME: ((system_dns_zone_name))
@@ -1228,6 +1238,9 @@ jobs:
             FLY_TEAM: ((aws_account))
             FLY_TARGET: ((deploy_env))
             FLY_CMD: ./paas-bootstrap/bin/fly
+            ENABLE_GITHUB: ((enable_github))
+            GITHUB_CLIENT_ID: ((github_client_id))
+            GITHUB_CLIENT_SECRET: ((github_client_secret))
           run:
             path: sh
             args:
@@ -1237,6 +1250,38 @@ jobs:
                 export CONCOURSE_URL="https://${CONCOURSE_HOSTNAME}.${SYSTEM_DNS_ZONE_NAME}"
                 export CONCOURSE_ATC_PASSWORD
                 CONCOURSE_ATC_PASSWORD=$(./paas-bootstrap/concourse/scripts/val_from_yaml.rb secrets.concourse_atc_password concourse-secrets/concourse-secrets.yml)
+                export GITHUB_CLIENT_ID
+                export GITHUB_CLIENT_SECRET
+
+                if [ "${ENABLE_GITHUB}" = "true" ] ; then
+                  GITHUB_CI_USERS=$(./paas-bootstrap/concourse/scripts/val_from_yaml.rb ci ./paas-bootstrap/concourse/users/users.yml)
+                  GITHUB_PROD_USERS=$(./paas-bootstrap/concourse/scripts/val_from_yaml.rb prod ./paas-bootstrap/concourse/users/users.yml)
+                  GITHUB_CLIENT_ID=$(./paas-bootstrap/concourse/scripts/val_from_yaml.rb secrets.github_client_id github-oauth-secrets/github-oauth-secrets.yml)
+                  GITHUB_CLIENT_SECRET=$(./paas-bootstrap/concourse/scripts/val_from_yaml.rb secrets.github_client_secret github-oauth-secrets/github-oauth-secrets.yml)
+
+                  if [ "${FLY_TEAM}" = "dev" ] || [ "${FLY_TEAM}" = "ci" ]; then
+                    export GITHUB_USERS="${GITHUB_CI_USERS} ${GITHUB_PROD_USERS}"
+                  else
+                    export GITHUB_USERS="${GITHUB_PROD_USERS}"
+                  fi
+
+                  ./paas-bootstrap/concourse/scripts/fly_sync_and_login.sh
+                  # shellcheck disable=SC2046,SC2116
+                  ${FLY_CMD} -t "${FLY_TARGET}" set-team -n "${FLY_TEAM}" \
+                    --github-auth-client-id "${GITHUB_CLIENT_ID}" \
+                    --github-auth-client-secret "${GITHUB_CLIENT_SECRET}"  \
+                    $(echo "$GITHUB_USERS") --basic-auth-username admin --basic-auth-password "${CONCOURSE_ATC_PASSWORD}" --non-interactive
+
+                  ./paas-bootstrap/concourse/scripts/fly_sync_and_login.sh
+                  # shellcheck disable=SC2046,SC2116
+                  ${FLY_CMD} -t "${FLY_TARGET}" set-team -n main \
+                    --github-auth-client-id "${GITHUB_CLIENT_ID}" \
+                    --github-auth-client-secret "${GITHUB_CLIENT_SECRET}"  \
+                    $(echo "$GITHUB_USERS") --basic-auth-username admin --basic-auth-password "${CONCOURSE_ATC_PASSWORD}" --non-interactive
+
+                  exit 0
+                fi
+
                 ./paas-bootstrap/concourse/scripts/fly_sync_and_login.sh
                 ${FLY_CMD} -t "${FLY_TARGET}" set-team -n "${FLY_TEAM}" \
                   --basic-auth-username admin --basic-auth-password "${CONCOURSE_ATC_PASSWORD}" --non-interactive

--- a/concourse/scripts/pipelines.sh
+++ b/concourse/scripts/pipelines.sh
@@ -34,6 +34,9 @@ concourse_instance_profile: ${CONCOURSE_INSTANCE_PROFILE}
 enable_datadog: ${ENABLE_DATADOG}
 datadog_api_key: ${DATADOG_API_KEY:-}
 datadog_app_key: ${DATADOG_APP_KEY:-}
+enable_github: ${ENABLE_GITHUB}
+github_client_id: ${GITHUB_CLIENT_ID:-}
+github_client_secret: ${GITHUB_CLIENT_SECRET:-}
 enable_collectd_addon: ${ENABLE_COLLECTD_ADDON}
 enable_syslog_addon: ${ENABLE_SYSLOG_ADDON}
 concourse_auth_duration: ${CONCOURSE_AUTH_DURATION:-5m}
@@ -43,6 +46,10 @@ EOF
 
 if [ "${ENABLE_DATADOG}" = "true" ] ; then
   eval "$("${SCRIPT_DIR}"/../../scripts/manage-datadog-secrets.sh retrieve)"
+fi
+
+if [ "${ENABLE_GITHUB}" = "true" ] ; then
+  eval "$("${SCRIPT_DIR}"/../../scripts/manage-github-secrets.sh retrieve)"
 fi
 
 if [ "${SKIP_COMMIT_VERIFICATION:-}" = "true" ] ; then

--- a/concourse/users/users.yml
+++ b/concourse/users/users.yml
@@ -1,0 +1,14 @@
+---
+prod: |
+      --github-auth-user alext
+      --github-auth-user dcarley
+      --github-auth-user bleach
+      --github-auth-user henrytk
+      --github-auth-user paroxp
+      --github-auth-user LeePorte
+      --github-auth-user samcrang
+ci: |
+      --github-auth-user chrisfarms
+      --github-auth-user 46bit
+      --github-auth-user bandesz
+      --github-auth-user camelpunch

--- a/scripts/manage-github-secrets.sh
+++ b/scripts/manage-github-secrets.sh
@@ -1,0 +1,93 @@
+#!/bin/sh
+set -eu
+
+SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)
+
+help() {
+  cat <<EOF
+Tries to retrieve github credentials from the S3 object github-secrets.yml.
+If the object or the bucket does not exists, it will try to retrieve the
+credentials from the environment or paas-pass. It will print the variables
+to be evaluated.
+
+It can also upload the S3 object with the credentials from the environment
+or paas-pass.
+
+Usage:
+
+  AWS_ACCOUNT=dev GITHUB_PASSWORD_STORE_DIR=~/.paas-pass DEPLOY_ENV=leeporte
+    ./scripts/manage-github-secrets.sh upload
+
+  eval \$(
+    AWS_ACCOUNT=dev GITHUB_PASSWORD_STORE_DIR=~/.paas-pass DEPLOY_ENV=leeporte
+    ./scripts/manage-github-secrets.sh retrieve
+  )
+
+EOF
+}
+
+val_from_yaml() {
+  "${SCRIPT_DIR}"/../concourse/scripts/val_from_yaml.rb "$1" "$2"
+}
+
+setup_env() {
+  export PASSWORD_STORE_DIR=${GITHUB_PASSWORD_STORE_DIR}
+  secrets_uri="s3://gds-paas-${DEPLOY_ENV}-state/github-oauth-secrets.yml"
+}
+
+get_creds_from_env_or_pass() {
+  setup_env
+  GITHUB_CLIENT_ID="${GITHUB_CLIENT_ID:-$(pass "github.com/concourse/${AWS_ACCOUNT}/client_id")}"
+  GITHUB_CLIENT_SECRET="${GITHUB_CLIENT_SECRET:-$(pass "github.com/concourse/${AWS_ACCOUNT}/client_secret")}"
+}
+
+upload() {
+  setup_env
+  get_creds_from_env_or_pass
+  secrets_file=$(mktemp secrets.yml.XXXXXX)
+  trap 'rm  "${secrets_file}"' EXIT
+
+  cat > "${secrets_file}" << EOF
+---
+secrets:
+  github_client_id: ${GITHUB_CLIENT_ID}
+  github_client_secret: ${GITHUB_CLIENT_SECRET}
+EOF
+
+  aws s3 cp "${secrets_file}" "${secrets_uri}"
+}
+
+retrieve() {
+  setup_env
+  if aws s3 ls "${secrets_uri}" > /dev/null ; then
+    secrets_file=$(mktemp -t github-oauth-secrets.XXXXXX)
+    trap 'rm  "${secrets_file}"' EXIT
+
+    aws s3 cp "${secrets_uri}" "${secrets_file}" 1>&2
+    GITHUB_CLIENT_ID="${GITHUB_CLIENT_ID:-$(val_from_yaml github_client_id "${secrets_file}")}"
+    GITHUB_CLIENT_SECRET="${GITHUB_CLIENT_SECRET:-$(val_from_yaml github_client_secret "${secrets_file}")}"
+  else
+    echo "Warning: Cannot retrieve github secrets from S3. Retriving from environment or from pass." 1>&2
+    get_creds_from_env_or_pass
+  fi
+
+  if [ -z "${GITHUB_CLIENT_ID}" ] || [ -z "${GITHUB_CLIENT_SECRET}" ] ; then
+    echo "\$GITHUB_CLIENT_ID or \$GITHUB_CLIENT_SECRET not set, failing" 1>&2
+  else
+    echo "export GITHUB_CLIENT_ID=\"${GITHUB_CLIENT_ID}\""
+    echo "export GITHUB_CLIENT_SECRET=\"${GITHUB_CLIENT_SECRET}\""
+  fi
+}
+
+case ${1:-} in
+  upload)
+    upload
+  ;;
+  retrieve)
+    retrieve
+  ;;
+  *)
+    help
+  ;;
+esac
+


### PR DESCRIPTION
## What

This PR introduces Github oAuth to log into Concourse. An additional make target has been created to facilitate uploading of API credentials for authentication of users.

`# shellcheck disable=SC2046,SC2116` is used for the team creation command due to the shellcheck incorrectly reporting quoting errors and an unnecessary echo. 

## How to review

1. Create an oAuth application at https://github.com/settings/applications/new
1. Authorization callback URL should be `https://deployer.<your env>.dev.cloudpipeline.digital/auth/github/callback`
1. Store the client ID and Client secret in your personal pass store under the following locations `github.com/concourse/dev/client_id` and `github.com/concourse/dev/client_secret`
1. Checkout this branch and run `make dev upload-github-oauth GITHUB_PASSWORD_STORE_DIR=<your pass dir> DEPLOY_ENV= <your Env>`
1. Push the pipeline with the following command `BRANCH=$(git rev-parse --abbrev-ref HEAD) make dev pipelines CONCOURSE_TYPE=deployer-concourse CONCOURSE_HOSTNAME=deployer BOSH_INSTANCE_PROFILE=bosh-director-cf CONCOURSE_INSTANCE_TYPE=m4.xlarge CONCOURSE_INSTANCE_PROFILE=deployer-concourse ENABLE_COLLECTD_ADDON=true ENABLE_SYSLOG_ADDON=true ENABLE_GITHUB=true`
1. Run the `create-bosh-concourse` pipeline
1. once it has completed, login to team main using the login with Github button.

## Merging

Github API credentials are already in the persistent environment state buckets. Once merge to master the pipeline needs to be run in each environment.

## Who can review

Not @LeePorte or @46bit 
