### PR TITLE
[Support] Fix pinning of paas-bootstrap resource in pipeline

### DIFF
--- a/concourse/pipelines/create-bosh-concourse.yml
+++ b/concourse/pipelines/create-bosh-concourse.yml
@@ -256,6 +256,7 @@ jobs:
         trigger: true
         passed: ['init-bucket']
       - get: paas-bootstrap
+        passed: ['init-bucket']
       - task: s3init
         config:
           platform: linux


### PR DESCRIPTION
## What

The version of this resource used in the s3init job wasn't pinned to use
the same version as in the in init-bucket job. This is inconsistent with
other pipelines, and causes mistakes when attempting to run the pipeline
with a specific version by disabling other versions in the UI etc.

## How to review

Push the pipeline to a concourse and verify that the new flow looks correct.

## Who can review

Not me.