### PR TITLE
Fix path to gpg-keys files.

### DIFF
--- a/concourse/scripts/deploy-pipeline.sh
+++ b/concourse/scripts/deploy-pipeline.sh
@@ -2,6 +2,7 @@
 set -euo pipefail
 
 SCRIPT=$0
+SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)
 
 usage() {
    cat <<EOF
@@ -32,9 +33,9 @@ echo "Pipeline ${pipeline}"
 echo "Config file ${config}"
 
 if [ "${SKIP_COMMIT_VERIFICATION:-}" = "true" ] ; then
-  gpg_option="--load-vars-from=./concourse/vars-files/gpg-keys-empty.yml"
+  gpg_option="--load-vars-from=${SCRIPT_DIR}/../vars-files/gpg-keys-empty.yml"
 else
-  gpg_option="--load-vars-from=./concourse/vars-files/gpg-keys.yml"
+  gpg_option="--load-vars-from=${SCRIPT_DIR}/../vars-files/gpg-keys.yml"
 fi
 
 $FLY_CMD -t "${FLY_TARGET}" \


### PR DESCRIPTION
## What

This was erroring when the pieplines were uploaded from a directory
other than the root directory. This manifested when creating a bootstrap
instance as this is invoked from the vagrant directory.

This updates the paths to be relative to the script dir so that it's no
longer dependent on where this is invoked from.

How to review
-------------

Spin up a bootstrap concourse, and verify the pipeline pushes successfully.

Who can review
--------------

Not me.