### PR TITLE
[#158938714] Ship concourse logs to logit

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -63,6 +63,7 @@ PASSWORD_STORE_DIR?=${HOME}/.paas-pass
 globals:
 	$(eval export PASSWORD_STORE_DIR=${PASSWORD_STORE_DIR})
 	$(eval export DATADOG_PASSWORD_STORE_DIR?=${HOME}/.paas-pass)
+	$(eval export LOGIT_PASSWORD_STORE_DIR?=${HOME}/.paas-pass)
 	$(eval export GITHUB_PASSWORD_STORE_DIR?=${HOME}/.paas-pass)
 	@true
 
@@ -235,6 +236,13 @@ upload-datadog-secrets: check-env-vars ## Decrypt and upload Datadog credentials
 	$(if ${DATADOG_PASSWORD_STORE_DIR},,$(error Must pass DATADOG_PASSWORD_STORE_DIR=<path_to_password_store>))
 	$(if $(wildcard ${DATADOG_PASSWORD_STORE_DIR}),,$(error Password store ${DATADOG_PASSWORD_STORE_DIR} does not exist))
 	@scripts/manage-datadog-secrets.sh upload
+
+.PHONY: upload-logit-secrets
+upload-logit-secrets: check-env-vars ## Decrypt and upload Logit credentials to S3
+	$(if ${AWS_ACCOUNT},,$(error Must set environment to ci/staging/prod))
+	$(if ${LOGIT_PASSWORD_STORE_DIR},,$(error Must pass LOGIT_PASSWORD_STORE_DIR=<path_to_password_store>))
+	$(if $(wildcard ${LOGIT_PASSWORD_STORE_DIR}),,$(error Password store ${LOGIT_PASSWORD_STORE_DIR} does not exist))
+	@scripts/upload-logit-secrets.sh upload
 
 .PHONY: upload-github-oauth
 upload-github-oauth: check-env-vars ## Decrypt and upload github OAuth credentials to S3

--- a/concourse/pipelines/create-bosh-concourse.yml
+++ b/concourse/pipelines/create-bosh-concourse.yml
@@ -114,6 +114,15 @@ resources:
       initial_version: "-"
       initial_content_text: ""
 
+  - name: logit-secrets
+    type: s3-iam
+    source:
+      bucket: ((state_bucket))
+      region_name: ((aws_region))
+      versioned_file: logit-secrets.yml
+      initial_version: "-"
+      initial_content_text: ""
+
   - name: bosh-ssh-private-key
     type: s3-iam
     source:
@@ -1197,6 +1206,7 @@ jobs:
         - get: concourse-secrets
         - get: bosh-tfstate
           passed: ['concourse-terraform']
+        - get: logit-secrets
 
       - task: terraform-outputs-to-yaml
         config:
@@ -1264,6 +1274,7 @@ jobs:
           inputs:
           - name: paas-bootstrap
           - name: concourse-secrets
+          - name: logit-secrets
           - name: terraform-outputs
           outputs:
           - name: concourse-manifest
@@ -1288,7 +1299,8 @@ jobs:
               fi
               if [ "${ENABLE_SYSLOG_ADDON}" = "true" ]; then
                  CONCOURSE_MANIFEST_STUBS="${CONCOURSE_MANIFEST_STUBS}
-                                ./paas-bootstrap/manifests/concourse-manifest/addons/syslog-forwarder.yml"
+                                ./paas-bootstrap/manifests/concourse-manifest/addons/syslog-forwarder.yml
+                                ./logit-secrets/logit-secrets.yml"
               fi
 
               # shellcheck disable=SC2086

--- a/manifests/concourse-manifest/addons/syslog-forwarder.yml
+++ b/manifests/concourse-manifest/addons/syslog-forwarder.yml
@@ -1,9 +1,9 @@
 ---
 releases:
   - name: syslog
-    version: 0.1.3
-    url: https://s3-eu-west-1.amazonaws.com/gds-paas-build-releases/syslog-0.1.3.tgz
-    sha1: d7048c6205929365b7de60c03b6dd16531c29d5d
+    version: "11.3.2"
+    url: https://bosh.io/d/github.com/cloudfoundry/syslog-release?v=11.3.2
+    sha1: 64cf40d44746b50edffa78cb0e0dd6f072fee695
 
 addons:
   - name: syslog_forwarder

--- a/manifests/concourse-manifest/addons/syslog-forwarder.yml
+++ b/manifests/concourse-manifest/addons/syslog-forwarder.yml
@@ -19,5 +19,5 @@ addons:
             permitted_peer: (( concat "*." $SYSTEM_DNS_ZONE_NAME ))
             custom_rule: |
               $MaxMessageSize 64k
-              if ($programname startswith "vcap.") then ~
+              if ($programname startswith "vcap.") then stop
             use_tcp_for_file_forwarding_local_transport: true

--- a/manifests/concourse-manifest/addons/syslog-forwarder.yml
+++ b/manifests/concourse-manifest/addons/syslog-forwarder.yml
@@ -12,11 +12,12 @@ addons:
         release: syslog
         properties:
           syslog:
-            address: (( concat "logsearch-ingestor." $SYSTEM_DNS_ZONE_NAME ))
-            port: 6514
+            address: (( grab meta.logit.syslog_address ))
+            port: (( grab meta.logit.syslog_port ))
             transport: 'tcp'
             tls_enabled: true
-            permitted_peer: (( concat "*." $SYSTEM_DNS_ZONE_NAME ))
+            ca_cert: (( grab meta.logit.ca_cert ))
+            permitted_peer: "*.logit.io"
             custom_rule: |
               $MaxMessageSize 64k
               if ($programname startswith "vcap.") then stop

--- a/manifests/concourse-manifest/spec/support/manifest_helpers.rb
+++ b/manifests/concourse-manifest/spec/support/manifest_helpers.rb
@@ -50,6 +50,7 @@ private
         File.expand_path("../../../../shared/spec/fixtures/concourse-terraform-outputs.yml", __FILE__),
         File.expand_path("../../../../shared/spec/fixtures/bosh-terraform-outputs.yml", __FILE__),
         File.expand_path("../../../../shared/spec/fixtures/vpc-terraform-outputs.yml", __FILE__),
+        File.expand_path("../../../../shared/spec/fixtures/logit-secrets.yml", __FILE__),
         File.expand_path("../../../../shared/addons/datadog-agent.yml", __FILE__),
         File.expand_path("../../../addons/datadog-concourse-integration.yml", __FILE__),
         File.expand_path("../../../addons/syslog-forwarder.yml", __FILE__),

--- a/manifests/concourse-manifest/spec/syslog_forwarder_spec.rb
+++ b/manifests/concourse-manifest/spec/syslog_forwarder_spec.rb
@@ -8,7 +8,15 @@ RSpec.describe "syslog forwarder config" do
     expect(syslog_addon).to be
   end
 
+  it "configures tls to be enabled" do
+    expect(syslog_properties.fetch("syslog").fetch("tls_enabled")).to be true
+  end
+
   it "configures the addon properties" do
-    expect(syslog_properties['syslog']['address']).to eq("logsearch-ingestor.example.com")
+    expect(syslog_properties['syslog']['address']).to eq("logit-syslog-url.internal")
+    expect(syslog_properties['syslog']['port']).to eq 6514
+    expect(syslog_properties['syslog']['permitted_peer']).to eq "*.logit.io"
+    expect(syslog_properties['syslog']['ca_cert']).to include("LOGIT_CA_CERT_1")
+    expect(syslog_properties['syslog']['ca_cert']).to include("LOGIT_CA_CERT_2")
   end
 end

--- a/manifests/shared/spec/fixtures/logit-secrets.yml
+++ b/manifests/shared/spec/fixtures/logit-secrets.yml
@@ -1,0 +1,12 @@
+---
+meta:
+  logit:
+    syslog_address: logit-syslog-url.internal
+    syslog_port: 6514
+    ca_cert: |
+      -----BEGIN CERTIFICATE-----
+      LOGIT_CA_CERT_1
+      -----END CERTIFICATE-----
+      -----BEGIN CERTIFICATE-----
+      LOGIT_CA_CERT_2
+      -----END CERTIFICATE-----

--- a/scripts/upload-logit-secrets.sh
+++ b/scripts/upload-logit-secrets.sh
@@ -1,0 +1,42 @@
+#!/bin/sh
+#
+# Upload the S3 object with the credentials and configuration
+# from the environment or paas-pass.
+#
+# Usage:
+#
+#  AWS_ACCOUNT=dev LOGIT_PASSWORD_STORE_DIR=~/.paas-pass DEPLOY_ENV=hector
+#   ./scripts/upload-logit-config.sh upload
+
+set -eu
+
+setup_env() {
+  export PASSWORD_STORE_DIR=${LOGIT_PASSWORD_STORE_DIR}
+  secrets_uri="s3://gds-paas-${DEPLOY_ENV}-state/logit-secrets.yml"
+}
+
+get_creds_from_env_or_pass() {
+  setup_env
+  LOGIT_SYSLOG_ADDRESS="${LOGIT_SYSLOG_ADDRESS:-$(pass "logit/${AWS_ACCOUNT}/syslog_address")}"
+  LOGIT_SYSLOG_PORT="${LOGIT_SYSLOG_PORT:-$(pass "logit/${AWS_ACCOUNT}/syslog_port")}"
+  LOGIT_CA_CERT="${LOGIT_CA_CERT:-$(pass "logit/${AWS_ACCOUNT}/ca_cert")}"
+}
+
+upload() {
+  setup_env
+  get_creds_from_env_or_pass
+
+  cat << EOF | aws s3 cp - "${secrets_uri}"
+---
+meta:
+  logit:
+    syslog_address: ${LOGIT_SYSLOG_ADDRESS}
+    syslog_port: ${LOGIT_SYSLOG_PORT}
+    ca_cert: |
+$(echo "${LOGIT_CA_CERT}" | sed 's/^/      /')
+EOF
+
+
+}
+
+upload


### PR DESCRIPTION
## What

This is a re-run of #163, with a reduced scope (Concourse logs not CF platform logs, no mutual TLS and no double-delivery of logs)

We want to send the logs of all the deployments to logit.io. In this repo we upload the logit secrets, as we do with other secrets (compose/notify...). We update the addon for Concourse, to send the logs for concourse, as now each deployment has its own addons #166 

We configure the new target based on the secrets in `logit-secrets.yml` and add the corresponding tests.

**Regarding Mutual TLS**

In #163 we were going to use Mutual TLS but we decided to drop it. Check that PR for reasoning.

## How to review

 1. Upload the logit secrets 
      - checkout the new secrets in the password store `paas git checkout  logit-secrets-take-2-158938714`
     - Run `make dev upload-logit-secrets`
 2. Use this branch in the pipeline (`make dev deployer-concourse pipelines DEPLOY_ENV=...`)
 3. Rerun the pipeline `create-bosh-concourse`
 
 4. Check that the logs work for both logit 

# Dependencies

Also review/merge 
   - https://github.com/alphagov/paas-credentials/pull/125
   - https://github.com/alphagov/paas-logsearch-for-cloudfoundry/pull/7
  

## Before merging ensure that

 - [x] The logit for staging and prod is created
 - [x] The logstash filter are configured for staging and prod
 - [x]  we uploaded the logit secrets for prod and staging.

## Who can review

Anyone but @keymon or @jpluscplusm