### PR TITLE
[#159136450] Enable local DNS for the director

### DIFF
--- a/manifests/bosh-manifest/bosh-manifest.yml
+++ b/manifests/bosh-manifest/bosh-manifest.yml
@@ -96,6 +96,9 @@ instance_groups:
       ssl:
         cert: (( grab secrets.bosh_director_cert ))
         key: (( grab secrets.bosh_director_key ))
+      local_dns:
+        enabled: true
+        use_dns_addresses: true
 
     hm:
       director_account:


### PR DESCRIPTION
What
----

This is a precursor for enabling Bosh DNS. It changes the DNS from using
AWS to a local DNS server, in this case to Bosh DNS. In addition we
enabled bosh to use DNS addresses as this reduces complexity in having
both DNS and IP addresses in use.

How to review
-------------

1. Code review
1. Deploy this branch on top a current master
1. Deploy https://github.com/alphagov/paas-cf/pull/1471 on in your dev environment with Datadog enabled
1. Check all tests pass
1. Check that the new datadog monitor is in place and is green

Who can review
--------------

Not @LeePorte or @richardTowers 