### PR TITLE
[#160446591] Bump stemcells to fix USNs

### DIFF
--- a/manifests/bosh-manifest/bosh-manifest.yml
+++ b/manifests/bosh-manifest/bosh-manifest.yml
@@ -180,8 +180,8 @@ resource_pools:
 - name: bosh
   network: private
   stemcell:
-    url: https://bosh.io/d/stemcells/bosh-aws-xen-hvm-ubuntu-trusty-go_agent?v=3586.36
-    sha1: df1d84d1d844bef3a6ce6e8f837f9ef1eeaed36c
+    url: https://bosh.io/d/stemcells/bosh-aws-xen-hvm-ubuntu-trusty-go_agent?v=3586.42
+    sha1: 5523cb507c6b02e997726b686dc18b0c285611cc
   cloud_properties:
     instance_type: t2.medium
     ephemeral_disk: {size: 40000, type: gp2}

--- a/manifests/concourse-manifest/concourse-base.yml
+++ b/manifests/concourse-manifest/concourse-base.yml
@@ -2,7 +2,7 @@
 meta:
   stemcell:
     name: bosh-aws-xen-hvm-ubuntu-trusty-go_agent
-    version: "3468.64"
+    version: "3468.69"
 
   zone: (( grab terraform_outputs.zone0 ))
 


### PR DESCRIPTION
## What

Includes fixes for the following:

- USN-3755-1: GD vulnerabilities
- USN-3756-1: Intel Microcode vulnerabilities
- USN-3753-2: Linux kernel (Xenial HWE) vulnerabilities

The version of concourse we're running doesn't work with the 3586 series
stemcells, so this bumps it to the latest 3468 version available which
also inclues the fixes.

How to review
-------------

Describe the steps required to test the changes.

Who can review
--------------

Not me.