### PR TITLE
[#154966289] Disable nats.allow_legacy_agents

### DIFF
--- a/concourse/resources/bosh-secrets-keep.yml
+++ b/concourse/resources/bosh-secrets-keep.yml
@@ -1,4 +1,4 @@
 ---
 keep:
-  bosh_nats_password: (( grab secrets.bosh_nats_password ))
+  bosh_mbus_bootstrap_password: (( grab secrets.bosh_mbus_bootstrap_password ))
   bosh_postgres_password: (( grab secrets.bosh_postgres_password ))

--- a/manifests/bosh-manifest/bosh-manifest.yml
+++ b/manifests/bosh-manifest/bosh-manifest.yml
@@ -69,8 +69,7 @@ jobs:
         health_monitor:
           certificate: (( grab secrets.default_hm_bosh_internal_cert ))
           private_key: (( grab secrets.default_hm_bosh_internal_key ))
-      # FIXME: To remove as all agents are redeployed with TLS support
-      allow_legacy_agents: true
+      allow_legacy_agents: false
 
     director:
       address: 127.0.0.1
@@ -101,7 +100,7 @@ jobs:
       resurrector_enabled: false
 
     agent:
-      mbus: (( concat "nats://nats:" secrets.bosh_nats_password "@" $BOSH_FQDN ":4222" ))
+      mbus: (( concat "nats://" $BOSH_FQDN ":4222" ))
 
     registry:
       db: (( grab meta.rds ))

--- a/manifests/bosh-manifest/bosh-manifest.yml
+++ b/manifests/bosh-manifest/bosh-manifest.yml
@@ -143,11 +143,11 @@ cloud_provider:
     user: vcap
     private_key: .ssh/bosh_id_rsa
 
-  mbus: (( concat "https://mbus:" secrets.bosh_nats_password "@" $BOSH_FQDN_EXTERNAL ":6868" ))
+  mbus: (( concat "https://mbus:" secrets.bosh_mbus_bootstrap_password "@" $BOSH_FQDN_EXTERNAL ":6868" ))
 
   properties:
     agent:
-      mbus: (( concat "https://mbus:" secrets.bosh_nats_password "@0.0.0.0:6868" ))
+      mbus: (( concat "https://mbus:" secrets.bosh_mbus_bootstrap_password "@0.0.0.0:6868" ))
     blobstore:
       provider: local
       path: /var/vcap/micro_bosh/data/cache

--- a/manifests/bosh-manifest/bosh-manifest.yml
+++ b/manifests/bosh-manifest/bosh-manifest.yml
@@ -53,8 +53,6 @@ jobs:
   properties:
     nats:
       address: 127.0.0.1
-      user: nats
-      password: (( grab secrets.bosh_nats_password ))
       tls:
         ca: (( grab secrets.bosh_ca_cert ))
         client_ca:

--- a/manifests/bosh-manifest/scripts/generate-bosh-secrets.rb
+++ b/manifests/bosh-manifest/scripts/generate-bosh-secrets.rb
@@ -6,7 +6,7 @@ require File.expand_path("../../../shared/lib/secret_generator", __FILE__)
 
 generator = SecretGenerator.new(
   "bosh_postgres_password" => :simple,
-  "bosh_nats_password" => :simple,
+  "bosh_mbus_bootstrap_password" => :simple,
   "bosh_registry_password" => :simple,
   "bosh_redis_password" => :simple,
   "bosh_hm_director_password" => :simple,


### PR DESCRIPTION
## What

Disable nats.allow_legacy_agents.

We want all the agents to connect using only mutual TLS.

Note: The NATS user+password is still needed, see [1].

[1] https://github.com/cloudfoundry/bosh-deployment/blob/a4fdaa9d334775359a8f15ef557e0f4099003ccc/bosh.yml

## How to review

1. Run your create-bosh-concourse pipeline from this branch
    ```BRANCH=disable_allow_legacy_agents_154966289 make dev deployer-concourse pipelines```

2. Run the create-cloudfoundry pipeline

3. Check if there are any errors on the BOSH VM in `/var/vcap/sys/log/nats/*.log`.

I created a new Bosh env from scratch and validated that it was created without errors. I don't think it's worth retesting this as it takes a long time.

## Who can review

Not me.
