### PR TITLE
[#154206780] Keep deployer Concourse CNAME records

### DIFF
--- a/concourse/scripts/common_cert_management.sh
+++ b/concourse/scripts/common_cert_management.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+
+set -eu
+
+get_certificate_arn() {
+  fqdn="$1"
+  aws acm list-certificates \
+    --query "CertificateSummaryList[?DomainName==\`${fqdn}\`].CertificateArn" \
+    --output text
+}
+
+get_dns_validation_record() {
+  arn="$1"
+  cert_info=$(aws acm describe-certificate --certificate-arn "${arn}" --query 'Certificate')
+  dns_validation_record=$(echo "${cert_info}" | jq -r '.DomainValidationOptions[0].ResourceRecord.Name')
+  dns_validation_value=$(echo "${cert_info}" | jq -r '.DomainValidationOptions[0].ResourceRecord.Value')
+}
+
+get_route53_change_batch() {
+  action=${1}
+  cat <<EOF
+{
+  "Changes": [
+    {
+      "Action": "${action}",
+      "ResourceRecordSet": {
+        "Name": "${dns_validation_record}",
+        "Type": "CNAME",
+        "TTL": 300,
+        "ResourceRecords": [
+          {
+            "Value": "${dns_validation_value}"
+          }
+        ]
+      }
+    }
+  ]
+}
+EOF
+}

--- a/concourse/scripts/create_concourse_cert.sh
+++ b/concourse/scripts/create_concourse_cert.sh
@@ -83,9 +83,6 @@ for _ in $(seq 40); do
     echo
     echo "Cert issued successfully."
 
-    echo "Deleting DNS validation record."
-    aws route53 change-resource-record-sets --hosted-zone-id "${SYSTEM_DNS_ZONE_ID}" --change-batch "$(get_route53_change_batch DELETE)" > /dev/null
-
     exit 0
   fi
 done

--- a/concourse/scripts/delete_concourse_cert.sh
+++ b/concourse/scripts/delete_concourse_cert.sh
@@ -2,9 +2,14 @@
 
 set -eu
 
+SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)
+
+# shellcheck disable=SC1090
+. "${SCRIPT_DIR}/common_cert_management.sh"
+
 concourse_fqdn="${CONCOURSE_HOSTNAME}.${SYSTEM_DNS_ZONE_NAME}"
 
-arn=$(aws acm list-certificates --query "CertificateSummaryList[?DomainName==\`${concourse_fqdn}\`].CertificateArn" --output text)
+arn=$(get_certificate_arn "$concourse_fqdn")
 
 if [ -z "${arn}" ] || [ "${arn}" = "None" ]; then
   echo "No cert found for ${concourse_fqdn}. Skipping..."
@@ -12,37 +17,15 @@ if [ -z "${arn}" ] || [ "${arn}" = "None" ]; then
 fi
 
 echo "Deleting DNS validation record for ${concourse_fqdn} - ARN: ${arn}"
-cert_info=$(aws acm describe-certificate --certificate-arn "${arn}" --query 'Certificate')
-dns_validation_record=$(echo "${cert_info}" | jq -r '.DomainValidationOptions[0].ResourceRecord.Name')
-dns_validation_value=$(echo "${cert_info}" | jq -r '.DomainValidationOptions[0].ResourceRecord.Value')
+dns_validation_record='null'
+dns_validation_value='null'
+cert_info=
+get_dns_validation_record "$arn"
 
 if [ "null" = "${dns_validation_record}" ] || [ "null" = "${dns_validation_value}" ]; then
-  echo "Could not find DNS validation records for ${concourse_fqdn} - ARN: ${arn}"
+  echo "DNS validation records are not found in the AWS API response: ${cert_info}"
   exit 1
 fi
-
-get_route53_change_batch() {
-  action=${1}
-  cat <<EOF
-{
-  "Changes": [
-    {
-      "Action": "${action}",
-      "ResourceRecordSet": {
-        "Name": "${dns_validation_record}",
-        "Type": "CNAME",
-        "TTL": 300,
-        "ResourceRecords": [
-          {
-            "Value": "${dns_validation_value}"
-          }
-        ]
-      }
-    }
-  ]
-}
-EOF
-}
 
 aws route53 change-resource-record-sets --hosted-zone-id "${SYSTEM_DNS_ZONE_ID}" --change-batch "$(get_route53_change_batch DELETE)" > /dev/null
 

--- a/concourse/scripts/delete_concourse_cert.sh
+++ b/concourse/scripts/delete_concourse_cert.sh
@@ -11,5 +11,40 @@ if [ -z "${arn}" ] || [ "${arn}" = "None" ]; then
   exit 0
 fi
 
-echo "Deleting cert for ${concourse_fqdn} - arn: ${arn}"
+echo "Deleting DNS validation record for ${concourse_fqdn} - ARN: ${arn}"
+cert_info=$(aws acm describe-certificate --certificate-arn "${arn}" --query 'Certificate')
+dns_validation_record=$(echo "${cert_info}" | jq -r '.DomainValidationOptions[0].ResourceRecord.Name')
+dns_validation_value=$(echo "${cert_info}" | jq -r '.DomainValidationOptions[0].ResourceRecord.Value')
+
+if [ "null" = "${dns_validation_record}" ] || [ "null" = "${dns_validation_value}" ]; then
+  echo "Could not find DNS validation records for ${concourse_fqdn} - ARN: ${arn}"
+  exit 1
+fi
+
+get_route53_change_batch() {
+  action=${1}
+  cat <<EOF
+{
+  "Changes": [
+    {
+      "Action": "${action}",
+      "ResourceRecordSet": {
+        "Name": "${dns_validation_record}",
+        "Type": "CNAME",
+        "TTL": 300,
+        "ResourceRecords": [
+          {
+            "Value": "${dns_validation_value}"
+          }
+        ]
+      }
+    }
+  ]
+}
+EOF
+}
+
+aws route53 change-resource-record-sets --hosted-zone-id "${SYSTEM_DNS_ZONE_ID}" --change-batch "$(get_route53_change_batch DELETE)" > /dev/null
+
+echo "Deleting cert for ${concourse_fqdn} - ARN: ${arn}"
 aws acm delete-certificate --certificate-arn "${arn}"


### PR DESCRIPTION
## What

We need to retain the DNS validation records for ACM certificates, otherwise they won't be renewed.

## How to review

I've tested cert creation in the pipeline, but not tried tearing down, since that would take forever. It's debatable whether you really need to test that, since the dependencies for the script in the pipeline hasn't changed.

You could probably get away with just testing the script:

* Create a cert (it can take a few minutes to complete):

  ```
  CONCOURSE_HOSTNAME=<choose_a_host> SYSTEM_DNS_ZONE_ID=Z1QGLFML8EG6G7 SYSTEM_DNS_ZONE_NAME="${DEPLOY_ENV}.dev.cloudpipeline.digital" ./concourse/scripts/create_concourse_cert.sh
  ```

* Check the validation DNS is there:

  ```
  # list certificates
  aws acm list-certificates

  # find the one for your domain and get it's validation details
  # Certificate.DomainValidationOptions[0].ResourceRecord.Name
  aws acm describe-certificate --certificate-arn $arn_from_command_above

  # check its CNAME
  dig $domain CNAME
  ```

* delete the cert:

  ```
  CONCOURSE_HOSTNAME=<same_host_as_before> SYSTEM_DNS_ZONE_ID=Z1QGLFML8EG6G7 SYSTEM_DNS_ZONE_NAME=henry.dev.cloudpipeline.digital ./concourse/scripts/delete_concourse_cert.sh
  ```
* Confirm the DNS record is gone by repeating the `dig` command. It may not be deleted immediately (in my experience it took about 3 minutes before it was gone). I've mentioned in the commit message why I don't think we should poll for this in the script.

## Who can review

Anyone but me.
