### PR TITLE
[#126788891] Change default ELB security policy to ELBSecurityPolicy-TLS-1-2-2017-01

### DIFF
--- a/terraform/globals.tf
+++ b/terraform/globals.tf
@@ -119,7 +119,7 @@ variable "admin_cidrs" {
 /* See https://docs.aws.amazon.com/elasticloadbalancing/latest/classic/elb-security-policy-table.html */
 variable "default_elb_security_policy" {
   description = "Which Security policy to use for ELBs. This controls things like available SSL protocols/ciphers."
-  default     = "ELBSecurityPolicy-2016-08"
+  default     = "ELBSecurityPolicy-TLS-1-2-2017-01"
 }
 
 variable "assets_prefix" {


### PR DESCRIPTION
## What

To make the ELB traffic more secure we want to remove support for TLSv1 and TLSv1.1.

The ELBSecurityPolicy-TLS-1-2-2017-01 additionally disables the following SSL ciphers:
 - ECDHE-ECDSA-AES128-SHA
 - ECDHE-ECDSA-AES256-SHA
 - ECDHE-RSA-AES128-SHA
 - ECDHE-RSA-AES256-SHA
 - AES128-SHA
 - AES256-SHA

The change effects the Concourse ELB.

## How to review

1. Update and run your create-bosh-concourse pipeline
    ```
    $ BRANCH=elb_require_tls12_126788891 make dev deployer-concourse  pipelines
    ```

2. Check if Concourse doesn't accept TLSv1 or TLSv1.1 connections:
    ```
    $ openssl s_client -connect deployer.${DEPLOY_ENV}.dev.cloudpipeline.digital:443 -tls1
    CONNECTED(00000006)
    write:errno=54
    [...]

    $ openssl s_client -connect deployer.${DEPLOY_ENV}.dev.cloudpipeline.digital:443 -tls1_1
    CONNECTED(00000006)
    write:errno=54
    ```

3. Check if Concourse accepts TLSv1.2 connections:
    ```
    $ openssl s_client -connect deployer.${DEPLOY_ENV}.dev.cloudpipeline.digital:443 -tls1_2
    CONNECTED(00000006)
    depth=3 C = US, ST = Arizona, L = Scottsdale, O = "Starfield Technologies, Inc.", CN = Starfield Services Root Certificate Authority - G2
    [...]
    ---
    [waiting to receive]
    ```

## Who can review

Not @bandesz
