### PR TITLE
[Support] Update ffi Gem to fix CVE-2018-1000201

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -6,7 +6,7 @@ GEM
     crack (0.4.3)
       safe_yaml (~> 1.0.0)
     diff-lcs (1.2.5)
-    ffi (1.9.23)
+    ffi (1.9.25)
     github_merge_sign (1.0.0)
     govuk-lint (3.8.0)
       rubocop (~> 0.52.0)


### PR DESCRIPTION
## What

This issue appears to only affect Windows, and therefore is unlikely to
affect us. It's still worth updating to avoid noise.

https://nvd.nist.gov/vuln/detail/CVE-2018-1000201

How to review
-------------

Code review. Verify Travis passes.

Who can review
--------------

Not me.