### PR TITLE
Provide `make help` words for the bosh-cli target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -208,7 +208,7 @@ showenv: check-env-vars ## Display environment information
                 --query 'Reservations[].Instances[].PublicIpAddress' --output text)
 
 .PHONY: bosh-cli
-bosh-cli: check-env-vars
+bosh-cli: check-env-vars ## Run a local container with bosh targetted at the DEPLOY_ENV's director
 	@./scripts/bosh-cli.sh
 
 .PHONY: ssh_bosh


### PR DESCRIPTION
What
----

The `bosh-cli` Makefile target wasn't shown in a `make help` invocation, making it somewhat invisible to a new starter. This PR adds a short description of what the target achieves.

How to review
-------------

- Run `make help`
- Observe that `bosh-cli` is included in the targets described

Who can review
--------------

Anyone except @jpluscplusm