### PR TITLE
[#159730005] Enable bosh-dns in the director's runtime-config

### DIFF
--- a/concourse/pipelines/create-bosh-concourse.yml
+++ b/concourse/pipelines/create-bosh-concourse.yml
@@ -261,6 +261,21 @@ resources:
       versioned_file: concourse_id_rsa
       initial_version: "-"
 
+  - name: cf-vars-store
+    type: s3-iam
+    source:
+      bucket: ((state_bucket))
+      region_name: ((aws_region))
+      versioned_file: cf-vars-store.yml
+
+  - name: bosh-runtime-config-vars
+    type: s3-iam
+    source:
+      bucket: ((state_bucket))
+      region_name: ((aws_region))
+      versioned_file: bosh-runtime-config-vars.yml
+      initial_version: "-"
+
 jobs:
   - name: init-bucket
     serial: true
@@ -930,11 +945,12 @@ jobs:
         - get: bosh-ssh-private-key
         - get: bosh-CA-crt
           passed: ['generate-secrets']
+        - get: cf-vars-store
 
       - task: bosh-create-env
         config:
           platform: linux
-          image_resource:
+          image_resource: &gov-paas-bosh-cli-v2-image-resource
             type: docker-image
             source:
               repository: governmentpaas/bosh-cli-v2
@@ -965,22 +981,49 @@ jobs:
           params:
             file: "bosh-init-working-dir/bosh-manifest-state.json"
 
-      # FIXME: remove this task once the runtime config has been cleared everywhere.
-      - task: clear-runtime-config
+      # FIXME: this needs to be replaced with a steady state certificate
+      # persistence which does not reference cf-vars-store before this story is
+      # able to be considered as complete
+      - task: steal-cf-vars
         config:
           platform: linux
-          image_resource:
-            type: docker-image
-            source:
-              repository: governmentpaas/bosh-cli-v2
-              tag: 0eff5b6a9c092f865a2b19cc4e75a3b539b82fa2
+          image_resource: *gov-paas-bosh-cli-v2-image-resource
+          inputs:
+            - name: cf-vars-store
+            - name: paas-bootstrap
+          outputs:
+            - name: new-bosh-runtime-config-vars
+          params:
+            BOSH_NON_INTERACTIVE: true
+          run:
+            path: sh
+            args:
+              - -ec
+              - |
+                bosh interpolate \
+                  --var-errs \
+                  --vars-file cf-vars-store/cf-vars-store.yml \
+                  --vars-store /dev/null \
+                  paas-bootstrap/manifests/runtime-config/variables-template.yml \
+                | grep -v '^variables:' \
+                >new-bosh-runtime-config-vars/bosh-runtime-config-vars.yml
+
+      - put: bosh-runtime-config-vars
+        params: { file: new-bosh-runtime-config-vars/bosh-runtime-config-vars.yml }
+
+      - task: set-runtime-configs
+        config:
+          platform: linux
+          image_resource: *gov-paas-bosh-cli-v2-image-resource
           inputs:
             - name: paas-bootstrap
             - name: bosh-secrets
             - name: bosh-CA-crt
+            - name: bosh-runtime-config-vars
           params:
             BOSH_ENVIRONMENT: ((bosh_fqdn_external))
             BOSH_CA_CERT: bosh-CA-crt/bosh-CA.crt
+            BOSH_NON_INTERACTIVE: true
           run:
             path: sh
             args:
@@ -989,12 +1032,20 @@ jobs:
               - |
                 ./paas-bootstrap/concourse/scripts/bosh_login.sh bosh-secrets/bosh-secrets.yml
 
-                cat <<EOT > blank-runtime-config.yml
+                cat <<EOT >blank-runtime-config.yml
                 ---
                 releases: []
                 addons: []
                 EOT
-                bosh -n update-runtime-config ./blank-runtime-config.yml
+
+                bosh update-runtime-config \
+                  --name '' \
+                  blank-runtime-config.yml
+
+                bosh update-runtime-config \
+                  --name bosh-dns \
+                  --vars-file=bosh-runtime-config-vars/bosh-runtime-config-vars.yml \
+                  paas-bootstrap/manifests/runtime-config/bosh-dns.yml
 
   - name: concourse-terraform
     serial: true
@@ -1313,11 +1364,7 @@ jobs:
       - task: get-and-upload-stemcell
         config:
           platform: linux
-          image_resource:
-            type: docker-image
-            source:
-              repository: governmentpaas/bosh-cli-v2
-              tag: 0eff5b6a9c092f865a2b19cc4e75a3b539b82fa2
+          image_resource: *gov-paas-bosh-cli-v2-image-resource
           inputs:
             - name: bosh-secrets
             - name: paas-bootstrap
@@ -1344,11 +1391,7 @@ jobs:
       - task: deploy-concourse
         config:
           platform: linux
-          image_resource:
-            type: docker-image
-            source:
-              repository: governmentpaas/bosh-cli-v2
-              tag: 0eff5b6a9c092f865a2b19cc4e75a3b539b82fa2
+          image_resource: *gov-paas-bosh-cli-v2-image-resource
           inputs:
           - name: concourse-manifest
           - name: bosh-secrets
@@ -1417,11 +1460,7 @@ jobs:
       - task: test-bosh-vms
         config:
           platform: linux
-          image_resource:
-            type: docker-image
-            source:
-              repository: governmentpaas/bosh-cli-v2
-              tag: 0eff5b6a9c092f865a2b19cc4e75a3b539b82fa2
+          image_resource: *gov-paas-bosh-cli-v2-image-resource
           inputs:
           - name: paas-bootstrap
           - name: bosh-secrets

--- a/manifests/concourse-manifest/concourse-base.yml
+++ b/manifests/concourse-manifest/concourse-base.yml
@@ -144,6 +144,11 @@ instance_groups:
             max_containers: 1024
             network_pool: "10.254.0.0/20"
 
+            # Override concourse containers to use VPC DNS instead of bosh-dns
+            # See https://github.com/concourse/concourse/issues/2482 for details
+            dns_servers:
+              - 10.0.0.2
+
     networks:
       - name: public
         static_ips:

--- a/manifests/runtime-config/bosh-dns.yml
+++ b/manifests/runtime-config/bosh-dns.yml
@@ -1,0 +1,37 @@
+releases:
+- name: bosh-dns
+  sha1: 3b77329a772483d6c949f1a47ba9734976bc2b31
+  url: https://bosh.io/d/github.com/cloudfoundry/bosh-dns-release?v=1.8.0
+  version: 1.8.0
+
+addons:
+- name: bosh-dns
+  jobs:
+  - name: bosh-dns
+    release: bosh-dns
+    properties:
+      api:
+        client:
+          tls:
+            ca: ((dns_api_tls_ca.certificate))((dns_api_tls_ca_old.certificate))
+            certificate: ((dns_api_client_tls.certificate))
+            private_key: ((dns_api_client_tls.private_key))
+        server:
+          tls:
+            ca: ((dns_api_tls_ca.certificate))((dns_api_tls_ca_old.certificate))
+            certificate: ((dns_api_server_tls.certificate))
+            private_key: ((dns_api_server_tls.private_key))
+      cache:
+        enabled: true
+      health:
+        client:
+          tls:
+            ca: ((dns_healthcheck_tls_ca.certificate))((dns_healthcheck_tls_ca_old.certificate))
+            certificate: ((dns_healthcheck_client_tls.certificate))
+            private_key: ((dns_healthcheck_client_tls.private_key))
+        enabled: true
+        server:
+          tls:
+            ca: ((dns_healthcheck_tls_ca.certificate))((dns_healthcheck_tls_ca_old.certificate))
+            certificate: ((dns_healthcheck_server_tls.certificate))
+            private_key: ((dns_healthcheck_server_tls.private_key))

--- a/manifests/runtime-config/variables-template.yml
+++ b/manifests/runtime-config/variables-template.yml
@@ -1,0 +1,75 @@
+dns_api_client_tls: ((dns_api_client_tls))
+dns_api_server_tls: ((dns_api_server_tls))
+dns_api_tls_ca: ((dns_api_tls_ca))
+dns_api_tls_ca_old: ((dns_api_tls_ca_old))
+dns_healthcheck_client_tls: ((dns_healthcheck_client_tls))
+dns_healthcheck_server_tls: ((dns_healthcheck_server_tls))
+dns_healthcheck_tls_ca: ((dns_healthcheck_tls_ca))
+dns_healthcheck_tls_ca_old: ((dns_healthcheck_tls_ca_old))
+
+# These variable definitions, from which our *_ca_old additions derive, are
+# borrowed from upstream [1]. We don't comsume bosh-deployment as an upstream
+# (yet), hence we're embedding them here.
+# [1] https://github.com/cloudfoundry/bosh-deployment/blob/master/runtime-configs/dns.yml
+
+variables:
+
+## Upstream 
+
+- name: dns_healthcheck_tls_ca
+  type: certificate
+  options:
+    is_ca: true
+    common_name: dns-healthcheck-tls-ca
+
+- name: dns_healthcheck_server_tls
+  type: certificate
+  options:
+    ca: dns_healthcheck_tls_ca
+    common_name: health.bosh-dns
+    extended_key_usage:
+    - server_auth
+
+- name: dns_healthcheck_client_tls
+  type: certificate
+  options:
+    ca: dns_healthcheck_tls_ca
+    common_name: health.bosh-dns
+    extended_key_usage:
+    - client_auth
+
+- name: dns_api_tls_ca
+  type: certificate
+  options:
+    is_ca: true
+    common_name: dns-api-tls-ca
+
+- name: dns_api_server_tls
+  type: certificate
+  options:
+    ca: dns_api_tls_ca
+    common_name: api.bosh-dns
+    extended_key_usage:
+    - server_auth
+
+- name: dns_api_client_tls
+  type: certificate
+  options:
+    ca: dns_api_tls_ca
+    common_name: api.bosh-dns
+    extended_key_usage:
+    - client_auth
+
+## Our additions
+
+- name: dns_healthcheck_tls_ca_old
+  type: certificate
+  options:
+    is_ca: true
+    common_name: dns-healthcheck-tls-ca
+
+- name: dns_api_tls_ca_old
+  type: certificate
+  options:
+    is_ca: true
+    common_name: dns-api-tls-ca


### PR DESCRIPTION
What
----

This PR, which must be closely coordinated with (and **must** come before) the merge and deployment of alphagov/paas-cf#1522, makes the deployment of bosh-dns global across all deployments from each environment's BOSH director.  This is a prerequisite which upstream (cf-deployment 3.0.0+) insist upon.

For operational reasons, this PR should be merged and deployed *after* alphagov/paas-cf#1523.

Our process is slightly complicated by the fact that we have to pull the existing bosh-dns CA and non-CA certs for healthchecks and the bosh-dns API over from CF, where it's been deployed for a few weeks, and adopt it in the `create-bosh-concourse` pipeline. This is because we're unsure if the API is exposed between VMs, or just inside each VM, hence if having half the system using one CA and half using another would be problematic. We *are* using our standard pattern to enable CA rotation, but it doesn't feel like the right place to prove its correctness, along with the CA migration across pipelines/systems.

Review
-------

This has been paired on throughout, and is being rolled out by @tlwr, @richardTowers and myself, with @henrytk  helping from a production access perspective.

Deployment plan: https://hackmd.cloudapps.digital/nZAnzvldRLqtxcEXbXoa6w?view#Deloyment-to-Production