### PR TITLE
[#154959067] Stop creating ACM certs in us-east-1

### DIFF
--- a/concourse/pipelines/create-bosh-concourse.yml
+++ b/concourse/pipelines/create-bosh-concourse.yml
@@ -1019,20 +1019,26 @@ jobs:
             - name: paas-bootstrap
           params:
             ACM_DOMAINS: ((acm_domains))
-            ACM_AWS_REGIONS: "((aws_region)) us-east-1"
+            AWS_DEFAULT_REGION: ((aws_region))
           run:
             path: sh
             args:
             - -e
             - -c
             - |
-              for region in ${ACM_AWS_REGIONS}; do
-                export AWS_DEFAULT_REGION="${region}"
-                for acm_domain in ${ACM_DOMAINS}; do
-                  export ACM_DOMAIN_ZONE_ID="${acm_domain%%:*}"
-                  export ACM_DOMAIN_FQDN="${acm_domain##*:}"
-                  ./paas-bootstrap/concourse/scripts/create_acm_cert.sh
-                done
+              for acm_domain in ${ACM_DOMAINS}; do
+                export ACM_DOMAIN_ZONE_ID="${acm_domain%%:*}"
+                export ACM_DOMAIN_FQDN="${acm_domain##*:}"
+                ./paas-bootstrap/concourse/scripts/create_acm_cert.sh
+              done
+
+              # FIXME: remove once this has been cleaned up everywhere
+              # Cleanup unneeded certs in us-east-1
+              export AWS_DEFAULT_REGION=us-east-1
+              for acm_domain in ${ACM_DOMAINS}; do
+                export ACM_DOMAIN_ZONE_ID="${acm_domain%%:*}"
+                export ACM_DOMAIN_FQDN="${acm_domain##*:}"
+                ./paas-bootstrap/concourse/scripts/delete_acm_cert.sh
               done
 
       - task: generate-concourse-ssh-key

--- a/concourse/pipelines/destroy-bosh-concourse.yml
+++ b/concourse/pipelines/destroy-bosh-concourse.yml
@@ -307,20 +307,26 @@ jobs:
             - name: paas-bootstrap
           params:
             ACM_DOMAINS: ((acm_domains))
-            ACM_AWS_REGIONS: "((aws_region)) us-east-1"
+            AWS_DEFAULT_REGION: ((aws_region))
           run:
             path: sh
             args:
             - -e
             - -c
             - |
-              for region in ${ACM_AWS_REGIONS}; do
-                export AWS_DEFAULT_REGION="${region}"
-                for acm_domain in ${ACM_DOMAINS}; do
-                  export ACM_DOMAIN_ZONE_ID="${acm_domain%%:*}"
-                  export ACM_DOMAIN_FQDN="${acm_domain##*:}"
-                  ./paas-bootstrap/concourse/scripts/delete_acm_cert.sh
-                done
+              for acm_domain in ${ACM_DOMAINS}; do
+                export ACM_DOMAIN_ZONE_ID="${acm_domain%%:*}"
+                export ACM_DOMAIN_FQDN="${acm_domain##*:}"
+                ./paas-bootstrap/concourse/scripts/delete_acm_cert.sh
+              done
+
+              # FIXME: remove once this has been cleaned up everywhere
+              # Cleanup unused certs in us-east-1
+              export AWS_DEFAULT_REGION=us-east-1
+              for acm_domain in ${ACM_DOMAINS}; do
+                export ACM_DOMAIN_ZONE_ID="${acm_domain%%:*}"
+                export ACM_DOMAIN_FQDN="${acm_domain##*:}"
+                ./paas-bootstrap/concourse/scripts/delete_acm_cert.sh
               done
 
   - name: destroy-bosh


### PR DESCRIPTION
## What

These were created with the expectation that they'd be used for the
product page and tech docs CloudFront deployments. We've since decided
that we're instead going to get rid of these CloudFront instances and
route the traffic directly to the paas. These certs are therefore no
longer needed.

## How to review

Run the bootstrap pipeline from this branch and verify it cleans up the unneeded certs.

## Who can review

Not me.