### PR TITLE
[#152150381] Ignore tracefs filesystem in the collectd df plugin.

### DIFF
--- a/manifests/runtime-config/addons-meta/collectd.yml
+++ b/manifests/runtime-config/addons-meta/collectd.yml
@@ -27,6 +27,8 @@ meta:
 
       LoadPlugin df
       <Plugin df>
+        FSType "tracefs"
+        IgnoreSelected true
         ReportInodes true
         ReportReserved true
       </Plugin>


### PR DESCRIPTION
## What

The df plugin is responsible for collecting disk usage information about mounted file systems. The plugin writes an error to syslog when it encounters the non-existing /var/lib/ureadahead/debugfs/tracing mount point. This happens every 10 seconds and we want to get rid of it.

The ureadahead daemon creates the temporary /var/lib/ureadahead/debugfs/tracing mount at boot but fails to clean it up when the final system mount is available. There is an old launchpad bug report that is related to our issue: https://bugs.launchpad.net/ubuntu/+source/mountall/+bug/499773

We can safely ignore any tracefs filesystem as /var/lib/ureadahead/debugfs/tracing is the only one in /etc/mtab.

The collectd df plugin configuration can be found here: https://collectd.org/wiki/index.php/Plugin:DF.
We have to set IgnoreSelected to true to ignore anything defined by FSType, MountPoint and Device.

## How to review

1. Update and run the create-bosh-concourse-pipeline from this branch:
    ```BRANCH=ignore_tracefs_in_collectd_df_152150381 make dev deployer-concourse pipelines```
2. Run the create-cloudfoundry pipeline
3. Go to Kibana and you should not see any new ```statvfs(/var/lib/ureadahead/debugfs/tracing) failed: No such file or directory``` errors in the logs.

## How to release

❗️ You have to pause the create-cloudfoundry pipelines first.

1. Merge the PR
2. Run the create-bosh-concourse pipelines for both environments and wait for them to finish successfully.
3. Unpause the create-cloudfoundry pipelines

## Who can review

Not @henrytk or me
