### PR TITLE
Revert "Configure Concourse to expose an endpoint for Prometheus"

### DIFF
--- a/manifests/concourse-manifest/concourse-base.yml
+++ b/manifests/concourse-manifest/concourse-base.yml
@@ -99,9 +99,6 @@ instance_groups:
       - name: atc
         release: concourse
         properties:
-          prometheus:
-            bind_ip: 0.0.0.0
-            bind_port: 9391
           external_url: (( concat "https://" terraform_outputs.concourse_dns_name ))
           add_local_users:
             - (( concat "admin:" secrets.concourse_atc_password ))


### PR DESCRIPTION
What
----

This reverts commit e43c750cc19b91b94b016a6c771f70a070d86c87. We are seeing issues with it in staging.

How to review
-------------

Code review

Who can review
--------------

@henrytk 
