### PR TITLE
[#154879166] Bump stemcell version to 3468.19

### DIFF
--- a/manifests/concourse-manifest/concourse-base.yml
+++ b/manifests/concourse-manifest/concourse-base.yml
@@ -2,7 +2,7 @@
 meta:
   stemcell:
     name: bosh-aws-xen-hvm-ubuntu-trusty-go_agent
-    version: "3468.17"
+    version: "3468.19"
 
   zone: (( grab terraform_outputs.zone0 ))
 


### PR DESCRIPTION
## What

Due to [USN-3534], we'd like to upgrade our stemcell to the version that
fixes the vulnerabilities. The USN info mention it to be version 3468.19
which happens to be the closest one to ours.

[USN-3534]: https://www.cloudfoundry.org/blog/usn-3534-1/

## How to review

- Sanity check - validate the version used is sufficient
- Make sure I haven't missed other places - I have in previous PR...
- Deploy from this branch
  ```sh
  BRANCH=$(git rev-parse --abbrev-ref HEAD) make dev pipelines CONCOURSE_TYPE=deployer-concourse CONCOURSE_HOSTNAME=deployer BOSH_INSTANCE_PROFILE=bosh-director-cf CONCOURSE_INSTANCE_TYPE=m4.xlarge CONCOURSE_INSTANCE_PROFILE=deployer-concourse ENABLE_COLLECTD_ADDON=true ENABLE_SYSLOG_ADDON=true
  ```
- Run `create-bosh-concourse` pipeline (running mine at the moment)
- Expect successes
