### PR TITLE
[Support] Use bosh-shell container with fix for missing cf deployment

### DIFF
--- a/scripts/bosh-cli.sh
+++ b/scripts/bosh-cli.sh
@@ -21,4 +21,4 @@ docker run \
     --env "BOSH_IP" \
     --env "BOSH_ADMIN_PASSWORD" \
     --env "BOSH_DEPLOYMENT=${DEPLOY_ENV}" \
-    governmentpaas/bosh-shell:2b4604fe69274908af304c15f28ca8dd657b0221
+    governmentpaas/bosh-shell:2f113f2ff3af8c9ccfc733040256caa0826e2245


### PR DESCRIPTION
## What

Update bosh-shell to work when the CF deployment doesn't exist in bosh. Pulls in changes from https://github.com/alphagov/paas-docker-cloudfoundry-tools/pull/113

## How to review

* Verify that this lets you interact with bosh when the CF deployment isn't present.
* Verify this still targets the CF deployment when it exists.

## Before merging

https://github.com/alphagov/paas-docker-cloudfoundry-tools/pull/113 must be merged and build in Docker Hub. Then the TMP commit must be updated with the relevant commit ID.

## Who can review

Not me.