### PR TITLE
[#152065618]  Upgrade Concourse to 3.6.0

### DIFF
--- a/manifests/concourse-manifest/concourse-base.yml
+++ b/manifests/concourse-manifest/concourse-base.yml
@@ -12,9 +12,9 @@ director_uuid: ~
 
 releases:
   - name: concourse
-    version: 3.5.0
-    url: https://bosh.io/d/github.com/concourse/concourse?v=3.5.0
-    sha1: 65a974b3831bb9908661a5ffffbe456e10185149
+    version: 3.6.0
+    url: https://bosh.io/d/github.com/concourse/concourse?v=3.6.0
+    sha1: 1257bdcd3181ab0a669bc9e34cd87aff584f007b
   - name: garden-runc
     version: 1.6.0
     url: https://bosh.io/d/github.com/cloudfoundry/garden-runc-release?v=1.6.0


### PR DESCRIPTION
## What

This is the third step of the Concourse upgrade process from 3.4.1 -> 3.8.0.

We have to upgrade to 3.6.0 first before we upgrade to 3.7.0 or newer as
mentioned in https://concourse.ci/downloads.html#v370. Upgrading to 3.7.0
will be skipped as it's buggy and also not necessary.

The bootstrap Docker images will be updated only in the last step.

## How to review

❗️ This PR also contains https://github.com/alphagov/paas-bootstrap/pull/109 which has to be merged first.

1. Update your pipeline from this branch
    ```BRANCH=152065618_upgrade_concourse_3 make dev pipelines```
2. Run the create-bosh-concourse pipeline (after it reaches the concourse-deploy task you have to reload Concourse after a couple of minutes)
3. Check if Concourse works by uploading the pipelines again and running create-bosh-concourse again

I also ran the create-cloudfoundry pipeline as a test successfully, I leave it to you if you want to test it or not.

## Who can review

Not @bandesz
