### PR TITLE
[#158791033] Use AWS internal ntp service

### DIFF
--- a/manifests/bosh-manifest/bosh-manifest.yml
+++ b/manifests/bosh-manifest/bosh-manifest.yml
@@ -131,6 +131,9 @@ instance_groups:
       region: (( grab meta.aws.region ))
       max_retries: (( grab meta.aws.max_retries ))
 
+    ntp:
+    - 169.254.169.123
+
 cloud_provider:
   template:
     name: aws_cpi
@@ -156,6 +159,8 @@ cloud_provider:
       default_security_groups: (( grab meta.aws.default_security_groups ))
       region: (( grab meta.aws.region ))
       max_retries: (( grab meta.aws.max_retries ))
+    ntp:
+    - 169.254.169.123
 
 disk_pools:
 - name: disks

--- a/manifests/concourse-manifest/concourse-base.yml
+++ b/manifests/concourse-manifest/concourse-base.yml
@@ -2,7 +2,7 @@
 meta:
   stemcell:
     name: bosh-aws-xen-hvm-ubuntu-trusty-go_agent
-    version: "3468.42"
+    version: "3468.53"
 
   zone: (( grab terraform_outputs.zone0 ))
 


### PR DESCRIPTION
What
----

We want to use the AWS Amazon Time Sync Service[1] rather
than rely on the default pool.ntp.org.

We configure it in bosh following the example for GCP in
bosh-deployment[2] but using the AWS IP 169.254.169.123

[1] https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/set-time.html
[2] https://github.com/cloudfoundry/bosh-deployment/blob/9b02de6c1b24fa770271f9b9bef75b19d5642902/gcp/cpi.yml#L62

How to review
-------------

Deploy this branch in your environment:
```
make dev deployer-concourse pipelines DEPLOY_ENV=hector BRANCH=$(git rev-parse --abbrev-ref HEAD) SELF_UPDATE_PIPELINE=false
```

and run the create-bosh-concourse pipeline

Run the main pipeline

All VMs shall get updated to the new ntp server. ssh to any and check the
file `/var/vcap/bosh/etc/ntpserver`.

You can run `ntpdate -q $(cat /var/vcap/bosh/etc/ntpserver)` to test it.

Who?
----

not me