### PR TITLE
[#149928858] Explicitly define the expire date of bosh CA cert

### DIFF
--- a/concourse/pipelines/create-bosh-concourse.yml
+++ b/concourse/pipelines/create-bosh-concourse.yml
@@ -394,7 +394,7 @@ jobs:
               - -c
               - |
                 if  [ -z "$(tar -tvzf existing-bosh-CA/bosh-CA.tar.gz)" ] ; then
-                  certstrap init --passphrase "" --common-name bosh-CA
+                  certstrap init --years "10" --passphrase "" --common-name bosh-CA
                   ( cd out && tar -cvzf ../generated-bosh-CA/bosh-CA.tar.gz bosh-CA.* )
                 else
                   echo "The CA cert already exists, skipping generation..."


### PR DESCRIPTION
https://www.pivotaltracker.com/n/projects/1275640/stories/149928858
https://www.pivotaltracker.com/n/projects/1275640/stories/154560347

What?
----

We want to be explicit when defining the expiration date
of the bosh CA generated by certstrap.

We pass the same value than default with --years "10"

How to review?
-------------

 - Code review
 - You can check certstrap args with: `docker run -ti governmentpaas/certstrap:465642da06051a55630d39c899697b678f66a7f7 certstrap init -h`

Who?
----
Anyone but @keymon or @leeporte