### PR TITLE
[#SUPPORT] Fix bootstrap password generation for assume-role

### DIFF
--- a/concourse/scripts/environment.sh
+++ b/concourse/scripts/environment.sh
@@ -25,7 +25,7 @@ case "${TARGET_CONCOURSE}" in
     FLY_CMD="${PROJECT_DIR}/bin/fly-bootstrap"
 
     if [ -z "${CONCOURSE_ATC_PASSWORD:-}" ]; then
-        user_id=$(aws sts get-caller-identity | awk '$1 ~ /UserId/ {print $2}')
+        user_id=$(aws sts get-caller-identity | awk '$1 ~ /UserId/ {sub(/:.*$/, "", $2); print $2}')
         CONCOURSE_ATC_PASSWORD=$(hashed_password "${user_id}")
     fi
     BOSH_LOGIN_HOST=${BOSH_FQDN_EXTERNAL}


### PR DESCRIPTION
## What

The bootstrap concourse password is generated by hashing the UserId
returned from `aws sts get-caller-identity`. This worked fine when using
direct users as this value was consistent for the duration of a session.

This no longer works when using assume-role because the UserId includes
a 2nd field that changes each time (it looks like a timestamp), meaning
each invocation generates a different password, which means you can't
get the bootstrap password from `make showenv`.

With a direct user, the UserId is something like
"AIDAJFHPYCE5LABCDABCB", whereas with assume-role it's something like
"AIDAJFHPYCE5LABCDABCB:1540995236076383733". To resolve this we update
the script to trim off everything after the ':' before hashing it, which
makes this consistent again.

How to review
-------------

Using assume-role credentials run `make dev deployer-concourse showenv` multiple times and verify the generated concourse password is the same each time.

Who can review
--------------

Not me.