### PR TITLE
[#154959067] Lower `DEPLOY_ENV` maximum length to 8

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 help:
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
 
-DEPLOY_ENV_MAX_LENGTH=12
+DEPLOY_ENV_MAX_LENGTH=8
 DEPLOY_ENV_VALID_LENGTH=$(shell if [ $$(printf "%s" $(DEPLOY_ENV) | wc -c) -gt $(DEPLOY_ENV_MAX_LENGTH) ]; then echo ""; else echo "OK"; fi)
 DEPLOY_ENV_VALID_CHARS=$(shell if echo $(DEPLOY_ENV) | grep -q '^[a-zA-Z0-9-]*$$'; then echo "OK"; else echo ""; fi)
 YAMLLINT=yamllint


### PR DESCRIPTION
## What

We now have an ELB unfortunately named `<env>-cf-router-system-domain`
(your're welcome), so, due to the limit of 32 characters in an ELB name,
we have to limit this variable to 8 characters.

## How to review

`DEPLOY_ENV=12345678 make check-env-vars` should exit zero.
`DEPLOY_ENV=123456789 make check-env-vars` should exit non-zero.

## Who can review

Anyone but me.