### PR TITLE
[#154249348] Use wildcard ACM certificates for public facing domains

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -74,6 +74,8 @@ globals:
 dev: globals check-env-vars ## Set Environment to DEV
 	$(eval export SYSTEM_DNS_ZONE_NAME=${DEPLOY_ENV}.dev.cloudpipeline.digital)
 	$(eval export SYSTEM_DNS_ZONE_ID=Z1QGLFML8EG6G7)
+	$(eval export APPS_DNS_ZONE_NAME=${DEPLOY_ENV}.dev.cloudpipelineapps.digital)
+	$(eval export APPS_DNS_ZONE_ID=Z3R6XFWUT4YZHB)
 	$(eval export AWS_ACCOUNT=dev)
 	$(eval export ENABLE_DESTROY=true)
 	$(eval export ENABLE_DATADOG ?= false)
@@ -93,6 +95,8 @@ ci: globals check-env-vars ## Set Environment to CI
 staging: globals check-env-vars ## Set Environment to Staging
 	$(eval export SYSTEM_DNS_ZONE_NAME=staging.cloudpipeline.digital)
 	$(eval export SYSTEM_DNS_ZONE_ID=ZPFAUK62IO6DS)
+	$(eval export APPS_DNS_ZONE_NAME=staging.cloudpipelineapps.digital)
+	$(eval export APPS_DNS_ZONE_ID=Z32JRRSU1CAFE8)
 	$(eval export AWS_ACCOUNT=staging)
 	$(eval export ENABLE_DATADOG=true)
 	$(eval export ENABLE_GITHUB=true)
@@ -101,6 +105,8 @@ staging: globals check-env-vars ## Set Environment to Staging
 prod: globals check-env-vars ## Set Environment to Production
 	$(eval export SYSTEM_DNS_ZONE_NAME=cloud.service.gov.uk)
 	$(eval export SYSTEM_DNS_ZONE_ID=Z39UURGVWSYTHL)
+	$(eval export APPS_DNS_ZONE_NAME=cloudapps.digital)
+	$(eval export APPS_DNS_ZONE_ID=Z29K8LQNCFDZ1T)
 	$(eval export AWS_ACCOUNT=prod)
 	$(eval export ENABLE_DATADOG=true)
 	$(eval export ENABLE_GITHUB=true)
@@ -116,6 +122,7 @@ build-concourse: ## Setup profiles for deploying a build concourse
 	$(eval export CONCOURSE_INSTANCE_PROFILE=concourse-build)
 	$(eval export ENABLE_COLLECTD_ADDON=false)
 	$(eval export ENABLE_SYSLOG_ADDON=false)
+	$(eval export ACM_DOMAINS=${SYSTEM_DNS_ZONE_ID}:*.${SYSTEM_DNS_ZONE_NAME})
 	@true
 
 .PHONY: deployer-concourse
@@ -127,6 +134,7 @@ deployer-concourse: ## Setup profiles for deploying a paas-cf deployer concourse
 	$(eval export CONCOURSE_INSTANCE_PROFILE=deployer-concourse)
 	$(eval export ENABLE_COLLECTD_ADDON=true)
 	$(eval export ENABLE_SYSLOG_ADDON=true)
+	$(eval export ACM_DOMAINS=${SYSTEM_DNS_ZONE_ID}:*.${SYSTEM_DNS_ZONE_NAME} ${APPS_DNS_ZONE_ID}:*.${APPS_DNS_ZONE_NAME})
 	@true
 
 ## Actions

--- a/concourse/pipelines/create-bosh-concourse.yml
+++ b/concourse/pipelines/create-bosh-concourse.yml
@@ -959,17 +959,20 @@ jobs:
             - name: paas-bootstrap
           params:
             ACM_DOMAINS: ((acm_domains))
-            AWS_DEFAULT_REGION: ((aws_region))
+            ACM_AWS_REGIONS: "((aws_region)) us-east-1"
           run:
             path: sh
             args:
             - -e
             - -c
             - |
-              for acm_domain in ${ACM_DOMAINS}; do
-                export ACM_DOMAIN_ZONE_ID="${acm_domain%%:*}"
-                export ACM_DOMAIN_FQDN="${acm_domain##*:}"
-                ./paas-bootstrap/concourse/scripts/create_acm_cert.sh
+              for region in ${ACM_AWS_REGIONS}; do
+                export AWS_DEFAULT_REGION="${region}"
+                for acm_domain in ${ACM_DOMAINS}; do
+                  export ACM_DOMAIN_ZONE_ID="${acm_domain%%:*}"
+                  export ACM_DOMAIN_FQDN="${acm_domain##*:}"
+                  ./paas-bootstrap/concourse/scripts/create_acm_cert.sh
+                done
               done
 
       - task: generate-concourse-ssh-key

--- a/concourse/pipelines/create-bosh-concourse.yml
+++ b/concourse/pipelines/create-bosh-concourse.yml
@@ -947,7 +947,7 @@ jobs:
               > bosh-terraform-outputs/tfvars.sh
               ls -l bosh-terraform-outputs/tfvars.sh
 
-      - task: generate-concourse-cert
+      - task: generate-acm-certs
         config:
           platform: linux
           image_resource:
@@ -958,12 +958,19 @@ jobs:
           inputs:
             - name: paas-bootstrap
           params:
-            CONCOURSE_HOSTNAME: ((concourse_hostname))
-            SYSTEM_DNS_ZONE_NAME: ((system_dns_zone_name))
-            SYSTEM_DNS_ZONE_ID: ((system_dns_zone_id))
+            ACM_DOMAINS: ((acm_domains))
             AWS_DEFAULT_REGION: ((aws_region))
           run:
-            path: ./paas-bootstrap/concourse/scripts/create_concourse_cert.sh
+            path: sh
+            args:
+            - -e
+            - -c
+            - |
+              for acm_domain in ${ACM_DOMAINS}; do
+                export ACM_DOMAIN_ZONE_ID="${acm_domain%%:*}"
+                export ACM_DOMAIN_FQDN="${acm_domain##*:}"
+                ./paas-bootstrap/concourse/scripts/create_acm_cert.sh
+              done
 
       - task: generate-concourse-ssh-key
         config:

--- a/concourse/pipelines/create-bosh-concourse.yml
+++ b/concourse/pipelines/create-bosh-concourse.yml
@@ -1047,6 +1047,24 @@ jobs:
           params:
             file: updated-concourse-tfstate/concourse.tfstate
 
+      # FIXME: Remove after the all Concourse instances were updated
+      - task: delete-concourse-acm-cert
+        config:
+          platform: linux
+          image_resource:
+            type: docker-image
+            source:
+              repository: governmentpaas/awscli
+              tag: b2495d6ed07f680125d19aa7d1701da7efabb289
+          inputs:
+            - name: paas-bootstrap
+          params:
+            ACM_DOMAIN_ZONE_ID: ((system_dns_zone_id))
+            ACM_DOMAIN_FQDN: ((concourse_hostname)).((system_dns_zone_name))
+            AWS_DEFAULT_REGION: ((aws_region))
+          run:
+            path: ./paas-bootstrap/concourse/scripts/delete_acm_cert.sh
+
       # Temporary task to add the git-${DEPLOY_ENV} user to git group
       - task: add-git-user-to-group
         config:

--- a/concourse/pipelines/destroy-bosh-concourse.yml
+++ b/concourse/pipelines/destroy-bosh-concourse.yml
@@ -295,7 +295,7 @@ jobs:
           params:
             file: updated-concourse-tfstate/concourse.tfstate
 
-      - task: delete-concourse-cert
+      - task: delete-acm-certs
         config:
           platform: linux
           image_resource:
@@ -306,12 +306,19 @@ jobs:
           inputs:
             - name: paas-bootstrap
           params:
-            CONCOURSE_HOSTNAME: ((concourse_hostname))
-            SYSTEM_DNS_ZONE_NAME: ((system_dns_zone_name))
-            SYSTEM_DNS_ZONE_ID: ((system_dns_zone_id))
+            ACM_DOMAINS: ((acm_domains))
             AWS_DEFAULT_REGION: ((aws_region))
           run:
-            path: ./paas-bootstrap/concourse/scripts/delete_concourse_cert.sh
+            path: sh
+            args:
+            - -e
+            - -c
+            - |
+              for acm_domain in ${ACM_DOMAINS}; do
+                export ACM_DOMAIN_ZONE_ID="${acm_domain%%:*}"
+                export ACM_DOMAIN_FQDN="${acm_domain##*:}"
+                ./paas-bootstrap/concourse/scripts/delete_acm_cert.sh
+              done
 
   - name: destroy-bosh
     serial: true

--- a/concourse/pipelines/destroy-bosh-concourse.yml
+++ b/concourse/pipelines/destroy-bosh-concourse.yml
@@ -307,17 +307,20 @@ jobs:
             - name: paas-bootstrap
           params:
             ACM_DOMAINS: ((acm_domains))
-            AWS_DEFAULT_REGION: ((aws_region))
+            ACM_AWS_REGIONS: "((aws_region)) us-east-1"
           run:
             path: sh
             args:
             - -e
             - -c
             - |
-              for acm_domain in ${ACM_DOMAINS}; do
-                export ACM_DOMAIN_ZONE_ID="${acm_domain%%:*}"
-                export ACM_DOMAIN_FQDN="${acm_domain##*:}"
-                ./paas-bootstrap/concourse/scripts/delete_acm_cert.sh
+              for region in ${ACM_AWS_REGIONS}; do
+                export AWS_DEFAULT_REGION="${region}"
+                for acm_domain in ${ACM_DOMAINS}; do
+                  export ACM_DOMAIN_ZONE_ID="${acm_domain%%:*}"
+                  export ACM_DOMAIN_FQDN="${acm_domain##*:}"
+                  ./paas-bootstrap/concourse/scripts/delete_acm_cert.sh
+                done
               done
 
   - name: destroy-bosh

--- a/concourse/scripts/create_acm_cert.sh
+++ b/concourse/scripts/create_acm_cert.sh
@@ -7,18 +7,21 @@ SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)
 # shellcheck disable=SC1090
 . "${SCRIPT_DIR}/common_cert_management.sh"
 
-concourse_fqdn="${CONCOURSE_HOSTNAME}.${SYSTEM_DNS_ZONE_NAME}"
-
-arn=$(get_certificate_arn "$concourse_fqdn")
+arn=$(get_certificate_arn "$ACM_DOMAIN_FQDN")
 
 if [ -z "${arn}" ] || [ "${arn}" = "None" ]; then
-  echo "Requesting certificate for ${concourse_fqdn}"
-  arn=$(aws acm request-certificate --domain-name "${concourse_fqdn}" --validation-method "DNS" --output text)
+  echo "Requesting certificate for ${ACM_DOMAIN_FQDN}"
+  if [ "${ACM_DOMAIN_FQDN#*\*\.}" != "${ACM_DOMAIN_FQDN}" ]; then
+    # If it's a wildcard domain we automatically add an alternative name without the wildcard
+    arn=$(aws acm request-certificate --domain-name "${ACM_DOMAIN_FQDN}" --subject-alternative-names "${ACM_DOMAIN_FQDN#*\*\.}" --validation-method "DNS" --output text)
+  else
+    arn=$(aws acm request-certificate --domain-name "${ACM_DOMAIN_FQDN}" --validation-method "DNS" --output text)
+  fi
 fi
 
 cert_status=$(aws acm describe-certificate --certificate-arn "${arn}" --query 'Certificate.Status' --output text)
 if [ "${cert_status}" = "ISSUED" ]; then
-  echo "Certificate already issued for ${concourse_fqdn}. Exiting..."
+  echo "Certificate already issued for ${ACM_DOMAIN_FQDN}. Exiting..."
   exit 0
 fi
 
@@ -45,11 +48,11 @@ fi
 
 echo "Upserting DNS validation record: ${dns_validation_record}"
 
-aws route53 change-resource-record-sets --hosted-zone-id "${SYSTEM_DNS_ZONE_ID}" --change-batch "$(get_route53_change_batch UPSERT)" > /dev/null
+aws route53 change-resource-record-sets --hosted-zone-id "${ACM_DOMAIN_ZONE_ID}" --change-batch "$(get_route53_change_batch UPSERT)" > /dev/null
 
 cat <<EOT
 
-The certificate for ${concourse_fqdn} has been requested. To verify this,
+The certificate for ${ACM_DOMAIN_FQDN} has been requested. To verify this,
 a new DNS record has been created on your domain and Amazon will
 automatically validate this request. Once that is done, the certificate
 can be used.

--- a/concourse/scripts/delete_acm_cert.sh
+++ b/concourse/scripts/delete_acm_cert.sh
@@ -10,11 +10,11 @@ SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)
 arn=$(get_certificate_arn "$ACM_DOMAIN_FQDN")
 
 if [ -z "${arn}" ] || [ "${arn}" = "None" ]; then
-  echo "No cert found for ${ACM_DOMAIN_FQDN}. Skipping..."
+  echo "No cert found for ${ACM_DOMAIN_FQDN} in ${AWS_DEFAULT_REGION}. Skipping..."
   exit 0
 fi
 
-echo "Deleting DNS validation record for ${ACM_DOMAIN_FQDN} - ARN: ${arn}"
+echo "Deleting DNS validation record for ${ACM_DOMAIN_FQDN} in ${AWS_DEFAULT_REGION} - ARN: ${arn}"
 dns_validation_record='null'
 dns_validation_value='null'
 cert_info=
@@ -27,5 +27,5 @@ fi
 
 aws route53 change-resource-record-sets --hosted-zone-id "${ACM_DOMAIN_ZONE_ID}" --change-batch "$(get_route53_change_batch DELETE)" > /dev/null
 
-echo "Deleting cert for ${ACM_DOMAIN_FQDN} - ARN: ${arn}"
+echo "Deleting cert for ${ACM_DOMAIN_FQDN} in ${AWS_DEFAULT_REGION} - ARN: ${arn}"
 aws acm delete-certificate --certificate-arn "${arn}"

--- a/concourse/scripts/delete_acm_cert.sh
+++ b/concourse/scripts/delete_acm_cert.sh
@@ -7,16 +7,14 @@ SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)
 # shellcheck disable=SC1090
 . "${SCRIPT_DIR}/common_cert_management.sh"
 
-concourse_fqdn="${CONCOURSE_HOSTNAME}.${SYSTEM_DNS_ZONE_NAME}"
-
-arn=$(get_certificate_arn "$concourse_fqdn")
+arn=$(get_certificate_arn "$ACM_DOMAIN_FQDN")
 
 if [ -z "${arn}" ] || [ "${arn}" = "None" ]; then
-  echo "No cert found for ${concourse_fqdn}. Skipping..."
+  echo "No cert found for ${ACM_DOMAIN_FQDN}. Skipping..."
   exit 0
 fi
 
-echo "Deleting DNS validation record for ${concourse_fqdn} - ARN: ${arn}"
+echo "Deleting DNS validation record for ${ACM_DOMAIN_FQDN} - ARN: ${arn}"
 dns_validation_record='null'
 dns_validation_value='null'
 cert_info=
@@ -27,7 +25,7 @@ if [ "null" = "${dns_validation_record}" ] || [ "null" = "${dns_validation_value
   exit 1
 fi
 
-aws route53 change-resource-record-sets --hosted-zone-id "${SYSTEM_DNS_ZONE_ID}" --change-batch "$(get_route53_change_batch DELETE)" > /dev/null
+aws route53 change-resource-record-sets --hosted-zone-id "${ACM_DOMAIN_ZONE_ID}" --change-batch "$(get_route53_change_batch DELETE)" > /dev/null
 
-echo "Deleting cert for ${concourse_fqdn} - ARN: ${arn}"
+echo "Deleting cert for ${ACM_DOMAIN_FQDN} - ARN: ${arn}"
 aws acm delete-certificate --certificate-arn "${arn}"

--- a/concourse/scripts/pipelines.sh
+++ b/concourse/scripts/pipelines.sh
@@ -42,6 +42,7 @@ enable_collectd_addon: ${ENABLE_COLLECTD_ADDON}
 enable_syslog_addon: ${ENABLE_SYSLOG_ADDON}
 concourse_auth_duration: ${CONCOURSE_AUTH_DURATION:-5m}
 gpg_ids: ${gpg_ids}
+acm_domains: ${ACM_DOMAINS:-}
 EOF
 }
 

--- a/terraform/concourse/elb.tf
+++ b/terraform/concourse/elb.tf
@@ -1,5 +1,5 @@
-data "aws_acm_certificate" "concourse" {
-  domain   = "${var.concourse_hostname}.${var.system_dns_zone_name}"
+data "aws_acm_certificate" "system" {
+  domain   = "*.${var.system_dns_zone_name}"
   statuses = ["ISSUED"]
 }
 
@@ -22,7 +22,7 @@ resource "aws_elb" "concourse" {
     instance_protocol  = "tcp"
     lb_port            = 443
     lb_protocol        = "ssl"
-    ssl_certificate_id = "${data.aws_acm_certificate.concourse.arn}"
+    ssl_certificate_id = "${data.aws_acm_certificate.system.arn}"
   }
 
   tags {


### PR DESCRIPTION
## What

Generate wildcard ACM certificates for public facing domains.

We don't want to purchase new wildcard certs every year at a significant cost.
This will also allow us to have valid certs for dev environments.

In this PR we use the new system ACM certificate for Concourse and delete the original Concourse-specific ACM cert.

We also generate the certificate for us-east-1 as There is ]a restriction with ACM certificates when using CloudFront, the certificate must be generated in the eu-east-1 region](https://docs.aws.amazon.com/acm/latest/userguide/acm-services.html)

## How to review

1. Update and run your create-bosh-concourse pipeline from this branch:
   ```BRANCH=acm-for-public-154249348 make dev deployer-concourse pipelines```
1. Check in the ACM console whether
    * *.${DEPLOY_ENV}.dev.cloudpipelineapps.digital was issued
    * *.${DEPLOY_ENV}.dev.cloudpipeline.digital was issued
    * concourse.${DEPLOY_ENV}.dev.cloudpipeline.digital was deleted
1. In Route 53 there should be only one _???.acm-validations.aws record as _???.${DEPLOY_ENV}.dev.cloudpipeline.digital
1. Run the create-bosh-concourse pipeline again to make sure we don't create the certificates multiple times and to make sure the clean up task doesn't fail on the second run
1. Create and destroy a new _build_ Concourse and make sure it doesn't leave any ACM certs behind

## Who can review

Not @keymon or me.
