### PR TITLE
Removes unneeded params and team settings

### DIFF
--- a/concourse/pipelines/create-bosh-concourse.yml
+++ b/concourse/pipelines/create-bosh-concourse.yml
@@ -1218,7 +1218,7 @@ jobs:
           params:
             file: updated-concourse-manifest/concourse-manifest.yml
 
-      - task: add-env-specific-team
+      - task: add-github-oauth
         config:
           platform: linux
           image_resource:
@@ -1239,8 +1239,6 @@ jobs:
             FLY_TARGET: ((deploy_env))
             FLY_CMD: ./paas-bootstrap/bin/fly
             ENABLE_GITHUB: ((enable_github))
-            GITHUB_CLIENT_ID: ((github_client_id))
-            GITHUB_CLIENT_SECRET: ((github_client_secret))
           run:
             path: sh
             args:
@@ -1250,8 +1248,6 @@ jobs:
                 export CONCOURSE_URL="https://${CONCOURSE_HOSTNAME}.${SYSTEM_DNS_ZONE_NAME}"
                 export CONCOURSE_ATC_PASSWORD
                 CONCOURSE_ATC_PASSWORD=$(./paas-bootstrap/concourse/scripts/val_from_yaml.rb secrets.concourse_atc_password concourse-secrets/concourse-secrets.yml)
-                export GITHUB_CLIENT_ID
-                export GITHUB_CLIENT_SECRET
 
                 if [ "${ENABLE_GITHUB}" = "true" ] ; then
                   GITHUB_CI_USERS=$(./paas-bootstrap/concourse/scripts/val_from_yaml.rb ci ./paas-bootstrap/concourse/users/users.yml)
@@ -1267,20 +1263,41 @@ jobs:
 
                   ./paas-bootstrap/concourse/scripts/fly_sync_and_login.sh
                   # shellcheck disable=SC2046,SC2116
-                  ${FLY_CMD} -t "${FLY_TARGET}" set-team -n "${FLY_TEAM}" \
-                    --github-auth-client-id "${GITHUB_CLIENT_ID}" \
-                    --github-auth-client-secret "${GITHUB_CLIENT_SECRET}"  \
-                    $(echo "$GITHUB_USERS") --basic-auth-username admin --basic-auth-password "${CONCOURSE_ATC_PASSWORD}" --non-interactive
-
-                  ./paas-bootstrap/concourse/scripts/fly_sync_and_login.sh
-                  # shellcheck disable=SC2046,SC2116
                   ${FLY_CMD} -t "${FLY_TARGET}" set-team -n main \
                     --github-auth-client-id "${GITHUB_CLIENT_ID}" \
                     --github-auth-client-secret "${GITHUB_CLIENT_SECRET}"  \
                     $(echo "$GITHUB_USERS") --basic-auth-username admin --basic-auth-password "${CONCOURSE_ATC_PASSWORD}" --non-interactive
 
-                  exit 0
                 fi
+
+      - task: add-env-specific-team
+        config:
+          platform: linux
+          image_resource:
+            type: docker-image
+            source:
+              repository: governmentpaas/self-update-pipelines
+              tag: 895cf6752c8ec64af05a3a735186b90acd3db65a
+          inputs:
+            - name: paas-bootstrap
+            - name: concourse-manifest
+            - name: concourse-secrets
+          params:
+            CONCOURSE_HOSTNAME: ((concourse_hostname))
+            SYSTEM_DNS_ZONE_NAME: ((system_dns_zone_name))
+            CONCOURSE_ATC_USER: admin
+            FLY_TEAM: ((aws_account))
+            FLY_TARGET: ((deploy_env))
+            FLY_CMD: ./paas-bootstrap/bin/fly
+          run:
+            path: sh
+            args:
+              - -e
+              - -c
+              - |
+                export CONCOURSE_URL="https://${CONCOURSE_HOSTNAME}.${SYSTEM_DNS_ZONE_NAME}"
+                export CONCOURSE_ATC_PASSWORD
+                CONCOURSE_ATC_PASSWORD=$(./paas-bootstrap/concourse/scripts/val_from_yaml.rb secrets.concourse_atc_password concourse-secrets/concourse-secrets.yml)
 
                 ./paas-bootstrap/concourse/scripts/fly_sync_and_login.sh
                 ${FLY_CMD} -t "${FLY_TARGET}" set-team -n "${FLY_TEAM}" \

--- a/concourse/scripts/pipelines.sh
+++ b/concourse/scripts/pipelines.sh
@@ -35,8 +35,6 @@ enable_datadog: ${ENABLE_DATADOG}
 datadog_api_key: ${DATADOG_API_KEY:-}
 datadog_app_key: ${DATADOG_APP_KEY:-}
 enable_github: ${ENABLE_GITHUB}
-github_client_id: ${GITHUB_CLIENT_ID:-}
-github_client_secret: ${GITHUB_CLIENT_SECRET:-}
 enable_collectd_addon: ${ENABLE_COLLECTD_ADDON}
 enable_syslog_addon: ${ENABLE_SYSLOG_ADDON}
 concourse_auth_duration: ${CONCOURSE_AUTH_DURATION:-5m}

--- a/scripts/manage-github-secrets.sh
+++ b/scripts/manage-github-secrets.sh
@@ -67,15 +67,7 @@ retrieve() {
     GITHUB_CLIENT_ID="${GITHUB_CLIENT_ID:-$(val_from_yaml github_client_id "${secrets_file}")}"
     GITHUB_CLIENT_SECRET="${GITHUB_CLIENT_SECRET:-$(val_from_yaml github_client_secret "${secrets_file}")}"
   else
-    echo "Warning: Cannot retrieve github secrets from S3. Retriving from environment or from pass." 1>&2
-    get_creds_from_env_or_pass
-  fi
-
-  if [ -z "${GITHUB_CLIENT_ID}" ] || [ -z "${GITHUB_CLIENT_SECRET}" ] ; then
-    echo "\$GITHUB_CLIENT_ID or \$GITHUB_CLIENT_SECRET not set, failing" 1>&2
-  else
-    echo "export GITHUB_CLIENT_ID=\"${GITHUB_CLIENT_ID}\""
-    echo "export GITHUB_CLIENT_SECRET=\"${GITHUB_CLIENT_SECRET}\""
+    echo "Warning: Cannot retrieve github secrets from S3. Did you upload them?" 
   fi
 }
 


### PR DESCRIPTION
## What

Fixes the Comments raised in #101 by @alext 

## How to review

1. Create an oAuth application at https://github.com/settings/applications/new
1. Authorization callback URL should be `https://deployer.<your env>.dev.cloudpipeline.digital/auth/github/callback`
1. Store the client ID and Client secret in your personal pass store under the following locations `github.com/concourse/dev/client_id` and `github.com/concourse/dev/client_secret`
1. Checkout this branch and run `make dev upload-github-oauth GITHUB_PASSWORD_STORE_DIR=<your pass dir> DEPLOY_ENV= <your Env>`
1. Push the pipeline with the following command `BRANCH=$(git rev-parse --abbrev-ref HEAD) make dev pipelines CONCOURSE_TYPE=deployer-concourse CONCOURSE_HOSTNAME=deployer BOSH_INSTANCE_PROFILE=bosh-director-cf CONCOURSE_INSTANCE_TYPE=m4.xlarge CONCOURSE_INSTANCE_PROFILE=deployer-concourse ENABLE_COLLECTD_ADDON=true ENABLE_SYSLOG_ADDON=true ENABLE_GITHUB=true`
1. Run the `create-bosh-concourse` pipeline
1. once it has completed, login to team main using the login with Github button.

## Merging

Github API credentials are already in the persistent environment state buckets. Once merge to master the pipeline needs to be run in each environment.

## Who can review

Not @LeePorte
