### PR TITLE
[#153696695] Upgrade stemcells for Ubuntu CVEs

### DIFF
--- a/manifests/bosh-manifest/bosh-manifest.yml
+++ b/manifests/bosh-manifest/bosh-manifest.yml
@@ -152,8 +152,8 @@ resource_pools:
 - name: bosh
   network: private
   stemcell:
-    url: https://bosh.io/d/stemcells/bosh-aws-xen-hvm-ubuntu-trusty-go_agent?v=3445.16
-    sha1: 1c79efef420ad8943ff040a5d274209d2bf73539
+    url: https://bosh.io/d/stemcells/bosh-aws-xen-hvm-ubuntu-trusty-go_agent?v=3468.13
+    sha1: 50416e0f48ff2dc3d954ac5082dda0965d97b93a
   cloud_properties:
     instance_type: t2.medium
     ephemeral_disk: {size: 40000, type: gp2}

--- a/manifests/concourse-manifest/concourse-base.yml
+++ b/manifests/concourse-manifest/concourse-base.yml
@@ -2,7 +2,7 @@
 meta:
   stemcell:
     name: bosh-aws-xen-hvm-ubuntu-trusty-go_agent
-    version: "3445.16"
+    version: "3468.13"
 
   zone: (( grab terraform_outputs.zone0 ))
 


### PR DESCRIPTION
## What

This fixes the following:

- https://www.cloudfoundry.org/usn-3498-1/
- https://www.cloudfoundry.org/usn-3496-3/
- https://www.cloudfoundry.org/usn-3489-1/
- https://www.cloudfoundry.org/usn-3505-1/
- https://www.cloudfoundry.org/usn-3504-1/
- https://www.cloudfoundry.org/usn-3496-1/

I've taken the opportunity to change the stemcell series so that it matches
what we use in alphagov/paas-cf.

## How to review

I've successfully deployed this in my dev environment by using the pipeline in the Deployer Concourse.

If you want to test it yourself then you can modify the branch that the pipeline uses with this command:
```
./bin/fly-bootstrap sp -t ${DEPLOY_ENV} -p create-bosh-concourse -c <(./bin/fly-bootstrap gp -t ${DEPLOY_ENV} -p create-bosh-concourse | gsed -r "s|( +branch: ).*|\1 $(git rev-parse --abbrev-ref HEAD)|i")
```

Otherwise a code review should be sufficient. I'll deploy it to the persistent environments after merge.

## Who can review

Anyone.