### PR TITLE
[#157467347] Update stemcells to the latest versions

### DIFF
--- a/manifests/bosh-manifest/bosh-manifest.yml
+++ b/manifests/bosh-manifest/bosh-manifest.yml
@@ -21,8 +21,8 @@ meta:
 releases:
 - name: bosh
   version: "265.2.0"
-  url: https://s3.amazonaws.com/bosh-compiled-release-tarballs/bosh-265.2.0-ubuntu-trusty-3541.12-20180407-050558-541046641-20180407050603.tgz?versionId=sEK4slEPPJa0X9Aoqtn8cew_zLSe.oXC
-  sha1: f6096eba8d1502f0c6fd13922d19c7271c911d45
+  url: https://s3.amazonaws.com/bosh-compiled-release-tarballs/bosh-265.2.0-ubuntu-trusty-3541.25-20180510-015838-907353893-20180510015842.tgz?versionId=6Ym0RSiSuRalyo5kFG40Zt.dnwcR28G3
+  sha1: e40aebe0018a69964f2e9a3b93e6a6e79705c581
 - name: bosh-aws-cpi
   version: 69
   url: https://bosh.io/d/github.com/cloudfoundry-incubator/bosh-aws-cpi-release?v=69
@@ -169,8 +169,8 @@ resource_pools:
 - name: bosh
   network: private
   stemcell:
-    url: https://bosh.io/d/stemcells/bosh-aws-xen-hvm-ubuntu-trusty-go_agent?v=3541.12
-    sha1: e2f9840e7ed3eb2ccdf4c39f3a7b49e35e1ad8ec
+    url: https://bosh.io/d/stemcells/bosh-aws-xen-hvm-ubuntu-trusty-go_agent?v=3541.25
+    sha1: 8607e8ccd8a66dc0248535f1d66d5b45d7a4db1d
   cloud_properties:
     instance_type: t2.medium
     ephemeral_disk: {size: 40000, type: gp2}

--- a/manifests/concourse-manifest/concourse-base.yml
+++ b/manifests/concourse-manifest/concourse-base.yml
@@ -2,7 +2,7 @@
 meta:
   stemcell:
     name: bosh-aws-xen-hvm-ubuntu-trusty-go_agent
-    version: "3468.28"
+    version: "3468.42"
 
   zone: (( grab terraform_outputs.zone0 ))
 


### PR DESCRIPTION
## What

There are multiple CVEs which can be mitigated by upgrading to the latest
stemcell version.

* https://www.cloudfoundry.org/blog/usn-3631-2/
* https://www.cloudfoundry.org/blog/usn-3625-1/
* https://www.cloudfoundry.org/blog/usn-3624-1/
* https://www.cloudfoundry.org/blog/usn-3628-1/

Latest versions as listed [here](http://bosh.io/stemcells/bosh-aws-xen-hvm-ubuntu-trusty-go_agent):
* 3541.25
* 3468.42

## How to review

1. Run the create-bosh-concourse pipeline from this branch

```
BRANCH=update_stemcells_157467347 make dev deployer-concourse pipelines
```

1. Update the stemcells on CF (https://github.com/alphagov/paas-cf/pull/1351)

## Who can review

Not me