### PR TITLE
[#161411167] Add a readonly UAA client for bosh-exporter

### DIFF
--- a/manifests/bosh-manifest/bosh-manifest.yml
+++ b/manifests/bosh-manifest/bosh-manifest.yml
@@ -103,6 +103,12 @@ instance_groups:
           scope: ""
           authorities: bosh.admin
           secret: (( grab secrets.bosh_hm_director_password )) ]
+        bosh_exporter:
+          override: true
+          authorized-grant-types: client_credentials
+          scope: ""
+          authorities: bosh.read
+          secret: (( grab secrets.bosh_bosh_exporter_password ))
       login:
         client_secret: (( grab secrets.bosh_uaa_login_client_password ))
       zones: {internal: {hostnames: []}}

--- a/manifests/bosh-manifest/scripts/generate-bosh-secrets.rb
+++ b/manifests/bosh-manifest/scripts/generate-bosh-secrets.rb
@@ -11,6 +11,7 @@ generator = SecretGenerator.new(
   "bosh_redis_password" => :simple,
   "bosh_hm_director_password" => :simple,
   "bosh_admin_password" => :simple,
+  "bosh_bosh_exporter_password" => :simple,
   "bosh_vcap_password" => :sha512_crypted,
   "bosh_uaa_postgres_password" => :simple,
   "bosh_uaa_login_client_password" => :simple,


### PR DESCRIPTION
What
----

We create a new client to be used by the bosh-exporter of
prometheus-release

It will have only bosh.read permissions

Continuation of:
 - https://www.pivotaltracker.com/n/projects/1275640/stories/160175644
 - https://github.com/alphagov/paas-cf/pull/1595

How to review
-------------

Code review. Run the pipeline

Who can review
--------------

@keymon or @henrytk or anybody else