### PR TITLE
[#160614327] Update bosh-cli-v2 image to use v5.2.1

### DIFF
--- a/concourse/pipelines/create-bosh-concourse.yml
+++ b/concourse/pipelines/create-bosh-concourse.yml
@@ -947,7 +947,7 @@ jobs:
             type: docker-image
             source:
               repository: governmentpaas/bosh-cli-v2
-              tag: 0eff5b6a9c092f865a2b19cc4e75a3b539b82fa2
+              tag: 4012d25ceb903b46908a830b8e05773ced1c8f86
           inputs:
             - name: bosh-manifest
             - name: bosh-init-state

--- a/concourse/pipelines/destroy-bosh-concourse.yml
+++ b/concourse/pipelines/destroy-bosh-concourse.yml
@@ -220,11 +220,11 @@ jobs:
       - task: destroy-concourse
         config:
           platform: linux
-          image_resource:
+          image_resource: &gov-paas-bosh-cli-v2-image-resource
             type: docker-image
             source:
               repository: governmentpaas/bosh-cli-v2
-              tag: 0eff5b6a9c092f865a2b19cc4e75a3b539b82fa2
+              tag: 4012d25ceb903b46908a830b8e05773ced1c8f86
           inputs:
           - name: paas-bootstrap
           - name: bosh-secrets
@@ -358,11 +358,7 @@ jobs:
       - task: check-existing-deployments
         config:
           platform: linux
-          image_resource:
-            type: docker-image
-            source:
-              repository: governmentpaas/bosh-cli-v2
-              tag: 0eff5b6a9c092f865a2b19cc4e75a3b539b82fa2
+          image_resource: *gov-paas-bosh-cli-v2-image-resource
           inputs:
             - name: paas-bootstrap
             - name: bosh-secrets
@@ -388,11 +384,7 @@ jobs:
       - task: cleanup-orphaned-disks
         config:
           platform: linux
-          image_resource:
-            type: docker-image
-            source:
-              repository: governmentpaas/bosh-cli-v2
-              tag: 0eff5b6a9c092f865a2b19cc4e75a3b539b82fa2
+          image_resource: *gov-paas-bosh-cli-v2-image-resource
           inputs:
             - name: paas-bootstrap
             - name: bosh-secrets
@@ -412,11 +404,7 @@ jobs:
       - task: destroy-bosh-instance
         config:
           platform: linux
-          image_resource:
-            type: docker-image
-            source:
-              repository: governmentpaas/bosh-cli-v2
-              tag: 0eff5b6a9c092f865a2b19cc4e75a3b539b82fa2
+          image_resource: *gov-paas-bosh-cli-v2-image-resource
           inputs:
             - name: paas-bootstrap
             - name: bosh-manifest


### PR DESCRIPTION
What
----

We want to use the bosh-cli v5.2.1 that includes support to
generate CA certificates with SKI[1], and stop using our
fork.

This new container includes the latest PR [2][3]

[1] https://github.com/cloudfoundry/bosh-cli/releases/tag/v5.2.1
[2] https://github.com/alphagov/paas-docker-cloudfoundry-tools/pull/134
[3] https://hub.docker.com/r/governmentpaas/bosh-cli-v2/builds/bdqhaxoavpkqqlgq2ivyg5k/


Dependencies
--------------

See https://github.com/alphagov/paas-cf/pull/1552

How to review
-------------

Code review. This has been tested in [2] and in the pipeline of alext.


Who can review
--------------

not me