### PR TITLE
[#153366899] Introduce SYSTEM_DNS_ZONE_ID variable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -79,7 +79,8 @@ globals:
 
 .PHONY: dev
 dev: globals check-env-vars ## Set Environment to DEV
-	$(eval export SYSTEM_DNS_ZONE_NAME=${DEPLOY_ENV}.dev.cloudpipeline.digital)
+	$(eval export ROOT_SYSTEM_DNS_ZONE_NAME=dev.cloudpipeline.digital)
+	$(eval export SYSTEM_DNS_ZONE_NAME=${DEPLOY_ENV}.${ROOT_SYSTEM_DNS_ZONE_NAME})
 	$(eval export AWS_ACCOUNT=dev)
 	$(eval export ENABLE_DESTROY=true)
 	$(eval export ENABLE_DATADOG ?= false)
@@ -89,21 +90,24 @@ dev: globals check-env-vars ## Set Environment to DEV
 
 .PHONY: ci
 ci: globals check-env-vars ## Set Environment to CI
-	$(eval export SYSTEM_DNS_ZONE_NAME=${DEPLOY_ENV}.ci.cloudpipeline.digital)
+	$(eval export ROOT_SYSTEM_DNS_ZONE_NAME=ci.cloudpipeline.digital)
+	$(eval export SYSTEM_DNS_ZONE_NAME=${DEPLOY_ENV}.${ROOT_SYSTEM_DNS_ZONE_NAME})
 	$(eval export AWS_ACCOUNT=ci)
 	$(eval export ENABLE_DATADOG=true)
 	$(eval export ENABLE_GITHUB=true)
 
 .PHONY: staging
 staging: globals check-env-vars ## Set Environment to Staging
-	$(eval export SYSTEM_DNS_ZONE_NAME=staging.cloudpipeline.digital)
+	$(eval export ROOT_SYSTEM_DNS_ZONE_NAME=staging.cloudpipeline.digital)
+	$(eval export SYSTEM_DNS_ZONE_NAME=${ROOT_SYSTEM_DNS_ZONE_NAME})
 	$(eval export AWS_ACCOUNT=staging)
 	$(eval export ENABLE_DATADOG=true)
 	$(eval export ENABLE_GITHUB=true)
 
 .PHONY: prod
 prod: globals check-env-vars ## Set Environment to Production
-	$(eval export SYSTEM_DNS_ZONE_NAME=cloud.service.gov.uk)
+	$(eval export ROOT_SYSTEM_DNS_ZONE_NAME=cloud.service.gov.uk)
+	$(eval export SYSTEM_DNS_ZONE_NAME=${ROOT_SYSTEM_DNS_ZONE_NAME})
 	$(eval export AWS_ACCOUNT=prod)
 	$(eval export ENABLE_DATADOG=true)
 	$(eval export ENABLE_GITHUB=true)

--- a/Makefile
+++ b/Makefile
@@ -79,8 +79,8 @@ globals:
 
 .PHONY: dev
 dev: globals check-env-vars ## Set Environment to DEV
-	$(eval export ROOT_SYSTEM_DNS_ZONE_NAME=dev.cloudpipeline.digital)
-	$(eval export SYSTEM_DNS_ZONE_NAME=${DEPLOY_ENV}.${ROOT_SYSTEM_DNS_ZONE_NAME})
+	$(eval export SYSTEM_DNS_ZONE_NAME=${DEPLOY_ENV}.dev.cloudpipeline.digital)
+	$(eval export SYSTEM_DNS_ZONE_ID=Z1QGLFML8EG6G7)
 	$(eval export AWS_ACCOUNT=dev)
 	$(eval export ENABLE_DESTROY=true)
 	$(eval export ENABLE_DATADOG ?= false)
@@ -90,24 +90,24 @@ dev: globals check-env-vars ## Set Environment to DEV
 
 .PHONY: ci
 ci: globals check-env-vars ## Set Environment to CI
-	$(eval export ROOT_SYSTEM_DNS_ZONE_NAME=ci.cloudpipeline.digital)
-	$(eval export SYSTEM_DNS_ZONE_NAME=${DEPLOY_ENV}.${ROOT_SYSTEM_DNS_ZONE_NAME})
+	$(eval export SYSTEM_DNS_ZONE_NAME=${DEPLOY_ENV}.ci.cloudpipeline.digital)
+	$(eval export SYSTEM_DNS_ZONE_ID=Z2PF4LCV9VR1MV)
 	$(eval export AWS_ACCOUNT=ci)
 	$(eval export ENABLE_DATADOG=true)
 	$(eval export ENABLE_GITHUB=true)
 
 .PHONY: staging
 staging: globals check-env-vars ## Set Environment to Staging
-	$(eval export ROOT_SYSTEM_DNS_ZONE_NAME=staging.cloudpipeline.digital)
-	$(eval export SYSTEM_DNS_ZONE_NAME=${ROOT_SYSTEM_DNS_ZONE_NAME})
+	$(eval export SYSTEM_DNS_ZONE_NAME=staging.cloudpipeline.digital)
+	$(eval export SYSTEM_DNS_ZONE_ID=ZPFAUK62IO6DS)
 	$(eval export AWS_ACCOUNT=staging)
 	$(eval export ENABLE_DATADOG=true)
 	$(eval export ENABLE_GITHUB=true)
 
 .PHONY: prod
 prod: globals check-env-vars ## Set Environment to Production
-	$(eval export ROOT_SYSTEM_DNS_ZONE_NAME=cloud.service.gov.uk)
-	$(eval export SYSTEM_DNS_ZONE_NAME=${ROOT_SYSTEM_DNS_ZONE_NAME})
+	$(eval export SYSTEM_DNS_ZONE_NAME=cloud.service.gov.uk)
+	$(eval export SYSTEM_DNS_ZONE_ID=Z39UURGVWSYTHL)
 	$(eval export AWS_ACCOUNT=prod)
 	$(eval export ENABLE_DATADOG=true)
 	$(eval export ENABLE_GITHUB=true)

--- a/concourse/pipelines/create-bosh-concourse.yml
+++ b/concourse/pipelines/create-bosh-concourse.yml
@@ -607,6 +607,7 @@ jobs:
             DEPLOY_ENV: ((deploy_env))
             AWS_DEFAULT_REGION: ((aws_region))
             TF_VAR_system_dns_zone_name: ((system_dns_zone_name))
+            TF_VAR_system_dns_zone_id: ((system_dns_zone_id))
             TF_VAR_bosh_az: ((bosh_az))
             TF_VAR_bosh_fqdn: ((bosh_fqdn))
             TF_VAR_bosh_fqdn_external: ((bosh_fqdn_external))
@@ -944,8 +945,8 @@ jobs:
             - name: paas-bootstrap
           params:
             CONCOURSE_HOSTNAME: ((concourse_hostname))
-            ROOT_SYSTEM_DNS_ZONE_NAME: ((root_system_dns_zone_name))
             SYSTEM_DNS_ZONE_NAME: ((system_dns_zone_name))
+            SYSTEM_DNS_ZONE_ID: ((system_dns_zone_id))
             AWS_DEFAULT_REGION: ((aws_region))
           run:
             path: ./paas-bootstrap/concourse/scripts/create_concourse_cert.sh
@@ -997,6 +998,7 @@ jobs:
             TF_VAR_env: ((deploy_env))
             TF_VAR_concourse_hostname: ((concourse_hostname))
             TF_VAR_system_dns_zone_name: ((system_dns_zone_name))
+            TF_VAR_system_dns_zone_id: ((system_dns_zone_id))
             AWS_DEFAULT_REGION: ((aws_region))
           run:
             path: sh
@@ -1454,6 +1456,7 @@ jobs:
           params:
             TF_VAR_env: ((deploy_env))
             TF_VAR_system_dns_zone_name: ((system_dns_zone_name))
+            TF_VAR_system_dns_zone_id: ((system_dns_zone_id))
             TF_VAR_bosh_fqdn: ((bosh_fqdn))
             TF_VAR_bosh_fqdn_external: ((bosh_fqdn_external))
             AWS_DEFAULT_REGION: ((aws_region))
@@ -1496,6 +1499,7 @@ jobs:
             TF_VAR_env: ((deploy_env))
             TF_VAR_concourse_hostname: ((concourse_hostname))
             TF_VAR_system_dns_zone_name: ((system_dns_zone_name))
+            TF_VAR_system_dns_zone_id: ((system_dns_zone_id))
             TF_VAR_git_rsa_id_pub: ""
             AWS_DEFAULT_REGION: ((aws_region))
           run:

--- a/concourse/pipelines/create-bosh-concourse.yml
+++ b/concourse/pipelines/create-bosh-concourse.yml
@@ -944,6 +944,7 @@ jobs:
             - name: paas-bootstrap
           params:
             CONCOURSE_HOSTNAME: ((concourse_hostname))
+            ROOT_SYSTEM_DNS_ZONE_NAME: ((root_system_dns_zone_name))
             SYSTEM_DNS_ZONE_NAME: ((system_dns_zone_name))
             AWS_DEFAULT_REGION: ((aws_region))
           run:

--- a/concourse/pipelines/destroy-bosh-concourse.yml
+++ b/concourse/pipelines/destroy-bosh-concourse.yml
@@ -163,6 +163,7 @@ jobs:
           params:
             TF_VAR_env: ((deploy_env))
             TF_VAR_system_dns_zone_name: ((system_dns_zone_name))
+            TF_VAR_system_dns_zone_id: ((system_dns_zone_id))
             TF_VAR_bosh_fqdn: ((bosh_fqdn))
             TF_VAR_bosh_fqdn_external: ((bosh_fqdn_external))
             AWS_DEFAULT_REGION: ((aws_region))
@@ -268,6 +269,7 @@ jobs:
             TF_VAR_env: ((deploy_env))
             TF_VAR_concourse_hostname: ((concourse_hostname))
             TF_VAR_system_dns_zone_name: ((system_dns_zone_name))
+            TF_VAR_system_dns_zone_id: ((system_dns_zone_id))
             TF_VAR_git_rsa_id_pub: anything
           run:
             path: sh
@@ -438,6 +440,7 @@ jobs:
             DEPLOY_ENV: ((deploy_env))
             AWS_DEFAULT_REGION: ((aws_region))
             TF_VAR_system_dns_zone_name: ((system_dns_zone_name))
+            TF_VAR_system_dns_zone_id: ((system_dns_zone_id))
             TF_VAR_bosh_az: ((bosh_az))
             TF_VAR_bosh_fqdn: ((bosh_fqdn))
             TF_VAR_bosh_fqdn_external: ((bosh_fqdn_external))

--- a/concourse/scripts/create_concourse_cert.sh
+++ b/concourse/scripts/create_concourse_cert.sh
@@ -61,7 +61,7 @@ if [ "null" = "${dns_validation_record}" ] || [ "null" = "${dns_validation_value
   exit 1
 fi
 
-zone_id=$(aws route53 list-hosted-zones-by-name --dns-name dev.cloudpipeline.digital --query 'HostedZones[0].Id' --output text | cut -d '/' -f 3)
+zone_id=$(aws route53 list-hosted-zones-by-name --dns-name "${ROOT_SYSTEM_DNS_ZONE_NAME}" --query 'HostedZones[0].Id' --output text | cut -d '/' -f 3)
 
 echo "Upserting DNS validation record: ${dns_validation_record}"
 

--- a/concourse/scripts/create_concourse_cert.sh
+++ b/concourse/scripts/create_concourse_cert.sh
@@ -61,11 +61,9 @@ if [ "null" = "${dns_validation_record}" ] || [ "null" = "${dns_validation_value
   exit 1
 fi
 
-zone_id=$(aws route53 list-hosted-zones-by-name --dns-name "${ROOT_SYSTEM_DNS_ZONE_NAME}" --query 'HostedZones[0].Id' --output text | cut -d '/' -f 3)
-
 echo "Upserting DNS validation record: ${dns_validation_record}"
 
-aws route53 change-resource-record-sets --hosted-zone-id "${zone_id}" --change-batch "$(get_route53_change_batch UPSERT)" > /dev/null
+aws route53 change-resource-record-sets --hosted-zone-id "${SYSTEM_DNS_ZONE_ID}" --change-batch "$(get_route53_change_batch UPSERT)" > /dev/null
 
 cat <<EOT
 
@@ -86,7 +84,7 @@ for _ in $(seq 40); do
     echo "Cert issued successfully."
 
     echo "Deleting DNS validation record."
-    aws route53 change-resource-record-sets --hosted-zone-id "${zone_id}" --change-batch "$(get_route53_change_batch DELETE)" > /dev/null
+    aws route53 change-resource-record-sets --hosted-zone-id "${SYSTEM_DNS_ZONE_ID}" --change-batch "$(get_route53_change_batch DELETE)" > /dev/null
 
     exit 0
   fi

--- a/concourse/scripts/pipelines.sh
+++ b/concourse/scripts/pipelines.sh
@@ -18,8 +18,8 @@ aws_region: ${AWS_DEFAULT_REGION:-eu-west-1}
 log_level: ${LOG_LEVEL:-}
 concourse_hostname: ${CONCOURSE_HOSTNAME}
 concourse_url: ${CONCOURSE_URL}
-root_system_dns_zone_name: ${ROOT_SYSTEM_DNS_ZONE_NAME}
 system_dns_zone_name: ${SYSTEM_DNS_ZONE_NAME}
+system_dns_zone_id: ${SYSTEM_DNS_ZONE_ID}
 bosh_az: ${BOSH_AZ:-eu-west-1a}
 bosh_manifest_state: bosh-manifest-state-${BOSH_AZ:-eu-west-1a}.json
 bosh_fqdn: ${BOSH_FQDN}

--- a/concourse/scripts/pipelines.sh
+++ b/concourse/scripts/pipelines.sh
@@ -18,6 +18,7 @@ aws_region: ${AWS_DEFAULT_REGION:-eu-west-1}
 log_level: ${LOG_LEVEL:-}
 concourse_hostname: ${CONCOURSE_HOSTNAME}
 concourse_url: ${CONCOURSE_URL}
+root_system_dns_zone_name: ${ROOT_SYSTEM_DNS_ZONE_NAME}
 system_dns_zone_name: ${SYSTEM_DNS_ZONE_NAME}
 bosh_az: ${BOSH_AZ:-eu-west-1a}
 bosh_manifest_state: bosh-manifest-state-${BOSH_AZ:-eu-west-1a}.json

--- a/manifests/runtime-config/spec/support/manifest_helpers.rb
+++ b/manifests/runtime-config/spec/support/manifest_helpers.rb
@@ -26,6 +26,7 @@ private
     ENV["AWS_ACCOUNT"] = "dev"
     ENV["DATADOG_API_KEY"] = "abcd1234"
     ENV["ENABLE_DATADOG"] = "true"
+    ENV["ROOT_SYSTEM_DNS_ZONE_NAME"] = ManifestHelpers::SYSTEM_DNS_ZONE_NAME
     ENV["SYSTEM_DNS_ZONE_NAME"] = ManifestHelpers::SYSTEM_DNS_ZONE_NAME
   end
 

--- a/manifests/runtime-config/spec/support/manifest_helpers.rb
+++ b/manifests/runtime-config/spec/support/manifest_helpers.rb
@@ -26,7 +26,6 @@ private
     ENV["AWS_ACCOUNT"] = "dev"
     ENV["DATADOG_API_KEY"] = "abcd1234"
     ENV["ENABLE_DATADOG"] = "true"
-    ENV["ROOT_SYSTEM_DNS_ZONE_NAME"] = ManifestHelpers::SYSTEM_DNS_ZONE_NAME
     ENV["SYSTEM_DNS_ZONE_NAME"] = ManifestHelpers::SYSTEM_DNS_ZONE_NAME
   end
 

--- a/terraform/ci.tfvars
+++ b/terraform/ci.tfvars
@@ -1,3 +1,2 @@
 aws_account = "ci"
-system_dns_zone_id = "Z2PF4LCV9VR1MV"
 bosh_db_maintenance_window = "Tue:06:00-Tue:07:00"

--- a/terraform/dev.tfvars
+++ b/terraform/dev.tfvars
@@ -1,3 +1,2 @@
 aws_account = "dev"
-system_dns_zone_id = "Z1QGLFML8EG6G7"
 bosh_db_maintenance_window = "Mon:06:00-Mon:07:00"

--- a/terraform/prod.tfvars
+++ b/terraform/prod.tfvars
@@ -1,5 +1,4 @@
 aws_account = "prod"
-system_dns_zone_id = "Z39UURGVWSYTHL"
 bosh_db_multi_az = "true"
 bosh_db_backup_retention_period = "35"
 bosh_db_skip_final_snapshot = "false"

--- a/terraform/staging.tfvars
+++ b/terraform/staging.tfvars
@@ -1,5 +1,4 @@
 aws_account = "staging"
-system_dns_zone_id = "ZPFAUK62IO6DS"
 bosh_db_multi_az = "true"
 bosh_db_backup_retention_period = "35"
 bosh_db_skip_final_snapshot = "false"


### PR DESCRIPTION
## What

Set SYSTEM_DNS_ZONE_ID in the Makefile for the different envs.

Instead of passing the root DNS zone name and looking up the zone id in the create certificate script just use the values we already have as Terraform variables. To avoid duplicating configuration we move the zone ids to the Makefile and pass them to Terraform and the cert script.

## How to review

1. Bootstrap a new BOSH + Concourse deployment to a new environment and validate in ACM if the certificate was created successfully.
2. Destroy the new deployment

For the persistent environments IMHO it should be enough if we run the create-bosh-concourse pipelines.

## Before merge

Squash the two commits as the first commit is superseeded by the second one. Keep the second commit's commit message only.

## Who can review

Not @bandesz
