### PR TITLE
[#156302820] Enable blackbox 

### DIFF
--- a/manifests/runtime-config/addons/syslog-forwarder.yml
+++ b/manifests/runtime-config/addons/syslog-forwarder.yml
@@ -18,5 +18,6 @@ addons:
         tls_enabled: true
         permitted_peer: (( concat "*." $SYSTEM_DNS_ZONE_NAME ))
         custom_rule: |
+          $MaxMessageSize 64k
           if ($programname startswith "vcap.") then ~
         use_tcp_for_file_forwarding_local_transport: true

--- a/manifests/runtime-config/addons/syslog-forwarder.yml
+++ b/manifests/runtime-config/addons/syslog-forwarder.yml
@@ -19,3 +19,4 @@ addons:
         permitted_peer: (( concat "*." $SYSTEM_DNS_ZONE_NAME ))
         custom_rule: |
           if ($programname startswith "vcap.") then ~
+        use_tcp_for_file_forwarding_local_transport: true

--- a/manifests/runtime-config/addons/syslog-forwarder.yml
+++ b/manifests/runtime-config/addons/syslog-forwarder.yml
@@ -17,3 +17,5 @@ addons:
         transport: 'tcp'
         tls_enabled: true
         permitted_peer: (( concat "*." $SYSTEM_DNS_ZONE_NAME ))
+        custom_rule: |
+          if ($programname startswith "vcap.") then ~

--- a/manifests/runtime-config/addons/syslog-forwarder.yml
+++ b/manifests/runtime-config/addons/syslog-forwarder.yml
@@ -1,9 +1,9 @@
 ---
 releases:
   - name: syslog
-    version: 11.1.0
-    url: https://bosh.io/d/github.com/cloudfoundry/syslog-release?v=11.1.0
-    sha1: 0dc6bdb820584d915be548dc32c99168230b8eb3
+    version: 0.1.3
+    url: https://s3-eu-west-1.amazonaws.com/gds-paas-build-releases/syslog-0.1.3.tgz
+    sha1: d7048c6205929365b7de60c03b6dd16531c29d5d
 
 addons:
   - name: syslog_forwarder

--- a/manifests/runtime-config/addons/syslog-forwarder.yml
+++ b/manifests/runtime-config/addons/syslog-forwarder.yml
@@ -17,4 +17,3 @@ addons:
         transport: 'tcp'
         tls_enabled: true
         permitted_peer: (( concat "*." $SYSTEM_DNS_ZONE_NAME ))
-        forward_files: false


### PR DESCRIPTION
## What

We enabled blackbox with TCP mode which would replace logger therefore eliminating the 1k size limit. It turned out blackbox (probably accidentally) truncates the messages at ~10k. We opened an issue [1] and PR upstream to fix this [2] (to increase it to ~100k).
We forked and patched blackbox. Because of this we have to use the paas-syslog-release fork again.

We also increased the rsyslog max message size to 64k.
Messages sent by logger (tagged with vcap.*) will be ignored by rsyslog.

By enabling blackbox we'll finally have all logs in logsearch which were written to a file under /var/vcap/sys/log

[1] https://github.com/concourse/blackbox/issues/7
[2] https://github.com/cloudfoundry/blackbox/pull/1 https://github.com/concourse/blackbox/pull/8

## How to review

1. Run the create-bosh-concourse pipeline from this branch
    ```BRANCH=enable_blackbox_156302820 paas-andras make dev deployer-concourse pipelines```

1. Test together with https://github.com/alphagov/paas-cf/pull/1298

## Who can review

Not @dcarley or me.
