### PR TITLE
[#155514398] Upgrade BOSH and stemcell to latest + use compiled BOSH release

### DIFF
--- a/manifests/bosh-manifest/bosh-manifest.yml
+++ b/manifests/bosh-manifest/bosh-manifest.yml
@@ -20,8 +20,9 @@ meta:
 
 releases:
 - name: bosh
-  url: https://bosh.io/d/github.com/cloudfoundry/bosh?v=264.7.0
-  sha1: 11433d7530eea34d9ae2385ce2a7cb13912928bf
+  version: "265.2.0"
+  url: https://s3.amazonaws.com/bosh-compiled-release-tarballs/bosh-265.2.0-ubuntu-trusty-3541.12-20180407-050558-541046641-20180407050603.tgz?versionId=sEK4slEPPJa0X9Aoqtn8cew_zLSe.oXC
+  sha1: f6096eba8d1502f0c6fd13922d19c7271c911d45
 - name: bosh-aws-cpi
   version: 69
   url: https://bosh.io/d/github.com/cloudfoundry-incubator/bosh-aws-cpi-release?v=69

--- a/manifests/bosh-manifest/bosh-manifest.yml
+++ b/manifests/bosh-manifest/bosh-manifest.yml
@@ -169,8 +169,8 @@ resource_pools:
 - name: bosh
   network: private
   stemcell:
-    url: https://bosh.io/d/stemcells/bosh-aws-xen-hvm-ubuntu-trusty-go_agent?v=3468.28
-    sha1: bd8a4c86118fbfc8643212b2c2f1ff4d842bfa87
+    url: https://bosh.io/d/stemcells/bosh-aws-xen-hvm-ubuntu-trusty-go_agent?v=3541.12
+    sha1: e2f9840e7ed3eb2ccdf4c39f3a7b49e35e1ad8ec
   cloud_properties:
     instance_type: t2.medium
     ephemeral_disk: {size: 40000, type: gp2}


### PR DESCRIPTION
## What

Upgrade BOSH to 265.2.0 and the stemcell version to 3541.12. Use a precompiled package for BOSH to speed up `create-env`.

## Known issues

* The Ruby package is always compiled (although not twice like previously): https://github.com/cloudfoundry/bosh-cli/issues/371
* The director's nginx is unable to write error logs under /var/vcap/packages/nginx/logs/, but there are error logs written to /var/vcap/sys/log/director/error.log. I don't think this is causing any problems, but I opened an issue about it: https://github.com/cloudfoundry/bosh/issues/1941.

## How to review

* Create a new environment from scratch and check if CF is deployed successfully.
* Update an existing environment and check if CF deploys successfully.

## Who can review

Not me.