### PR TITLE
[#156877256] Monitor DNS resolution on each VM

### DIFF
--- a/concourse/pipelines/create-bosh-concourse.yml
+++ b/concourse/pipelines/create-bosh-concourse.yml
@@ -881,6 +881,7 @@ jobs:
           params:
             DEPLOY_ENV: ((deploy_env))
             AWS_ACCOUNT: ((aws_account))
+            SYSTEM_DNS_ZONE_NAME: ((system_dns_zone_name))
             DATADOG_API_KEY: ((datadog_api_key))
             DATADOG_APP_KEY: ((datadog_app_key))
             ENABLE_DATADOG: ((enable_datadog))

--- a/manifests/bosh-manifest/spec/support/manifest_helpers.rb
+++ b/manifests/bosh-manifest/spec/support/manifest_helpers.rb
@@ -4,6 +4,8 @@ require 'yaml'
 require 'tempfile'
 
 module ManifestHelpers
+  SYSTEM_DNS_ZONE_NAME = 'example.com'.freeze
+
   class Cache
     include Singleton
     attr_accessor :manifest_with_defaults
@@ -40,6 +42,7 @@ private
     ENV["DATADOG_APP_KEY"] = "abcd4321"
     ENV["ENABLE_DATADOG"] = "true"
     ENV["DEPLOY_ENV"] = ManifestHelpers.deploy_env
+    ENV["SYSTEM_DNS_ZONE_NAME"] = ManifestHelpers::SYSTEM_DNS_ZONE_NAME
   end
 
   def load_default_manifest

--- a/manifests/runtime-config/addons-meta/datadog-agent.yml
+++ b/manifests/runtime-config/addons-meta/datadog-agent.yml
@@ -27,4 +27,3 @@ meta:
         instances:
           - name: Canary
             hostname: (( concat "__canary." $SYSTEM_DNS_ZONE_NAME ))
-            record_type: TXT

--- a/manifests/runtime-config/addons-meta/datadog-agent.yml
+++ b/manifests/runtime-config/addons-meta/datadog-agent.yml
@@ -22,3 +22,9 @@ meta:
         instances:
           - name: btrfs
             search_string: ["btrfs"]
+      dns_check:
+        init_config:
+        instances:
+          - name: Canary
+            hostname: (( concat "__canary." $SYSTEM_DNS_ZONE_NAME ))
+            record_type: TXT

--- a/terraform/bosh/canary_dns.tf
+++ b/terraform/bosh/canary_dns.tf
@@ -1,0 +1,7 @@
+resource "aws_route53_record" "canary" {
+  zone_id = "${var.system_dns_zone_id}"
+  name    = "__canary.${var.system_dns_zone_name}"
+  type    = "TXT"
+  ttl     = "1"
+  records = ["Test record for DNS resolution checks."]
+}

--- a/terraform/bosh/canary_dns.tf
+++ b/terraform/bosh/canary_dns.tf
@@ -1,7 +1,7 @@
 resource "aws_route53_record" "canary" {
   zone_id = "${var.system_dns_zone_id}"
   name    = "__canary.${var.system_dns_zone_name}"
-  type    = "TXT"
+  type    = "A"
   ttl     = "1"
-  records = ["Test record for DNS resolution checks."]
+  records = ["127.0.0.1"]
 }


### PR DESCRIPTION
## What

This sets up a canary DNS record, and adds a datadog check on every VM
to check resolution of that record.

This is being added because we recently hit some issues in the platform
that were caused by DNS resolution being flakey from one VM in our
deployment.

## How to review

* Deploy from this branch (it includes a TMP commit to enable datadog)
* Deploy paas-cf from alphagov/paas-cf#1334
* Verify that dns metrics are appearing in Datadog.

## Before merging

Remove the TMP commit.

## Who can review

Not me.