### PR TITLE
[#161387517] Configure Concourse to expose an endpoint for Prometheus

### DIFF
--- a/manifests/concourse-manifest/concourse-base.yml
+++ b/manifests/concourse-manifest/concourse-base.yml
@@ -99,6 +99,9 @@ instance_groups:
       - name: atc
         release: concourse
         properties:
+          prometheus:
+            bind_ip: 0.0.0.0
+            bind_port: 9391
           external_url: (( concat "https://" terraform_outputs.concourse_dns_name ))
           add_local_users:
             - (( concat "admin:" secrets.concourse_atc_password ))


### PR DESCRIPTION
What
----

This PR tells Concourse to listen on :9391, and serve Prometheus-scrape-able metrics.

How to review
-------------

Code review suffices, as this is a config lever exposed by a well-known Bosh release.

This PR has no sequencing implications with any other part of #161387517.

Who can review
--------------

Anyone