### PR TITLE
bosh-shell improvements

### DIFF
--- a/scripts/bosh-cli.sh
+++ b/scripts/bosh-cli.sh
@@ -20,4 +20,5 @@ docker run \
     --env "BOSH_ID_RSA" \
     --env "BOSH_IP" \
     --env "BOSH_ADMIN_PASSWORD" \
-    governmentpaas/bosh-shell:f804160a7e6f455ef206b56eab25063908703dd5
+    --env "BOSH_DEPLOYMENT=${DEPLOY_ENV}" \
+    governmentpaas/bosh-shell:2b4604fe69274908af304c15f28ca8dd657b0221


### PR DESCRIPTION
## What

This has two changes:

- it automatically downloads the manifest and selects the deployment based
  on the `BOSH_DEPLOYMENT` environment variable that I've added
- it no longer uses a separate command for `bosh ssh` using the director as
  a gateway

## How to review

1. Wait for [Docker Hub to finally build](https://hub.docker.com/r/governmentpaas/bosh-shell/builds/bxtr5qnkscbseuo3wmhco95/)
1. Checkout this branch
1. Run `make dev bosh-cli`
1. Run `bosh ssh api/0`
1. Confirm that you are given a shell on the VM without any other actions required

## :bee:-fore merging

1. Merge alphagov/paas-docker-cloudfoundry-tools#109
1. Update the `wip` commit to use the Docker tag which matches the merge commit ref

## Who can review

Anyone, but possibly @alext while on support.