### PR TITLE
[Firebreak] Add script for running arbitrary Bosh commands

### DIFF
--- a/scripts/bosh
+++ b/scripts/bosh
@@ -38,16 +38,19 @@ BOSH_IP=$(aws ec2 describe-instances \
 	--query 'Reservations[].Instances[].PublicIpAddress' --output text)
 export BOSH_IP
 
-BOSH_ADMIN_PASSWORD=$(aws s3 cp "s3://gds-paas-${DEPLOY_ENV}-state/bosh-secrets.yml" - | \
+export BOSH_CLIENT=admin
+BOSH_CLIENT_SECRET=$(aws s3 cp "s3://gds-paas-${DEPLOY_ENV}-state/bosh-secrets.yml" - | \
 	ruby -ryaml -e 'print YAML.load(STDIN)["secrets"]["bosh_admin_password"]')
-export BOSH_ADMIN_PASSWORD
+export BOSH_CLIENT_SECRET
+
 
 docker run  \
     -it \
 	--rm \
 	--env "BOSH_ID_RSA" \
 	--env "BOSH_IP" \
-	--env "BOSH_ADMIN_PASSWORD" \
+	--env "BOSH_CLIENT" \
+	--env "BOSH_CLIENT_SECRET" \
 	--env "BOSH_ENVIRONMENT=bosh.${SYSTEM_DNS_ZONE_NAME}" \
 	--env "BOSH_CA_CERT" \
 	--env "BOSH_DEPLOYMENT=${DEPLOY_ENV}" \

--- a/scripts/bosh
+++ b/scripts/bosh
@@ -1,0 +1,55 @@
+#!/bin/bash
+
+set -eu
+
+if [ -z "${DEPLOY_ENV:-}" ]; then
+  echo "You must set the DEPLOY_ENV environment variable" 1>&2
+  exit 1
+fi
+
+if [ -z "${AWS_ACCOUNT}" ]; then
+  echo "You must set the AWS_ACCOUNT environment variable to (dev|ci|staging|prod)" 1>&2
+  exit 1
+fi
+
+case "$AWS_ACCOUNT" in
+  dev)
+	SYSTEM_DNS_ZONE_NAME="${DEPLOY_ENV}.dev.cloudpipeline.digital"
+  ;;
+  ci)
+	SYSTEM_DNS_ZONE_NAME="${DEPLOY_ENV}.ci.cloudpipeline.digital"
+  ;;
+  staging)
+	SYSTEM_DNS_ZONE_NAME="staging.cloudpipeline.digital"
+  ;;
+  prod)
+	SYSTEM_DNS_ZONE_NAME="cloud.service.gov.uk"
+  ;;
+esac
+
+BOSH_ID_RSA="$(aws s3 cp "s3://gds-paas-${DEPLOY_ENV}-state/bosh_id_rsa" - | base64)"
+export BOSH_ID_RSA
+
+BOSH_CA_CERT="$(aws s3 cp "s3://gds-paas-${DEPLOY_ENV}-state/bosh-CA.crt" -)"
+export BOSH_CA_CERT
+
+BOSH_IP=$(aws ec2 describe-instances \
+	--filters "Name=key-name,Values=${DEPLOY_ENV}_bosh_ssh_key_pair" \
+	--query 'Reservations[].Instances[].PublicIpAddress' --output text)
+export BOSH_IP
+
+BOSH_ADMIN_PASSWORD=$(aws s3 cp "s3://gds-paas-${DEPLOY_ENV}-state/bosh-secrets.yml" - | \
+	ruby -ryaml -e 'print YAML.load(STDIN)["secrets"]["bosh_admin_password"]')
+export BOSH_ADMIN_PASSWORD
+
+docker run  \
+    -it \
+	--rm \
+	--env "BOSH_ID_RSA" \
+	--env "BOSH_IP" \
+	--env "BOSH_ADMIN_PASSWORD" \
+	--env "BOSH_ENVIRONMENT=bosh.${SYSTEM_DNS_ZONE_NAME}" \
+	--env "BOSH_CA_CERT" \
+	--env "BOSH_DEPLOYMENT=${DEPLOY_ENV}" \
+	governmentpaas/bosh:81417f366669e87c59e683f4ac93e0deda0625ba "$@"
+


### PR DESCRIPTION
## What

Sometimes we may want to execute Bosh commands and pipe the output
to other processes. For this, the existing bosh-cli `make` target
was not suitable, as it is an interactive process.

This script makes use of a new Docker image[1], which merely passes
all `docker run` arguments to the `bosh` command. The script does
connect STDIO, so `bosh ssh` is supported as well.

[1] https://github.com/alphagov/paas-docker-cloudfoundry-tools/tree/master/bosh

## How to review

⚠️ Merge https://github.com/alphagov/paas-docker-cloudfoundry-tools/pull/122 first and update this commit to point to the newly built image

## Who can review

Anyone but me or @chrisfarms 
