### PR TITLE
[#155398419] Fix the Datadog Agent

### DIFF
--- a/manifests/runtime-config/addons-meta/datadog-agent.yml
+++ b/manifests/runtime-config/addons-meta/datadog-agent.yml
@@ -1,9 +1,9 @@
 ---
 releases:
   - name: datadog-agent
-    version: 0.1.4
-    url: https://s3-eu-west-1.amazonaws.com/gds-paas-build-releases/datadog-agent-0.1.4.tgz
-    sha1: a1902a885ef465617eae4f1de184ecaed0d1feb8
+    version: 0.1.5
+    url: https://s3-eu-west-1.amazonaws.com/gds-paas-build-releases/datadog-agent-0.1.5.tgz
+    sha1: 573bed2ab7960eb97dafff4b7c6111e7ad72b39c
 
 meta:
   datadog:


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/155398419

## What

We want to upgrade the stemcell version to >=3541.5, but starting from 3541.2 the /var/vcap permissions are hardened. Most of the files/directories won't be readable by the world or even by the group. This can cause issues when a process running by vcap tries to access a directory/file owned by root.
We won't do the stemcell upgrade in this story but we prepare the datadog releases to work with the new stemcells.

Update the datadog-agent Bosh release. See https://github.com/alphagov/paas-datadog-agent-boshrelease/pull/13 for details.

❗️ This PR contains a temporary commit which should be replaced with the final datadog-agent release.

## How to review

Code review first:
 * https://github.com/alphagov/paas-datadog-agent-boshrelease/pull/13
 * https://github.com/alphagov/paas-datadog-for-cloudfoundry-boshrelease/pull/22

1. Run create-bosh-concourse from this branch
    ```BRANCH=fix_datadog_agent_155398419 ENABLE_DATADOG=true SELF_UPDATE_PIPELINE=false  make dev deployer-concourse pipelines```

1. SSH to Bosh and check the log files in /var/vcap/sys/log/datadog-agent for errors

1. Validate that you receive metrics for the bosh VM (e.g. Infrastructure/Host map, filter for: deploy-env:${DEPLOY_ENV} and bosh-deployment:bosh, click on the host and check "Metrics (as of X mins ago)")

1. Testing a stemcell change is not necessary here as the official bosh-deployment still uses 3468.21 version in their manifests. (https://github.com/cloudfoundry/bosh-deployment/commit/c7fa3da00a84b59853e0f76d2504df23cbd5c1b5)

## How to release

Merge in the following order:
 * https://github.com/alphagov/paas-datadog-agent-boshrelease/pull/13
 * https://github.com/alphagov/paas-datadog-for-cloudfoundry-boshrelease/pull/22
 * this PR

## Who can review

Not me.
