### PR TITLE
[#153119879] Upgrade Terraform

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ rvm:
   - 2.2.6
 env:
   global:
-    - TF_VERSION="0.8.5"
+    - TF_VERSION="0.11.1"
     - SPRUCE_VERSION="1.8.9"
 
 addons:

--- a/Makefile
+++ b/Makefile
@@ -48,14 +48,7 @@ list_merge_keys: ## List all GPG keys allowed to sign merge commits.
 	done
 
 lint_terraform:
-	$(eval export TF_VAR_system_dns_zone_name=service.com)
-	$(eval export TF_VAR_apps_dns_zone_name=apps.com)
-	find terraform -mindepth 1 -maxdepth 1 -type d -print0 | xargs -0 -n 1 -t terraform graph > /dev/null
-	@if [ "$$(terraform fmt -write=false terraform)" != "" ] ; then \
-		echo "Use 'terraform fmt' to fix HCL formatting:"; \
-		terraform fmt -write=false -diff=true terraform ; \
-		exit 1; \
-	fi
+	@./scripts/lint_terraform.sh
 
 lint_shellcheck:
 	find . -name '*.sh' -not -path '*/vendor/*' | xargs $(SHELLCHECK)

--- a/concourse/pipelines/create-bosh-concourse.yml
+++ b/concourse/pipelines/create-bosh-concourse.yml
@@ -213,12 +213,12 @@ jobs:
             - -c
             - -x
             - |
+              cp bucket-state/bucket.tfstate updated-bucket-state/bucket.tfstate
               terraform init paas-bootstrap/terraform/bucket
               terraform apply \
                 -auto-approve=true \
                 -var-file="paas-bootstrap/terraform/((aws_account)).tfvars" \
-                -state=bucket-state/bucket.tfstate \
-                -state-out=updated-bucket-state/bucket.tfstate \
+                -state=updated-bucket-state/bucket.tfstate \
                 paas-bootstrap/terraform/bucket
         on_success:
           put: bucket-terraform-state
@@ -342,13 +342,13 @@ jobs:
             - -c
             - |
               CONCOURSE_EGRESS_IP=$(wget -q -O - http://169.254.169.254/latest/meta-data/public-ipv4)
+              cp vpc-tfstate/vpc.tfstate updated-vpc-tfstate/vpc.tfstate
               terraform init paas-bootstrap/terraform/vpc
               terraform apply \
                 -auto-approve=true \
                 -var concourse_egress_cidr="${CONCOURSE_EGRESS_IP}/32" \
                 -var-file="paas-bootstrap/terraform/((aws_account)).tfvars" \
-                -state=vpc-tfstate/vpc.tfstate \
-                -state-out=updated-vpc-tfstate/vpc.tfstate \
+                -state=updated-vpc-tfstate/vpc.tfstate \
                 paas-bootstrap/terraform/vpc
         ensure:
           put: vpc-tfstate
@@ -629,13 +629,15 @@ jobs:
                 cp ssh-public-key/id_rsa.pub paas-bootstrap/terraform/bosh
                 cp bosh-ssh-public-key/bosh_id_rsa.pub paas-bootstrap/terraform/bosh
                 CONCOURSE_EGRESS_IP=$(wget -q -O - http://169.254.169.254/latest/meta-data/public-ipv4)
+
+                cp bosh-tfstate/bosh.tfstate updated-bosh-tfstate/bosh.tfstate
                 terraform init paas-bootstrap/terraform/bosh
                 terraform apply \
                   -auto-approve=true \
                   -var concourse_egress_cidr="${CONCOURSE_EGRESS_IP}/32" \
                   -var env="((deploy_env))" \
                   -var-file="paas-bootstrap/terraform/((aws_account)).tfvars" \
-                  -state=bosh-tfstate/bosh.tfstate -state-out=updated-bosh-tfstate/bosh.tfstate \
+                  -state=updated-bosh-tfstate/bosh.tfstate \
                   paas-bootstrap/terraform/bosh
         ensure:
           put: bosh-tfstate
@@ -1020,13 +1022,14 @@ jobs:
               export TF_VAR_git_rsa_id_pub
               TF_VAR_git_rsa_id_pub=$(cat git-ssh-public-key/git_id_rsa.pub)
               CONCOURSE_EGRESS_IP=$(wget -q -O - http://169.254.169.254/latest/meta-data/public-ipv4)
+
+              cp concourse-tfstate/concourse.tfstate updated-concourse-tfstate/concourse.tfstate
               terraform init paas-bootstrap/terraform/concourse
               terraform apply \
                 -auto-approve=true \
                 -var concourse_egress_cidr="${CONCOURSE_EGRESS_IP}/32" \
                 -var-file="paas-bootstrap/terraform/((aws_account)).tfvars" \
-                -state=concourse-tfstate/concourse.tfstate \
-                -state-out=updated-concourse-tfstate/concourse.tfstate \
+                -state=updated-concourse-tfstate/concourse.tfstate \
                 paas-bootstrap/terraform/concourse
         ensure:
           put: concourse-tfstate
@@ -1437,14 +1440,14 @@ jobs:
             - -e
             - -c
             - |
+              cp vpc-tfstate/vpc.tfstate updated-vpc-tfstate/vpc.tfstate
               terraform init paas-bootstrap/terraform/vpc
               terraform apply \
                 -auto-approve=true \
                 -target=aws_security_group.office-access-ssh \
                 -var-file="paas-bootstrap/terraform/((aws_account)).tfvars" \
                 -target=aws_subnet.infra \
-                -state=vpc-tfstate/vpc.tfstate \
-                -state-out=updated-vpc-tfstate/vpc.tfstate \
+                -state=updated-vpc-tfstate/vpc.tfstate \
                 paas-bootstrap/terraform/vpc
         ensure:
           put: vpc-tfstate
@@ -1481,12 +1484,13 @@ jobs:
               . vpc-terraform-outputs/tfvars.sh
               export TF_VAR_secrets_bosh_postgres_password=""
               export TF_VAR_bosh_az=""
+
+              cp bosh-tfstate/bosh.tfstate updated-bosh-tfstate/bosh.tfstate
               terraform init paas-bootstrap/terraform/bosh
               terraform apply \
                 -auto-approve=true \
                 -target=aws_security_group.bosh \
-                -state=bosh-tfstate/bosh.tfstate \
-                -state-out=updated-bosh-tfstate/bosh.tfstate \
+                -state=updated-bosh-tfstate/bosh.tfstate \
                 -var-file="paas-bootstrap/terraform/((aws_account)).tfvars" \
                 paas-bootstrap/terraform/bosh
         ensure:
@@ -1525,13 +1529,13 @@ jobs:
               . vpc-terraform-outputs/tfvars.sh
               . bosh-terraform-outputs/tfvars.sh
 
+              cp concourse-tfstate/concourse.tfstate updated-concourse-tfstate/concourse.tfstate
               terraform init paas-bootstrap/terraform/concourse
               terraform apply \
                 -auto-approve=true \
                 -target=aws_security_group.concourse \
                 -var-file="paas-bootstrap/terraform/((aws_account)).tfvars" \
-                -state=concourse-tfstate/concourse.tfstate \
-                -state-out=updated-concourse-tfstate/concourse.tfstate \
+                -state=updated-concourse-tfstate/concourse.tfstate \
                 paas-bootstrap/terraform/concourse
         ensure:
           put: concourse-tfstate

--- a/concourse/pipelines/create-bosh-concourse.yml
+++ b/concourse/pipelines/create-bosh-concourse.yml
@@ -197,7 +197,7 @@ jobs:
             type: docker-image
             source:
               repository: governmentpaas/terraform
-              tag: 895cf6752c8ec64af05a3a735186b90acd3db65a
+              tag: 9cad30b5d5889a0b72173f39701d1620e24df82c
           params:
             TF_VAR_env: ((deploy_env))
             TF_VAR_state_bucket: ((state_bucket))
@@ -211,8 +211,12 @@ jobs:
             path: sh
             args:
             - -c
+            - -x
             - |
-              terraform apply -var-file="paas-bootstrap/terraform/((aws_account)).tfvars" \
+              terraform init paas-bootstrap/terraform/bucket
+              terraform apply \
+                -auto-approve=true \
+                -var-file="paas-bootstrap/terraform/((aws_account)).tfvars" \
                 -state=bucket-state/bucket.tfstate \
                 -state-out=updated-bucket-state/bucket.tfstate \
                 paas-bootstrap/terraform/bucket
@@ -322,7 +326,7 @@ jobs:
             type: docker-image
             source:
               repository: governmentpaas/terraform
-              tag: 895cf6752c8ec64af05a3a735186b90acd3db65a
+              tag: 9cad30b5d5889a0b72173f39701d1620e24df82c
           inputs:
           - name: paas-bootstrap
           - name: vpc-tfstate
@@ -338,7 +342,9 @@ jobs:
             - -c
             - |
               CONCOURSE_EGRESS_IP=$(wget -q -O - http://169.254.169.254/latest/meta-data/public-ipv4)
+              terraform init paas-bootstrap/terraform/vpc
               terraform apply \
+                -auto-approve=true \
                 -var concourse_egress_cidr="${CONCOURSE_EGRESS_IP}/32" \
                 -var-file="paas-bootstrap/terraform/((aws_account)).tfvars" \
                 -state=vpc-tfstate/vpc.tfstate \
@@ -594,7 +600,7 @@ jobs:
             type: docker-image
             source:
               repository: governmentpaas/terraform
-              tag: 895cf6752c8ec64af05a3a735186b90acd3db65a
+              tag: 9cad30b5d5889a0b72173f39701d1620e24df82c
           inputs:
             - name: paas-bootstrap
             - name: terraform-variables
@@ -623,7 +629,9 @@ jobs:
                 cp ssh-public-key/id_rsa.pub paas-bootstrap/terraform/bosh
                 cp bosh-ssh-public-key/bosh_id_rsa.pub paas-bootstrap/terraform/bosh
                 CONCOURSE_EGRESS_IP=$(wget -q -O - http://169.254.169.254/latest/meta-data/public-ipv4)
+                terraform init paas-bootstrap/terraform/bosh
                 terraform apply \
+                  -auto-approve=true \
                   -var concourse_egress_cidr="${CONCOURSE_EGRESS_IP}/32" \
                   -var env="((deploy_env))" \
                   -var-file="paas-bootstrap/terraform/((aws_account)).tfvars" \
@@ -984,7 +992,7 @@ jobs:
             type: docker-image
             source:
               repository: governmentpaas/terraform
-              tag: 895cf6752c8ec64af05a3a735186b90acd3db65a
+              tag: 9cad30b5d5889a0b72173f39701d1620e24df82c
           inputs:
           - name: paas-bootstrap
           - name: vpc-terraform-outputs
@@ -1012,7 +1020,9 @@ jobs:
               export TF_VAR_git_rsa_id_pub
               TF_VAR_git_rsa_id_pub=$(cat git-ssh-public-key/git_id_rsa.pub)
               CONCOURSE_EGRESS_IP=$(wget -q -O - http://169.254.169.254/latest/meta-data/public-ipv4)
+              terraform init paas-bootstrap/terraform/concourse
               terraform apply \
+                -auto-approve=true \
                 -var concourse_egress_cidr="${CONCOURSE_EGRESS_IP}/32" \
                 -var-file="paas-bootstrap/terraform/((aws_account)).tfvars" \
                 -state=concourse-tfstate/concourse.tfstate \
@@ -1412,7 +1422,7 @@ jobs:
             type: docker-image
             source:
               repository: governmentpaas/terraform
-              tag: 895cf6752c8ec64af05a3a735186b90acd3db65a
+              tag: 9cad30b5d5889a0b72173f39701d1620e24df82c
           inputs:
           - name: paas-bootstrap
           - name: vpc-tfstate
@@ -1427,7 +1437,9 @@ jobs:
             - -e
             - -c
             - |
+              terraform init paas-bootstrap/terraform/vpc
               terraform apply \
+                -auto-approve=true \
                 -target=aws_security_group.office-access-ssh \
                 -var-file="paas-bootstrap/terraform/((aws_account)).tfvars" \
                 -target=aws_subnet.infra \
@@ -1446,7 +1458,7 @@ jobs:
             type: docker-image
             source:
               repository: governmentpaas/terraform
-              tag: 895cf6752c8ec64af05a3a735186b90acd3db65a
+              tag: 9cad30b5d5889a0b72173f39701d1620e24df82c
           inputs:
           - name: paas-bootstrap
           - name: vpc-terraform-outputs
@@ -1469,7 +1481,9 @@ jobs:
               . vpc-terraform-outputs/tfvars.sh
               export TF_VAR_secrets_bosh_postgres_password=""
               export TF_VAR_bosh_az=""
+              terraform init paas-bootstrap/terraform/bosh
               terraform apply \
+                -auto-approve=true \
                 -target=aws_security_group.bosh \
                 -state=bosh-tfstate/bosh.tfstate \
                 -state-out=updated-bosh-tfstate/bosh.tfstate \
@@ -1487,7 +1501,7 @@ jobs:
             type: docker-image
             source:
               repository: governmentpaas/terraform
-              tag: 895cf6752c8ec64af05a3a735186b90acd3db65a
+              tag: 9cad30b5d5889a0b72173f39701d1620e24df82c
           inputs:
           - name: paas-bootstrap
           - name: vpc-terraform-outputs
@@ -1511,7 +1525,9 @@ jobs:
               . vpc-terraform-outputs/tfvars.sh
               . bosh-terraform-outputs/tfvars.sh
 
+              terraform init paas-bootstrap/terraform/concourse
               terraform apply \
+                -auto-approve=true \
                 -target=aws_security_group.concourse \
                 -var-file="paas-bootstrap/terraform/((aws_account)).tfvars" \
                 -state=concourse-tfstate/concourse.tfstate \

--- a/concourse/pipelines/destroy-bosh-concourse.yml
+++ b/concourse/pipelines/destroy-bosh-concourse.yml
@@ -153,7 +153,7 @@ jobs:
             type: docker-image
             source:
               repository: governmentpaas/terraform
-              tag: 895cf6752c8ec64af05a3a735186b90acd3db65a
+              tag: 9cad30b5d5889a0b72173f39701d1620e24df82c
           inputs:
             - name: paas-bootstrap
             - name: vpc-terraform-outputs
@@ -177,7 +177,9 @@ jobs:
               export TF_VAR_secrets_bosh_postgres_password=""
               export TF_VAR_bosh_az=""
               CONCOURSE_EGRESS_IP=$(wget -q -O - http://169.254.169.254/latest/meta-data/public-ipv4)
+              terraform init paas-bootstrap/terraform/bosh
               terraform apply \
+                -auto-approve=true \
                 -var concourse_egress_cidr="${CONCOURSE_EGRESS_IP}/32" \
                 -target=aws_security_group.bosh \
                 -state=bosh-tfstate/bosh.tfstate -state-out=updated-bosh-tfstate/bosh.tfstate \
@@ -257,7 +259,7 @@ jobs:
             type: docker-image
             source:
               repository: governmentpaas/terraform
-              tag: 895cf6752c8ec64af05a3a735186b90acd3db65a
+              tag: 9cad30b5d5889a0b72173f39701d1620e24df82c
           inputs:
             - name: paas-bootstrap
             - name: vpc-terraform-outputs
@@ -279,6 +281,7 @@ jobs:
             - |
               . vpc-terraform-outputs/tfvars.sh
               touch concourse.crt concourse.key paas-bootstrap/terraform/concourse/concourse_id_rsa.pub
+              terraform init paas-bootstrap/terraform/concourse
               terraform destroy -force \
                 -var-file="paas-bootstrap/terraform/((aws_account)).tfvars" \
                 -state=concourse-tfstate/concourse.tfstate -state-out=updated-concourse-tfstate/concourse.tfstate \
@@ -429,7 +432,7 @@ jobs:
             type: docker-image
             source:
               repository: governmentpaas/terraform
-              tag: 895cf6752c8ec64af05a3a735186b90acd3db65a
+              tag: 9cad30b5d5889a0b72173f39701d1620e24df82c
           inputs:
             - name: paas-bootstrap
             - name: terraform-variables
@@ -455,6 +458,7 @@ jobs:
 
                 touch paas-bootstrap/terraform/bosh/id_rsa.pub paas-bootstrap/terraform/bosh/bosh_id_rsa.pub
                 CONCOURSE_EGRESS_IP=$(wget -q -O - http://169.254.169.254/latest/meta-data/public-ipv4)
+                terraform init paas-bootstrap/terraform/bosh
                 terraform destroy -force \
                   -var concourse_egress_cidr="${CONCOURSE_EGRESS_IP}/32" \
                   -var env="((deploy_env))" \
@@ -484,7 +488,7 @@ jobs:
             type: docker-image
             source:
               repository: governmentpaas/terraform
-              tag: 895cf6752c8ec64af05a3a735186b90acd3db65a
+              tag: 9cad30b5d5889a0b72173f39701d1620e24df82c
           params:
               TF_VAR_env: ((deploy_env))
               AWS_DEFAULT_REGION: ((aws_region))
@@ -499,6 +503,7 @@ jobs:
             - -e
             - -c
             - |
+              terraform init paas-bootstrap/terraform/vpc
               terraform destroy -force \
                 -var-file="paas-bootstrap/terraform/((aws_account)).tfvars" \
                 -state=vpc-tfstate/vpc.tfstate -state-out=updated-vpc-tfstate/vpc.tfstate \
@@ -526,7 +531,7 @@ jobs:
             type: docker-image
             source:
               repository: governmentpaas/terraform
-              tag: 895cf6752c8ec64af05a3a735186b90acd3db65a
+              tag: 9cad30b5d5889a0b72173f39701d1620e24df82c
           params:
               TF_VAR_env: ((deploy_env))
               TF_VAR_state_bucket: ((state_bucket))
@@ -540,6 +545,7 @@ jobs:
             - -e
             - -c
             - |
+              terraform init paas-bootstrap/terraform/bucket
               terraform destroy -force \
                 -var-file="paas-bootstrap/terraform/((aws_account)).tfvars" \
                 -state=bucket-terraform-state/bucket.tfstate \

--- a/concourse/pipelines/destroy-bosh-concourse.yml
+++ b/concourse/pipelines/destroy-bosh-concourse.yml
@@ -177,12 +177,14 @@ jobs:
               export TF_VAR_secrets_bosh_postgres_password=""
               export TF_VAR_bosh_az=""
               CONCOURSE_EGRESS_IP=$(wget -q -O - http://169.254.169.254/latest/meta-data/public-ipv4)
+
+              cp bosh-tfstate/bosh.tfstate updated-bosh-tfstate/bosh.tfstate
               terraform init paas-bootstrap/terraform/bosh
               terraform apply \
                 -auto-approve=true \
                 -var concourse_egress_cidr="${CONCOURSE_EGRESS_IP}/32" \
                 -target=aws_security_group.bosh \
-                -state=bosh-tfstate/bosh.tfstate -state-out=updated-bosh-tfstate/bosh.tfstate \
+                -state=updated-bosh-tfstate/bosh.tfstate \
                 -var-file="paas-bootstrap/terraform/((aws_account)).tfvars" \
                 paas-bootstrap/terraform/bosh
         ensure:
@@ -281,10 +283,12 @@ jobs:
             - |
               . vpc-terraform-outputs/tfvars.sh
               touch concourse.crt concourse.key paas-bootstrap/terraform/concourse/concourse_id_rsa.pub
+
+              cp concourse-tfstate/concourse.tfstate updated-concourse-tfstate/concourse.tfstate
               terraform init paas-bootstrap/terraform/concourse
               terraform destroy -force \
                 -var-file="paas-bootstrap/terraform/((aws_account)).tfvars" \
-                -state=concourse-tfstate/concourse.tfstate -state-out=updated-concourse-tfstate/concourse.tfstate \
+                -state=updated-concourse-tfstate/concourse.tfstate \
                 paas-bootstrap/terraform/concourse
         ensure:
           put: concourse-tfstate
@@ -458,12 +462,14 @@ jobs:
 
                 touch paas-bootstrap/terraform/bosh/id_rsa.pub paas-bootstrap/terraform/bosh/bosh_id_rsa.pub
                 CONCOURSE_EGRESS_IP=$(wget -q -O - http://169.254.169.254/latest/meta-data/public-ipv4)
+
+                cp bosh-tfstate/bosh.tfstate updated-bosh-tfstate/bosh.tfstate
                 terraform init paas-bootstrap/terraform/bosh
                 terraform destroy -force \
                   -var concourse_egress_cidr="${CONCOURSE_EGRESS_IP}/32" \
                   -var env="((deploy_env))" \
                   -var-file="paas-bootstrap/terraform/((aws_account)).tfvars" \
-                  -state=bosh-tfstate/bosh.tfstate -state-out=updated-bosh-tfstate/bosh.tfstate \
+                  -state=updated-bosh-tfstate/bosh.tfstate \
                   paas-bootstrap/terraform/bosh
         ensure:
           put: bosh-tfstate
@@ -503,10 +509,11 @@ jobs:
             - -e
             - -c
             - |
+              cp vpc-tfstate/vpc.tfstate updated-vpc-tfstate/vpc.tfstate
               terraform init paas-bootstrap/terraform/vpc
               terraform destroy -force \
                 -var-file="paas-bootstrap/terraform/((aws_account)).tfvars" \
-                -state=vpc-tfstate/vpc.tfstate -state-out=updated-vpc-tfstate/vpc.tfstate \
+                -state=updated-vpc-tfstate/vpc.tfstate \
                 paas-bootstrap/terraform/vpc
         ensure:
           put: vpc-tfstate

--- a/scripts/lint_terraform.sh
+++ b/scripts/lint_terraform.sh
@@ -1,0 +1,14 @@
+#!/bin/sh
+set -eu
+
+TMPDIR=${TMPDIR:-/tmp}
+TF_DATA_DIR=$(mktemp -d "${TMPDIR}/terraform_lint.XXXXXX")
+trap 'rm -r "${TF_DATA_DIR}"' EXIT
+
+export TF_DATA_DIR
+
+for dir in terraform/*/; do
+  terraform init "${dir}" >/dev/null
+  terraform validate -check-variables=false "${dir}" >/dev/null
+  terraform fmt -check -diff "${dir}"
+done


### PR DESCRIPTION
## What

Upgrade Terraform to latest stable version.

## How to review

There are two variations that you could test at your own discretion.

You can use either a Build or Deployer Concourse, but you might want to use Build so that you can test alphagov/paas-release-ci#49 at the same time.

### Existing environment

1. Create a Bootstrap Concourse and Build/Deployer Concourse from `master`.
1. Checkout this branch and re-upload the pipelines to your Bootstrap Concourse.
1. Run the pipelines and check that all of the Terraform jobs complete and only modify the Vagrant IP in an existing security group.

### New environment

1. Checkout this branch and create a new Bootstrap Concourse and Build/Deployer Concourse.
1. Run the pipelines and check that all of the Terraform jobs complete and only modify the Vagrant IP in an existing security group.

:bee: :bee: :bee: Bee-fore merging :bee: :bee: :bee:

1. Merge alphagov/paas-docker-cloudfoundry-tools#107
1. Wait for Docker Hub to build and tag the container.
1. Amend the `wip` commit to use the Docker image tag that matches the merge commit from alphagov/paas-docker-cloudfoundry-tools#107

## Who can review

Not @dcarley or @46bit.
  