### PR TITLE
[#152065618]  Replace concourse/postgresql with postgres/postgres

### DIFF
--- a/manifests/concourse-manifest/concourse-base.yml
+++ b/manifests/concourse-manifest/concourse-base.yml
@@ -19,6 +19,10 @@ releases:
     version: 1.6.0
     url: https://bosh.io/d/github.com/cloudfoundry/garden-runc-release?v=1.6.0
     sha1: 58fbc64aff303e6d76899441241dd5dacef50cb7
+  - name: postgres
+    version: 22
+    url: https://bosh.io/d/github.com/cloudfoundry/postgres-release?v=22
+    sha1: 86a1333122e9cdd051551c83ec26d36f6e325d6c
 
 properties:
   aws:
@@ -83,13 +87,16 @@ jobs:
     persistent_disk_pool: db
 
     templates:
-      - name: postgresql
-        release: concourse
+      - name: postgres
+        release: postgres
         properties:
           databases:
-            - name: atc
-              role: atc
-              password: (( grab secrets.concourse_postgres_password ))
+            port: 5432
+            databases:
+              - name: atc
+            roles:
+              - name: atc
+                password: (( grab secrets.concourse_postgres_password ))
 
       - name: atc
         release: concourse
@@ -98,7 +105,11 @@ jobs:
           basic_auth_username: admin
           basic_auth_password: (( grab secrets.concourse_atc_password ))
           auth_duration: (( grab $CONCOURSE_AUTH_DURATION ))
-          postgresql_database: atc
+          postgresql:
+            database: atc
+            role:
+              name: atc
+              password: (( grab secrets.concourse_postgres_password ))
 
       - name: groundcrew
         release: concourse


### PR DESCRIPTION
## What

Replace concourse/postgresql with postgres/postgres

This is the second step of the Concourse upgrade process from 3.4.1 -> 3.8.0.

Following the upgrade notes written in https://concourse.ci/downloads.html#v350.

The bootstrap Docker images will be updated only in the last step.

❗️ The Postgres DB upgrade must not be combined in the same deployment operation with a stemcell update.

## How to review

❗️ This PR also contains https://github.com/alphagov/paas-bootstrap/pull/108 which has to be merged first.

1. Update your pipeline from this branch
    ```BRANCH=152065618_upgrade_concourse_2 make dev pipelines```
2. Run the create-bosh-concourse pipeline (after it reaches the concourse-deploy task you have to reload Concourse after a couple of minutes)
3. Check if Concourse works by uploading the pipelines again and running create-bosh-concourse again

I also ran the create-cloudfoundry pipeline as a test successfully, I leave it to you if you want to test it or not.

## Who can review

Not @bandesz