### PR TITLE
[#160453965] Ensure the ACM DNS verification record is right

### DIFF
--- a/concourse/scripts/common_cert_management.sh
+++ b/concourse/scripts/common_cert_management.sh
@@ -16,6 +16,15 @@ get_dns_validation_record() {
   dns_validation_value=$(echo "${cert_info}" | jq -r '.DomainValidationOptions[0].ResourceRecord.Value')
 }
 
+get_route53_resource_record_value() {
+  zone="$1"
+  name="$2"
+  aws route53 list-resource-record-sets \
+    --hosted-zone-id "${zone}" \
+    --query "ResourceRecordSets[?Name == '${name}'].ResourceRecords[0].Value" \
+    --output text
+}
+
 get_route53_change_batch() {
   action=${1}
   cat <<EOF


### PR DESCRIPTION
What
----

Because some reason it happens that in some environments (specially
prod) the DNS record to verify the certificate is wrong, pointing
to a loadbalancer instead to the right verification value.

To fix this automatically, we change the create_acm_cert.sh script
to also verify if the value of the DNS is right, and update it
if not.

How to review
-------------

 - Code review

Then manual testing:

 1. Go to the route53 console and change to any other value the record for
 acm validations: eg _f01fadf7da24471e59a04d50dfbace53.hector.dev.cloudpipelineapps.digital.
 2. rerun the pipeline create-bosh-concourse
 3. The job concourse-terraform shall update the entries

NOTE: in the AWS console in route53, you have to refresh to see that the change has been updated

Who can review
--------------

not me