### PR TITLE
[#154879166] Bump stemcell version to 3468.19

### DIFF
--- a/manifests/bosh-manifest/bosh-manifest.yml
+++ b/manifests/bosh-manifest/bosh-manifest.yml
@@ -152,8 +152,8 @@ resource_pools:
 - name: bosh
   network: private
   stemcell:
-    url: https://bosh.io/d/stemcells/bosh-aws-xen-hvm-ubuntu-trusty-go_agent?v=3468.17
-    sha1: c09040e9e0fcef6dffaece68f8d4173066e4f458
+    url: https://bosh.io/d/stemcells/bosh-aws-xen-hvm-ubuntu-trusty-go_agent?v=3468.19
+    sha1: 6850746403871c4584adf080b488604e116259b0
   cloud_properties:
     instance_type: t2.medium
     ephemeral_disk: {size: 40000, type: gp2}


### PR DESCRIPTION
## What

Due to [USN-3534], we'd like to upgrade our stemcell to the version that
fixes the vulnerabilities. The USN info mention it to be version 3468.19
which happens to be the closest one to ours.

[USN-3534]: https://www.cloudfoundry.org/blog/usn-3534-1/

## How to review

- Sanity check - validate the version used is sufficient
- Deploy from this branch
  ```sh
  BRANCH=$(git rev-parse --abbrev-ref HEAD) make dev pipelines CONCOURSE_TYPE=deployer-concourse CONCOURSE_HOSTNAME=deployer BOSH_INSTANCE_PROFILE=bosh-director-cf CONCOURSE_INSTANCE_TYPE=m4.xlarge CONCOURSE_INSTANCE_PROFILE=deployer-concourse ENABLE_COLLECTD_ADDON=true ENABLE_SYSLOG_ADDON=true
  ```
- Run `create-bosh-concourse` pipeline (running mine at the moment)
- Expect successes
