### PR TITLE
[#SUPPORT] Deploy patched version of bosh v268.2.0

### DIFF
--- a/manifests/bosh-manifest/bosh-manifest.yml
+++ b/manifests/bosh-manifest/bosh-manifest.yml
@@ -20,9 +20,10 @@ meta:
 
 releases:
 - name: "bosh"
-  version: "268.2.0"
-  url: "https://bosh.io/d/github.com/cloudfoundry/bosh?v=268.2.0"
-  sha1: "5b18a671401f5bc001b216b74e7d03307cfbbe7a"
+  # 268.2.0 + https://github.com/cloudfoundry/bosh/commit/bc4bc20
+  version: 0.1.1
+  url: https://s3-eu-west-1.amazonaws.com/gds-paas-build-releases/bosh-0.1.1.tgz
+  sha1: b69a2e11996f7daa9658dbacfe3c13137b667811
 - name: "bosh-aws-cpi"
   version: "72"
   url: "https://bosh.io/d/github.com/cloudfoundry-incubator/bosh-aws-cpi-release?v=72"


### PR DESCRIPTION
What
----

Bosh v268.2.0 seems to have a bug that occassionally causes bosh
dns to wipe DNS entries during a deployment.

This caused API availability issues in our staging deployment.

Reported upstream in slack[1], they claim that there is a bug related
to a patch[2].

Here we use a patched version of bosh including that patch.

[1] https://cloudfoundry.slack.com/archives/C02HPPYQ2/p1542383747442400
[2] https://github.com/cloudfoundry/bosh/commit/bc4bc20fcf8fec20c975d8d6b1bf0c2


How to review
-------------

Code review

Note: A PR for release-ci is ready in case we want to generate the
release from concourse build, and not use the one generated manually:

https://github.com/alphagov/paas-release-ci/pull/82

If merged, update this PR

Who can review
--------------

Not me