### PR TITLE
[#158180318] Remove Environment specific team name

### DIFF
--- a/concourse/pipelines/create-bosh-concourse.yml
+++ b/concourse/pipelines/create-bosh-concourse.yml
@@ -1388,7 +1388,7 @@ jobs:
               ./paas-bootstrap/concourse/scripts/bosh_login.sh bosh-secrets/bosh-secrets.yml
               bosh -n deploy concourse-manifest/concourse-manifest.yml
 
-      - task: add-env-specific-team
+      - task: delete-env-specific-team
         config:
           platform: linux
           image_resource:
@@ -1418,8 +1418,7 @@ jobs:
                 CONCOURSE_ATC_PASSWORD=$(./paas-bootstrap/concourse/scripts/val_from_yaml.rb secrets.concourse_atc_password concourse-secrets/concourse-secrets.yml)
 
                 ./paas-bootstrap/concourse/scripts/fly_sync_and_login.sh
-                ${FLY_CMD} -t "${FLY_TARGET}" set-team -n "${FLY_TEAM}" \
-                  --basic-auth-username admin --basic-auth-password "${CONCOURSE_ATC_PASSWORD}" --non-interactive
+                ${FLY_CMD} -t "${FLY_TARGET}" destroy-team -n "${FLY_TEAM}" --non-interactive
 
   - name: post-deploy
     serial: true


### PR DESCRIPTION
What
----

The concept of teams has changed significantly in concourse 4.0.0 and up. Having 2 teams with the same username breaks the migration as a result.

Given that the env-specific team is a visual sign for devs, and that it’s not visible on the login screen in 4.0.0+, it serves little purpose. This PR should go down our existing 3.8.x Concoursii early, to prevent this mid-upgrade breakage when we upgrade past 4.0.0.

How to review
-------------

Code review

Who can review
--------------

Not @LeePorte or @jpluscplusm 
