### PR TITLE
[#158180318 ] Make temporary `fly destroy-team` invocation idempotent

### DIFF
--- a/concourse/pipelines/create-bosh-concourse.yml
+++ b/concourse/pipelines/create-bosh-concourse.yml
@@ -1418,7 +1418,7 @@ jobs:
                 CONCOURSE_ATC_PASSWORD=$(./paas-bootstrap/concourse/scripts/val_from_yaml.rb secrets.concourse_atc_password concourse-secrets/concourse-secrets.yml)
 
                 ./paas-bootstrap/concourse/scripts/fly_sync_and_login.sh
-                ${FLY_CMD} -t "${FLY_TARGET}" destroy-team -n "${FLY_TEAM}" --non-interactive
+                ${FLY_CMD} -t "${FLY_TARGET}" destroy-team -n "${FLY_TEAM}" --non-interactive || true
 
   - name: post-deploy
     serial: true


### PR DESCRIPTION
What
----

In merging https://github.com/alphagov/paas-bootstrap/pull/187 we only tested that it worked on an existing, as-prod, Concourse. Subsequent pipeline runs will error when the now-deleted team is deleted again - unless we explicitly excuse that failure.

Review
-------

@jpluscplusm solo authored, committed, reviewed and merged this.  He's *that* confident it'll work.