### PR TITLE
[#160175644] Add a user for prometheus bosh-exporter

### DIFF
--- a/manifests/bosh-manifest/bosh-manifest.yml
+++ b/manifests/bosh-manifest/bosh-manifest.yml
@@ -87,6 +87,7 @@ instance_groups:
           users:
             - { name: admin, password: (( grab secrets.bosh_admin_password )) }
             - { name: hm, password: (( grab secrets.bosh_hm_director_password )) }
+            - { name: prometheus, password: (( grab secrets.bosh_prometheus_password )) }
       trusted_certs: (( grab secrets.bosh_ca_cert ))
       events:
         record_events: true

--- a/manifests/bosh-manifest/scripts/generate-bosh-secrets.rb
+++ b/manifests/bosh-manifest/scripts/generate-bosh-secrets.rb
@@ -11,6 +11,7 @@ generator = SecretGenerator.new(
   "bosh_redis_password" => :simple,
   "bosh_hm_director_password" => :simple,
   "bosh_admin_password" => :simple,
+  "bosh_prometheus_password" => :simple,
   "bosh_vcap_password" => :sha512_crypted,
 )
 


### PR DESCRIPTION
What
----
We want to integrate prometheus and use the bosh exporter[1]
to get metrics from bosh and enable auto discovery.

Bosh exporter requires a user to connect. We do not want to use
the admin user directly, so we add a "prometheus" user.

This user will still be an admin user, as all the local users
have admin permissions. But having a separated user would
make it easier convert it later to a read-only user, either
by using UAA or changing the bosh behaviour[2]

[1] https://github.com/bosh-prometheus/bosh_exporter
[2] https://github.com/cloudfoundry/bosh/pull/2068

Dependencies
-------------

Merge and apply before https://github.com/alphagov/paas-cf/pull/1595

How to review
-------------
Code review

Who can review
--------------

Anyone