### PR TITLE
[#134014357] Disable blackbox

### DIFF
--- a/manifests/runtime-config/addons/syslog-forwarder.yml
+++ b/manifests/runtime-config/addons/syslog-forwarder.yml
@@ -17,3 +17,4 @@ addons:
         transport: 'tcp'
         tls_enabled: true
         permitted_peer: (( concat "*." $SYSTEM_DNS_ZONE_NAME ))
+        forward_files: false


### PR DESCRIPTION
## What

By enabling blackbox some logs written by the logger command are written to the disk six times wouch could cause disk fillup and adverse effects on CPU and disk usage.
Blackbox duplicates the logs handled by the logger command as usually the job scripts write the logs both to a file and syslog. See [2].

In the latest syslog release notes [1] they only able to partially solve the issue, that these duplicated logs are not sent to Logsearch but still written to the disk duplicated.

We decided to not enable blackbox (syslog.forward_files) and wait for a solution from upstream.

[1] https://github.com/cloudfoundry/syslog-release/releases/tag/v11.1.1
[2] https://github.com/cloudfoundry/syslog-release/issues/31

## How to review

1. Run create-bosh-concourse from this branch
    ```BRANCH=disable_blackbox_134014357 paas-dev make dev deployer-concourse pipelines```
1. Run create-cloudfoundry
1. SSH into one of the VMs and validate that there is no blackbox process running
    ```ps ax | grep blackbox | grep -v grep```

## Who can review

Not @bandesz
