### PR TITLE
[#161388997] Fix config for bosh healthmanager talking to UAA

### DIFF
--- a/manifests/bosh-manifest/bosh-manifest.yml
+++ b/manifests/bosh-manifest/bosh-manifest.yml
@@ -102,7 +102,7 @@ instance_groups:
           authorized-grant-types: client_credentials
           scope: ""
           authorities: bosh.admin
-          secret: (( grab secrets.bosh_hm_director_password )) ]
+          secret: (( grab secrets.bosh_hm_director_password ))
         bosh_exporter:
           override: true
           authorized-grant-types: client_credentials
@@ -193,6 +193,7 @@ instance_groups:
       director_account:
         client_id: hm
         client_secret: (( grab secrets.bosh_hm_director_password ))
+        ca_cert: (( grab secrets.bosh_ca_cert ))
       resurrector_enabled: false
 
     agent:


### PR DESCRIPTION
What
----

In #204 we added UAA for bosh, and created credentials for the
healthmanager to use UAA.

But there were a pair of configuration errors:

 - We do not set the UAA certificate. This shouldn't be a problem
   because currently our CA is the bosh-CA that is trusted at
   the system level, but apparently health_monitor is not using
   the system certs and fails connecting to UAA.

 - We had a typo in the password of the healthmanager client in UAA

Health manager process starts anyway even if it cannot authenticate
to UAA to connect to bosh, but starts complaining because it
cannot retrieve the deployments and it gets heartbeats from
unknown VMs.

In the logs /var/vcap/sys/log/health_monitor/health_monitor.log:

    W, [2018-10-31T03:30:06.198390 #29559]  WARN : Received heartbeat from unmanaged agent: 79317636-6e51-4ed4-9c01-96ad49071988

This was also causing a flood of messages in our datadog saying:

    cb3670a5-fcca-415f-b27f-e2792d618c66 is not a part of any deployment #deployment: #source:agent_cb3670a5-fcca-415f-b27f-e2792d618c66 #host:localhost
cb3670a5-fcca-415f-b27f-e2792d618c66 is not a part of any deployment


How to review
-------------

Code review

Who can review
--------------

Not me