### PR TITLE
[#152065618] Upgrade Concourse to 3.5.0

### DIFF
--- a/manifests/concourse-manifest/concourse-base.yml
+++ b/manifests/concourse-manifest/concourse-base.yml
@@ -12,9 +12,9 @@ director_uuid: ~
 
 releases:
   - name: concourse
-    version: 3.4.1
-    url: https://bosh.io/d/github.com/concourse/concourse?v=3.4.1
-    sha1: b9c3cd85caccf0dae7406f8d7dfc237b4c698ce6
+    version: 3.5.0
+    url: https://bosh.io/d/github.com/concourse/concourse?v=3.5.0
+    sha1: 65a974b3831bb9908661a5ffffbe456e10185149
   - name: garden-runc
     version: 1.6.0
     url: https://bosh.io/d/github.com/cloudfoundry/garden-runc-release?v=1.6.0


### PR DESCRIPTION
## What

This is the first step of the Concourse upgrade process from 3.4.1 -> 3.8.0.

This change only updates the Concourse BOSH release version, which enables an
upgrade path to swap out the bundled PostgreSQL job with the one using the
official Postgres BOSH release.

Following the upgrade notes written in https://concourse.ci/downloads.html#v350.

The bootstrap Docker images will be updated only in the last step.

## How to review

1. Update your pipeline from this branch
    ```BRANCH=152065618_upgrade_concourse_1 make dev pipelines```
2. Run the create-bosh-concourse pipeline (after it reaches the concourse-deploy task you have to reload Concourse after a couple of minutes)
3. Check if Concourse works by uploading the pipelines again and running create-bosh-concourse again

I also ran the create-cloudfoundry pipeline as a test successfully, I leave it to you if you want to test it or not.

## Who can review

Not @bandesz
