### PR TITLE
[#161388997] Use uaa precompile release for trusty

### DIFF
--- a/manifests/bosh-manifest/bosh-manifest.yml
+++ b/manifests/bosh-manifest/bosh-manifest.yml
@@ -37,8 +37,8 @@ releases:
   sha1: 50b04aaefabbb8a2c371b086f570b37e25607052
 - name: uaa
   version: "60.2"
-  url: https://s3.amazonaws.com/bosh-compiled-release-tarballs/uaa-60.2-ubuntu-xenial-97.12-20180815-231707-188963409-20180815231720.tgz?versionId=AJarW.I0RXfMpEAgq.d.qCuG_oAht_80
-  sha1: 97fcf9ce8b8bc9866771ce4c1ba59c9b19aa6f25
+  url: https://s3.amazonaws.com/bosh-compiled-release-tarballs/uaa-60.2-ubuntu-trusty-3586.25-20180719-211521-859356054-20180719211535.tgz?versionId=xPYgwJsDhNEtSKGpTBe5ts8kaHCINK0y
+  sha1: ab2f9afc80e7655ab51514e15a7b3ead79d66d54
 
 instance_groups:
 - name: bosh


### PR DESCRIPTION
What
----

We are using trusty stemcells, so we should use the precompile
release of UAA for trusty, not xenial

How to review
-------------

Code review.
I will run it in my deployment

Who can review
--------------

anyone