### PR TITLE
[#134014357] Upgrade syslog-release to 11.1.0 (upstream)

### DIFF
--- a/manifests/runtime-config/addons/syslog-forwarder.yml
+++ b/manifests/runtime-config/addons/syslog-forwarder.yml
@@ -1,9 +1,9 @@
 ---
 releases:
   - name: syslog
-    version: 0.1.1
-    url: https://s3-eu-west-1.amazonaws.com/gds-paas-build-releases/syslog-0.1.1.tgz
-    sha1: 6f2dae6c44cbd326fde2081983a3bdebac3825b4
+    version: 11.1.0
+    url: https://bosh.io/d/github.com/cloudfoundry/syslog-release?v=11.1.0
+    sha1: 0dc6bdb820584d915be548dc32c99168230b8eb3
 
 addons:
   - name: syslog_forwarder
@@ -15,6 +15,5 @@ addons:
         address: (( concat "logsearch-ingestor." $SYSTEM_DNS_ZONE_NAME ))
         port: 6514
         transport: 'tcp'
-        log_template: 'metron_agent'
         tls_enabled: true
         permitted_peer: (( concat "*." $SYSTEM_DNS_ZONE_NAME ))


### PR DESCRIPTION
## What

We want to be up-to-date with the latest upstream changes. Also we want to make sure everything would be ready for migrating to Logit.

The new version introduces a new syslog log format based on RFC 5424.

```
template(name="SyslogForwarderTemplate" type="list") {
  constant(value="<")
  property(name="pri")
  constant(value=">1 ")
  property(name="timestamp" dateFormat="rfc3339")
  constant(value=" <%= spec.address %> ")
  property(name="app-name")
  constant(value=" ")
  property(name="procid")
  constant(value=" ")
  property(name="msgid")
  # 47450 is CFF in https://www.iana.org/assignments/enterprise-numbers/enterprise-numbers
  constant(value=" [instance@47450 director=\"<%= p('syslog.director') %>\" deployment=\"<%= spec.deployment %>\" group=\"<%= spec.job.name %>\" az=\"<%= spec.az %>\" id=\"<%= spec.id %>\"]")
  property(name="msg" spifno1stsp="on" )
  property(name="msg")
}
```

Example log line:
```
<46>1 2018-01-25T17:25:02.033728+00:00 10.0.18.37 rsyslogd-2359 - - [instance@47450 director="" deployment="andras" group="consul" az="z3" id="78bc9c43-82c4-4e58-910c-9548a4904405"] message
```

Also blackbox will be enabled by default which will tail all log files under ```/var/vcap/sys/log/*/*``` and forward the logs to the local syslog daemon.

The log_template parameter was removed as it was used only by our fork.

## How to review

Review as part of https://github.com/alphagov/paas-cf/pull/1185.

## Who can review

Not @LeePorte or @bandesz
