### PR TITLE
[#154202936] Stemcell bump for CVE-2017-5754 (aka Meltdown)

### DIFF
--- a/manifests/bosh-manifest/bosh-manifest.yml
+++ b/manifests/bosh-manifest/bosh-manifest.yml
@@ -152,8 +152,8 @@ resource_pools:
 - name: bosh
   network: private
   stemcell:
-    url: https://bosh.io/d/stemcells/bosh-aws-xen-hvm-ubuntu-trusty-go_agent?v=3468.13
-    sha1: 50416e0f48ff2dc3d954ac5082dda0965d97b93a
+    url: https://bosh.io/d/stemcells/bosh-aws-xen-hvm-ubuntu-trusty-go_agent?v=3468.16
+    sha1: f805227b06823daf8be33df61d9a78534423a451
   cloud_properties:
     instance_type: t2.medium
     ephemeral_disk: {size: 40000, type: gp2}

--- a/manifests/concourse-manifest/concourse-base.yml
+++ b/manifests/concourse-manifest/concourse-base.yml
@@ -2,7 +2,7 @@
 meta:
   stemcell:
     name: bosh-aws-xen-hvm-ubuntu-trusty-go_agent
-    version: "3468.13"
+    version: "3468.16"
 
   zone: (( grab terraform_outputs.zone0 ))
 


### PR DESCRIPTION
## What

Apply mitigations for CVE-2017-5754 (aka Meltdown)

Links:

CVE: https://people.canonical.com/~ubuntu-security/cve/2017/CVE-2017-5754.html
USN: https://usn.ubuntu.com/usn/usn-3522-2/
CF announcement: https://www.cloudfoundry.org/usn-3522-2/

## How to review

Test an upgrade from current master applies cleanly. It should be sufficient to run the `create-bosh-concourse` pipeline on the deployed concourse.

## Who can review

Not @alext