### PR TITLE
[bugfix] Force rsync for shared folders

### DIFF
--- a/vagrant/Vagrantfile
+++ b/vagrant/Vagrantfile
@@ -28,6 +28,7 @@ AWS_ACCOUNT_VARIABLES = AWS_ACCOUNT_DATA.fetch(AWS_ACCOUNT)
 # rubocop:disable Metrics/BlockLength
 Vagrant.configure(2) do |config|
   config.vm.box = ENV['VAGRANT_BOX_NAME'] || 'aws_vagrant_box'
+  config.vm.allowed_synced_folder_types = :rsync
 
   Dir.glob("./post-deploy.d/*").sort.each do |post_deploy_file|
     config.vm.provision "shell" do |s|
@@ -78,8 +79,5 @@ Vagrant.configure(2) do |config|
     # We will rely on vagrant generating a ssh key, but this must be the ubuntu user, as the vagrant user does not exist on the vm
     override.ssh.username = "ubuntu"
     override.ssh.private_key_path = ENV['VAGRANT_SSH_KEY']
-
-    # Fix issue on osx: https://github.com/mitchellh/vagrant/issues/5401#issuecomment-115240904
-    override.nfs.functional = false
   end
 end


### PR DESCRIPTION
## What

To prevent it prompting to use SMB with Vagrant 2.0.2 on High Sierra:

     dcarley@Dans-Air  ~/p/p/paas-bootstrap   master  make dev deployer-concourse bootstrap
    vagrant/deploy.sh
    Bringing machine 'default' up with 'aws' provider...
    ==> default: Preparing SMB shared folders...
	default: You will be asked for the username and password to use for the SMB
	default: folders shortly. Please use the proper username/password of your
	default: account.
	default:
	default: Username:

Since we're restricting it to rsync only, which is functional on Mac and
Linux, we no longer need to tell it not to use NFS.

## How to review

Check that `make dev deployer-concourse bootstrap` still produces you a working Bootstrap Concourse.

## Who can review

Anyone. Though it might be good for someone on Linux and someone on a version of Mac older than High Sierra to test this.
