### PR TITLE
[#147833555] Parse YAML lists as comma-delimited strings

### DIFF
--- a/concourse/scripts/val_from_yaml.rb
+++ b/concourse/scripts/val_from_yaml.rb
@@ -51,7 +51,9 @@ if $0 == __FILE__ # Only execute if called directly as command
   val = property_tree[key]
   abort "Unable to find key: #{key}" if val.nil?
 
-  if val.is_a?(Array) || val.is_a?(Hash)
+  if val.is_a?(Array)
+    puts val.join(',')
+  elsif val.is_a?(Hash)
     puts YAML.dump(val)
   else
     puts val

--- a/concourse/scripts/val_from_yaml_test.go
+++ b/concourse/scripts/val_from_yaml_test.go
@@ -120,4 +120,16 @@ val2: b
 			Expect(session.Err.Contents()).To(BeEmpty())
 		})
 	})
+
+	Context("argument references an array of string values", func() {
+		BeforeEach(func() {
+			cmdArg = "foo.array2"
+		})
+
+		It("joins them into a comma-delimited string", func() {
+			Eventually(session).Should(gexec.Exit(0))
+			Expect(session.Out.Contents()).To(Equal([]byte("array2_value1,array2_value2,array2_value3\n")))
+			Expect(session.Err.Contents()).To(BeEmpty())
+		})
+	})
 })


### PR DESCRIPTION
## What

This script is duplicated from paas-cf so has to be maintained here
as well. This change was needed to extract a YAML list and pass it
as a comma-delimited string for use as an environment variable.

## How to review

Review in conjunction with https://github.com/alphagov/paas-cf/pull/1151

## Who can review

Anyone but me, @camelpunch, or @46bit 
