### PR TITLE
[Support] Update Docker image for Bosh CLI cve-2018-1231

### DIFF
--- a/concourse/pipelines/create-bosh-concourse.yml
+++ b/concourse/pipelines/create-bosh-concourse.yml
@@ -928,7 +928,7 @@ jobs:
             type: docker-image
             source:
               repository: governmentpaas/bosh-cli-v2
-              tag: c735581beb174ecc95ca1a7b57eff444af3bf099
+              tag: 777204b5c870fc7ebf0d2b7aa55fcccddfa29c4b
           inputs:
             - name: bosh-manifest
             - name: bosh-init-state
@@ -962,7 +962,7 @@ jobs:
             type: docker-image
             source:
               repository: governmentpaas/bosh-cli-v2
-              tag: c735581beb174ecc95ca1a7b57eff444af3bf099
+              tag: 777204b5c870fc7ebf0d2b7aa55fcccddfa29c4b
           inputs:
             - name: paas-bootstrap
             - name: bosh-secrets
@@ -1302,7 +1302,7 @@ jobs:
             type: docker-image
             source:
               repository: governmentpaas/bosh-cli-v2
-              tag: c735581beb174ecc95ca1a7b57eff444af3bf099
+              tag: 777204b5c870fc7ebf0d2b7aa55fcccddfa29c4b
           inputs:
             - name: bosh-secrets
             - name: paas-bootstrap
@@ -1333,7 +1333,7 @@ jobs:
             type: docker-image
             source:
               repository: governmentpaas/bosh-cli-v2
-              tag: c735581beb174ecc95ca1a7b57eff444af3bf099
+              tag: 777204b5c870fc7ebf0d2b7aa55fcccddfa29c4b
           inputs:
           - name: concourse-manifest
           - name: bosh-secrets
@@ -1406,7 +1406,7 @@ jobs:
             type: docker-image
             source:
               repository: governmentpaas/bosh-cli-v2
-              tag: c735581beb174ecc95ca1a7b57eff444af3bf099
+              tag: 777204b5c870fc7ebf0d2b7aa55fcccddfa29c4b
           inputs:
           - name: paas-bootstrap
           - name: bosh-secrets

--- a/concourse/pipelines/destroy-bosh-concourse.yml
+++ b/concourse/pipelines/destroy-bosh-concourse.yml
@@ -220,7 +220,7 @@ jobs:
             type: docker-image
             source:
               repository: governmentpaas/bosh-cli-v2
-              tag: c735581beb174ecc95ca1a7b57eff444af3bf099
+              tag: 777204b5c870fc7ebf0d2b7aa55fcccddfa29c4b
           inputs:
           - name: paas-bootstrap
           - name: bosh-secrets
@@ -357,7 +357,7 @@ jobs:
             type: docker-image
             source:
               repository: governmentpaas/bosh-cli-v2
-              tag: c735581beb174ecc95ca1a7b57eff444af3bf099
+              tag: 777204b5c870fc7ebf0d2b7aa55fcccddfa29c4b
           inputs:
             - name: paas-bootstrap
             - name: bosh-secrets
@@ -387,7 +387,7 @@ jobs:
             type: docker-image
             source:
               repository: governmentpaas/bosh-cli-v2
-              tag: c735581beb174ecc95ca1a7b57eff444af3bf099
+              tag: 777204b5c870fc7ebf0d2b7aa55fcccddfa29c4b
           inputs:
             - name: paas-bootstrap
             - name: bosh-secrets
@@ -411,7 +411,7 @@ jobs:
             type: docker-image
             source:
               repository: governmentpaas/bosh-cli-v2
-              tag: c735581beb174ecc95ca1a7b57eff444af3bf099
+              tag: 777204b5c870fc7ebf0d2b7aa55fcccddfa29c4b
           inputs:
             - name: paas-bootstrap
             - name: bosh-manifest


### PR DESCRIPTION
## What

This PR uses the new bosh-cli-v2 image that contains Bosh CLI 3.0.1
to mitigate against https://www.cloudfoundry.org/blog/cve-2018-1231/

## How to review

Code review against https://hub.docker.com/r/governmentpaas/bosh-cli-v2/tags/ for the tag
Run the `create-bosh-concourse` pipeline in your environment and see the tests pass

## Who can review

Not @LeePorte
