### PR TITLE
[#154206780] Fix missing environment variable for cert deletion

### DIFF
--- a/concourse/pipelines/destroy-bosh-concourse.yml
+++ b/concourse/pipelines/destroy-bosh-concourse.yml
@@ -308,6 +308,7 @@ jobs:
           params:
             CONCOURSE_HOSTNAME: ((concourse_hostname))
             SYSTEM_DNS_ZONE_NAME: ((system_dns_zone_name))
+            SYSTEM_DNS_ZONE_ID: ((system_dns_zone_id))
             AWS_DEFAULT_REGION: ((aws_region))
           run:
             path: ./paas-bootstrap/concourse/scripts/delete_concourse_cert.sh


### PR DESCRIPTION
## What

This was omitted when the script was updated to delete DNS validation
records in route53.

## How to review

Carefully. I haven't tested this, but in theory it should work.

## Who can review

@keymon 
