### PR TITLE
[#153119879] Set serial:true for all Concourse jobs

### DIFF
--- a/concourse/pipelines/create-bosh-concourse.yml
+++ b/concourse/pipelines/create-bosh-concourse.yml
@@ -350,6 +350,7 @@ jobs:
             file: updated-vpc-tfstate/vpc.tfstate
 
   - name: generate-secrets
+    serial: true
     plan:
       - aggregate:
         - get: paas-bootstrap
@@ -545,6 +546,7 @@ jobs:
             file: generated-concourse-secrets/concourse-secrets.yml
 
   - name: bosh-terraform
+    serial: true
     plan:
       - aggregate:
         - get: pipeline-trigger
@@ -816,6 +818,7 @@ jobs:
             file: runtime-config/runtime-config.yml
 
   - name: bosh-deploy
+    serial: true
     plan:
       - aggregate:
         - get: pipeline-trigger
@@ -1300,6 +1303,7 @@ jobs:
                   --basic-auth-username admin --basic-auth-password "${CONCOURSE_ATC_PASSWORD}" --non-interactive
 
   - name: post-deploy
+    serial: true
     plan:
       - aggregate:
         - get: pipeline-trigger


### PR DESCRIPTION
## What

While working on a story I noticed that it was possible to run two parallel
instances of the `bosh-terraform` job, both of which were trying to modify
the same resources.

Apply `serial: true` to all other jobs in this pipeline so that they only
execute once at a given time otherwise there will be race conditions and
conflicts.

## How to review

Code review if you're comfortable with the changes. Otherwise to test:

1. Checkout this branch:

        git fetch && git checkout bugfix/serial_jobs
1. Upload the pipeline changes (it doesn't do self update):

        BRANCH=$(git rev-parse --abbrev-ref HEAD) make dev deployer-concourse bootstrap`
1. Trigger the `bosh-terraform` job twice and confirm that the 2nd run stays in a pending state while the 1st is running. You might need to run the pipeline from the beginning so that the job has all the resources it needs. You can pause the jobs after it though, so you don't need to wait for the whole pipeline.
1. Run the `destroy-bosh-concourse` pipeline to clean up.

## Who can review

Anyone.
