### PR TITLE
[#153366899] Use DNS validation when creating ACM certificates

### DIFF
--- a/concourse/pipelines/concourse-lite-self-terminate.yml
+++ b/concourse/pipelines/concourse-lite-self-terminate.yml
@@ -21,7 +21,7 @@ jobs:
           type: docker-image
           source:
             repository: governmentpaas/awscli
-            tag: 895cf6752c8ec64af05a3a735186b90acd3db65a
+            tag: b2495d6ed07f680125d19aa7d1701da7efabb289
         params:
           VAGRANT_SSH_KEY_NAME: ((vagrant_ssh_key_name))
         run:

--- a/concourse/pipelines/create-bosh-concourse.yml
+++ b/concourse/pipelines/create-bosh-concourse.yml
@@ -173,7 +173,7 @@ jobs:
             type: docker-image
             source:
               repository: governmentpaas/awscli
-              tag: 895cf6752c8ec64af05a3a735186b90acd3db65a
+              tag: b2495d6ed07f680125d19aa7d1701da7efabb289
           params:
             AWS_DEFAULT_REGION: ((aws_region))
           inputs:
@@ -937,7 +937,7 @@ jobs:
             type: docker-image
             source:
               repository: governmentpaas/awscli
-              tag: 895cf6752c8ec64af05a3a735186b90acd3db65a
+              tag: b2495d6ed07f680125d19aa7d1701da7efabb289
           inputs:
             - name: paas-bootstrap
           params:
@@ -1026,7 +1026,7 @@ jobs:
             type: docker-image
             source:
               repository: governmentpaas/awscli
-              tag: 895cf6752c8ec64af05a3a735186b90acd3db65a
+              tag: b2495d6ed07f680125d19aa7d1701da7efabb289
           inputs:
           - name: paas-bootstrap
           params:

--- a/concourse/pipelines/destroy-bosh-concourse.yml
+++ b/concourse/pipelines/destroy-bosh-concourse.yml
@@ -293,7 +293,7 @@ jobs:
             type: docker-image
             source:
               repository: governmentpaas/awscli
-              tag: 895cf6752c8ec64af05a3a735186b90acd3db65a
+              tag: b2495d6ed07f680125d19aa7d1701da7efabb289
           inputs:
             - name: paas-bootstrap
           params:

--- a/concourse/scripts/create_concourse_cert.sh
+++ b/concourse/scripts/create_concourse_cert.sh
@@ -1,16 +1,37 @@
 #!/bin/sh
 
-set -eu
+set -euo pipefail
 
 concourse_fqdn="${CONCOURSE_HOSTNAME}.${SYSTEM_DNS_ZONE_NAME}"
 
+get_route53_change_batch() {
+  action=${1}
+  cat <<EOF
+{
+  "Changes": [
+    {
+      "Action": "${action}",
+      "ResourceRecordSet": {
+        "Name": "${dns_validation_record}",
+        "Type": "CNAME",
+        "TTL": 300,
+        "ResourceRecords": [
+          {
+            "Value": "${dns_validation_value}"
+          }
+        ]
+      }
+    }
+  ]
+}
+EOF
+}
+
 arn=$(aws acm list-certificates --query "CertificateSummaryList[?DomainName==\`${concourse_fqdn}\`].CertificateArn" --output text)
 
-created_cert="false"
 if [ -z "${arn}" ] || [ "${arn}" = "None" ]; then
   echo "Requesting certificate for ${concourse_fqdn}"
-  arn=$(aws acm request-certificate --domain-name "${concourse_fqdn}" --domain-validation-options "DomainName=${concourse_fqdn},ValidationDomain=${SYSTEM_DNS_ZONE_NAME}" --output text)
-  created_cert="true"
+  arn=$(aws acm request-certificate --domain-name "${concourse_fqdn}" --validation-method "DNS" --output text)
 fi
 
 cert_status=$(aws acm describe-certificate --certificate-arn "${arn}" --query 'Certificate.Status' --output text)
@@ -19,15 +40,39 @@ if [ "${cert_status}" = "ISSUED" ]; then
   exit 0
 fi
 
-if [ "${created_cert}" = "false" ]; then
-  echo "Resending validation email for ${concourse_fqdn} certificate"
-  aws acm resend-validation-email --certificate-arn "${arn}" --domain "${concourse_fqdn}" --validation-domain "${SYSTEM_DNS_ZONE_NAME}"
+# The validation records are not returned for a couple of seconds from the API after creation
+echo "Getting DNS validation records"
+for _ in $(seq 20); do
+  sleep 3
+
+  cert_info=$(aws acm describe-certificate --certificate-arn "${arn}" --query 'Certificate')
+  dns_validation_record=$(echo "${cert_info}" | jq -r '.DomainValidationOptions[0].ResourceRecord.Name')
+  dns_validation_value=$(echo "${cert_info}" | jq -r '.DomainValidationOptions[0].ResourceRecord.Value')
+
+  if [ "null" != "${dns_validation_record}" ] && [ "null" != "${dns_validation_value}" ]; then
+    break
+  fi
+done
+
+if [ "null" = "${dns_validation_record}" ] || [ "null" = "${dns_validation_value}" ]; then
+  echo "DNS validation records are not found in the AWS API response: ${cert_info}"
+  echo
+  echo "Please run the script again"
+  exit 1
 fi
 
+zone_id=$(aws route53 list-hosted-zones-by-name --dns-name dev.cloudpipeline.digital --query 'HostedZones[0].Id' --output text | cut -d '/' -f 3)
+
+echo "Upserting DNS validation record: ${dns_validation_record}"
+
+aws route53 change-resource-record-sets --hosted-zone-id "${zone_id}" --change-batch "$(get_route53_change_batch UPSERT)" > /dev/null
+
 cat <<EOT
+
 The certificate for ${concourse_fqdn} has been requested. To verify this,
-emails will be sent to the paas-domain-admins containing a link to validate
-this request. Once that is done, the certificate can be used.
+a new DNS record has been created on your domain and Amazon will
+automatically validate this request. Once that is done, the certificate
+can be used.
 
 This script will now poll for up to 10 mins waiting for this to happen.
 EOT
@@ -39,6 +84,10 @@ for _ in $(seq 40); do
   if [ "${cert_status}" = "ISSUED" ]; then
     echo
     echo "Cert issued successfully."
+
+    echo "Deleting DNS validation record."
+    aws route53 change-resource-record-sets --hosted-zone-id "${zone_id}" --change-batch "$(get_route53_change_batch DELETE)" > /dev/null
+
     exit 0
   fi
 done

--- a/concourse/tasks/delete-ssh-keys.yml
+++ b/concourse/tasks/delete-ssh-keys.yml
@@ -4,7 +4,7 @@ image_resource:
   type: docker-image
   source:
     repository: governmentpaas/awscli
-    tag: 895cf6752c8ec64af05a3a735186b90acd3db65a
+    tag: b2495d6ed07f680125d19aa7d1701da7efabb289
 inputs:
   - name: paas-bootstrap
 run:


### PR DESCRIPTION
## What

Introduce DNS validation to fully automate the ACM certificate request process. Previously we used email validation which required manual action from one of the team members.

After creating an ACM certificate request it takes some time to get back the Route 53 validation record data from the Amazon API. The script polls every 3 seconds and fails after 60 seconds.

After the validation record was created the script waits up to 10 minutes for Amazon to automatically do the validation.

If the validation is successful the validation record will be deleted.

On any failure the script can be run again.

I added the jq package and updated the awscli in the awscli Docker image, please review and merge first:
 * https://github.com/alphagov/paas-docker-cloudfoundry-tools/pull/105
 * https://github.com/alphagov/paas-docker-cloudfoundry-tools/pull/106

Additional IAM access is needed, please review, merge and apply: 
* https://github.com/alphagov/paas-aws-account-wide-terraform/pull/108
* https://github.com/alphagov/paas-aws-account-wide-terraform/pull/109

## How to review

First test the certificate creation by running its script manually:

```
CONCOURSE_HOSTNAME=deployer SYSTEM_DNS_ZONE_NAME=${DEPLOY_ENV}.dev.cloudpipeline.digital ./concourse/scripts/create_concourse_cert.sh
```

Run the script for the following scenarios:
 * [x] existing deploy env with a valid certificate
 * [x] non-existing deploy env (wait for the script to finish)
 * [x] existing deploy env with a pending certificate (cancel the script after a while and run it again for the same deploy env)

To fully test the change boostrap e.g. your build Concourse with a new environment name and run the create-bosh-concourse pipeline. It should create your ACM successfully.

## Who can review

Not @bandesz