### PR TITLE
[#161184357] Upgrade AWS Terraform provider

### DIFF
--- a/concourse/pipelines/concourse-lite-self-terminate.yml
+++ b/concourse/pipelines/concourse-lite-self-terminate.yml
@@ -1,3 +1,11 @@
+meta:
+  containers:
+    awscli: &awscli-image-resource
+      type: docker-image
+      source:
+        repository: governmentpaas/awscli
+        tag: b2495d6ed07f680125d19aa7d1701da7efabb289
+
 resources:
   - name: delete-timer
     type: time
@@ -15,13 +23,9 @@ jobs:
     - task: delete-deployment
       config:
         platform: linux
+        image_resource: *awscli-image-resource
         inputs:
-        - name: delete-timer
-        image_resource:
-          type: docker-image
-          source:
-            repository: governmentpaas/awscli
-            tag: b2495d6ed07f680125d19aa7d1701da7efabb289
+          - name: delete-timer
         params:
           VAGRANT_SSH_KEY_NAME: ((vagrant_ssh_key_name))
         run:

--- a/concourse/pipelines/create-bosh-concourse.yml
+++ b/concourse/pipelines/create-bosh-concourse.yml
@@ -1088,23 +1088,6 @@ jobs:
           params:
             file: updated-concourse-tfstate/concourse.tfstate
 
-      # Temporary task to add the git-${DEPLOY_ENV} user to git group
-      - task: add-git-user-to-group
-        config:
-          platform: linux
-          image_resource: *awscli-image-resource
-          inputs:
-          - name: paas-bootstrap
-          params:
-            DEPLOY_ENV: ((deploy_env))
-          run:
-            path: sh
-            args:
-            - -e
-            - -c
-            - |
-              aws iam add-user-to-group --user-name "git-${DEPLOY_ENV}" --group-name concourse-pool-git-rw
-
   - name: generate-concourse-config
     serial: true
     plan:

--- a/concourse/pipelines/create-bosh-concourse.yml
+++ b/concourse/pipelines/create-bosh-concourse.yml
@@ -1,4 +1,47 @@
 ---
+meta:
+  containers:
+    awscli: &awscli-image-resource
+      type: docker-image
+      source:
+        repository: governmentpaas/awscli
+        tag: b2495d6ed07f680125d19aa7d1701da7efabb289
+    bosh-cli-v2: &gov-paas-bosh-cli-v2-image-resource
+      type: docker-image
+      source:
+        repository: governmentpaas/bosh-cli-v2
+        tag: 93e168b4244873902cd552ae08fc4a67a7b2e6f5
+    certstrap: &certstrap-image-resource
+      type: docker-image
+      source:
+        repository: governmentpaas/certstrap
+        tag: 895cf6752c8ec64af05a3a735186b90acd3db65a
+    git-ssh: &git-ssh-image-resource
+      type: docker-image
+      source:
+        repository: governmentpaas/git-ssh
+        tag: 895cf6752c8ec64af05a3a735186b90acd3db65a
+    ruby-slim: &ruby-slim-image-resource
+      type: docker-image
+      source:
+        repository: ruby
+        tag: 2.5-slim
+    self-update-pipelines: &self-update-pipelines-image-resource
+      type: docker-image
+      source:
+        repository: governmentpaas/self-update-pipelines
+        tag: 0eff5b6a9c092f865a2b19cc4e75a3b539b82fa2
+    spruce: &spruce-image-resource
+      type: docker-image
+      source:
+        repository: governmentpaas/spruce
+        tag: 895cf6752c8ec64af05a3a735186b90acd3db65a
+    terraform: &terraform-image-resource
+      type: docker-image
+      source:
+        repository: governmentpaas/terraform
+        tag: 9cad30b5d5889a0b72173f39701d1620e24df82c
+
 groups:
   - name: all
     jobs:
@@ -277,11 +320,7 @@ jobs:
       - task: try-fetch-bucket-state
         config:
           platform: linux
-          image_resource:
-            type: docker-image
-            source:
-              repository: governmentpaas/awscli
-              tag: b2495d6ed07f680125d19aa7d1701da7efabb289
+          image_resource: *awscli-image-resource
           params:
             AWS_DEFAULT_REGION: ((aws_region))
           inputs:
@@ -301,11 +340,7 @@ jobs:
       - task: create-init-bucket
         config:
           platform: linux
-          image_resource:
-            type: docker-image
-            source:
-              repository: governmentpaas/terraform
-              tag: 9cad30b5d5889a0b72173f39701d1620e24df82c
+          image_resource: *terraform-image-resource
           params:
             TF_VAR_env: ((deploy_env))
             TF_VAR_state_bucket: ((state_bucket))
@@ -337,11 +372,7 @@ jobs:
       - task: self-update-pipelines
         config:
           platform: linux
-          image_resource:
-            type: docker-image
-            source:
-              repository: governmentpaas/self-update-pipelines
-              tag: 0eff5b6a9c092f865a2b19cc4e75a3b539b82fa2
+          image_resource: *self-update-pipelines-image-resource
           inputs:
             - name: paas-bootstrap
           params:
@@ -378,11 +409,7 @@ jobs:
       - task: generate-git-ssh-keys
         config:
           platform: linux
-          image_resource:
-            type: docker-image
-            source:
-              repository: governmentpaas/awscli
-              tag: b2495d6ed07f680125d19aa7d1701da7efabb289
+          image_resource: *awscli-image-resource
           inputs:
           - name: paas-bootstrap
           - name: git-ssh-public-key
@@ -418,11 +445,7 @@ jobs:
       - task: deploy-vpc
         config:
           platform: linux
-          image_resource:
-            type: docker-image
-            source:
-              repository: governmentpaas/terraform
-              tag: 9cad30b5d5889a0b72173f39701d1620e24df82c
+          image_resource: *terraform-image-resource
           inputs:
           - name: paas-bootstrap
           - name: vpc-tfstate
@@ -474,11 +497,7 @@ jobs:
       - task: generate-bosh-CA
         config:
           platform: linux
-          image_resource:
-            type: docker-image
-            source:
-              repository: governmentpaas/certstrap
-              tag: 895cf6752c8ec64af05a3a735186b90acd3db65a
+          image_resource: *certstrap-image-resource
           inputs:
             - name: paas-bootstrap
             - name: bosh-CA
@@ -514,11 +533,7 @@ jobs:
         - task: generate-bosh-certs
           config:
             platform: linux
-            image_resource:
-              type: docker-image
-              source:
-                repository: governmentpaas/certstrap
-                tag: 465642da06051a55630d39c899697b678f66a7f7
+            image_resource: *certstrap-image-resource
             inputs:
               - name: bosh-CA
               - name: paas-bootstrap
@@ -551,11 +566,7 @@ jobs:
         - task: generate-bosh-secrets
           config:
             platform: linux
-            image_resource:
-              type: docker-image
-              source:
-                repository: ruby
-                tag: 2.5-slim
+            image_resource: *ruby-slim-image-resource
             inputs:
               - name: paas-bootstrap
               - name: bosh-secrets
@@ -581,11 +592,7 @@ jobs:
         - task: generate-bosh-ssh-keypair
           config:
             platform: linux
-            image_resource:
-              type: docker-image
-              source:
-                repository: governmentpaas/git-ssh
-                tag: 895cf6752c8ec64af05a3a735186b90acd3db65a
+            image_resource: *git-ssh-image-resource
             inputs:
               - name: paas-bootstrap
               - name: bosh-ssh-private-key
@@ -623,11 +630,7 @@ jobs:
         - task: generate-deployments-ssh-keypair
           config:
             platform: linux
-            image_resource:
-              type: docker-image
-              source:
-                repository: governmentpaas/git-ssh
-                tag: 895cf6752c8ec64af05a3a735186b90acd3db65a
+            image_resource: *git-ssh-image-resource
             inputs:
               - name: paas-bootstrap
               - name: ssh-private-key
@@ -665,11 +668,7 @@ jobs:
       - task: generate-concourse-secrets
         config:
           platform: linux
-          image_resource:
-            type: docker-image
-            source:
-              repository: ruby
-              tag: 2.5-slim
+          image_resource: *ruby-slim-image-resource
           inputs:
           - name: paas-bootstrap
           - name: concourse-secrets
@@ -713,11 +712,7 @@ jobs:
       - task: extract-terraform-variables
         config:
           platform: linux
-          image_resource:
-            type: docker-image
-            source:
-              repository: ruby
-              tag: 2.5-slim
+          image_resource: *ruby-slim-image-resource
           inputs:
             - name: paas-bootstrap
             - name: vpc-tfstate
@@ -738,11 +733,7 @@ jobs:
       - task: terraform-apply
         config:
           platform: linux
-          image_resource:
-            type: docker-image
-            source:
-              repository: governmentpaas/terraform
-              tag: 9cad30b5d5889a0b72173f39701d1620e24df82c
+          image_resource: *terraform-image-resource
           inputs:
             - name: paas-bootstrap
             - name: terraform-variables
@@ -809,11 +800,7 @@ jobs:
       - task: extract_terraform_outputs
         config:
           platform: linux
-          image_resource:
-            type: docker-image
-            source:
-              repository: ruby
-              tag: 2.5-slim
+          image_resource: *ruby-slim-image-resource
           inputs:
             - name: paas-bootstrap
             - name: vpc-tfstate
@@ -836,11 +823,7 @@ jobs:
       - task: extract-bosh-CA-and-certs
         config:
           platform: linux
-          image_resource:
-            type: docker-image
-            source:
-              repository: governmentpaas/certstrap
-              tag: 895cf6752c8ec64af05a3a735186b90acd3db65a
+          image_resource: *certstrap-image-resource
           inputs:
             - name: paas-bootstrap
             - name: bosh-CA
@@ -871,11 +854,7 @@ jobs:
       - task: render-bosh-manifest
         config:
           platform: linux
-          image_resource:
-            type: docker-image
-            source:
-              repository: governmentpaas/spruce
-              tag: 895cf6752c8ec64af05a3a735186b90acd3db65a
+          image_resource: *spruce-image-resource
           inputs:
             - name: paas-bootstrap
             - name: terraform-outputs
@@ -934,11 +913,7 @@ jobs:
       - task: bosh-create-env
         config:
           platform: linux
-          image_resource: &gov-paas-bosh-cli-v2-image-resource
-            type: docker-image
-            source:
-              repository: governmentpaas/bosh-cli-v2
-              tag: 93e168b4244873902cd552ae08fc4a67a7b2e6f5
+          image_resource: *gov-paas-bosh-cli-v2-image-resource
           inputs:
             - name: bosh-manifest
             - name: bosh-init-state
@@ -986,11 +961,7 @@ jobs:
       - task: terraform-outputs-to-sh
         config:
           platform: linux
-          image_resource:
-            type: docker-image
-            source:
-              repository: ruby
-              tag: 2.5-slim
+          image_resource: *ruby-slim-image-resource
           inputs:
           - name: paas-bootstrap
           - name: vpc-tfstate
@@ -1016,11 +987,7 @@ jobs:
       - task: generate-acm-certs
         config:
           platform: linux
-          image_resource:
-            type: docker-image
-            source:
-              repository: governmentpaas/awscli
-              tag: b2495d6ed07f680125d19aa7d1701da7efabb289
+          image_resource: *awscli-image-resource
           inputs:
             - name: paas-bootstrap
           params:
@@ -1041,11 +1008,7 @@ jobs:
       - task: generate-concourse-ssh-keys
         config:
           platform: linux
-          image_resource:
-            type: docker-image
-            source:
-              repository: governmentpaas/awscli
-              tag: b2495d6ed07f680125d19aa7d1701da7efabb289
+          image_resource: *awscli-image-resource
           inputs:
           - name: paas-bootstrap
           - name: concourse-ssh-public-key
@@ -1082,11 +1045,7 @@ jobs:
       - task: terraform-apply
         config:
           platform: linux
-          image_resource:
-            type: docker-image
-            source:
-              repository: governmentpaas/terraform
-              tag: 9cad30b5d5889a0b72173f39701d1620e24df82c
+          image_resource: *terraform-image-resource
           inputs:
           - name: paas-bootstrap
           - name: vpc-terraform-outputs
@@ -1133,11 +1092,7 @@ jobs:
       - task: add-git-user-to-group
         config:
           platform: linux
-          image_resource:
-            type: docker-image
-            source:
-              repository: governmentpaas/awscli
-              tag: b2495d6ed07f680125d19aa7d1701da7efabb289
+          image_resource: *awscli-image-resource
           inputs:
           - name: paas-bootstrap
           params:
@@ -1169,11 +1124,7 @@ jobs:
       - task: terraform-outputs-to-yaml
         config:
           platform: linux
-          image_resource:
-            type: docker-image
-            source:
-              repository: ruby
-              tag: 2.5-slim
+          image_resource: *ruby-slim-image-resource
           inputs:
           - name: paas-bootstrap
           - name: concourse-tfstate
@@ -1205,11 +1156,7 @@ jobs:
       - task: generate-concourse-manifest
         config:
           platform: linux
-          image_resource:
-            type: docker-image
-            source:
-              repository: governmentpaas/spruce
-              tag: 895cf6752c8ec64af05a3a735186b90acd3db65a
+          image_resource: *spruce-image-resource
           params:
             AWS_ACCOUNT: ((aws_account))
             DATADOG_API_KEY: ((datadog_api_key))
@@ -1413,11 +1360,7 @@ jobs:
       - task: upload-pipeline
         config:
           platform: linux
-          image_resource:
-            type: docker-image
-            source:
-              repository: governmentpaas/self-update-pipelines
-              tag: 0eff5b6a9c092f865a2b19cc4e75a3b539b82fa2
+          image_resource: *self-update-pipelines-image-resource
           inputs:
             - name: paas-bootstrap
           params:
@@ -1454,11 +1397,7 @@ jobs:
       - task: terraform-outputs-to-sh
         config:
           platform: linux
-          image_resource:
-            type: docker-image
-            source:
-              repository: ruby
-              tag: 2.5-slim
+          image_resource: *ruby-slim-image-resource
           inputs:
           - name: paas-bootstrap
           - name: vpc-tfstate
@@ -1484,11 +1423,7 @@ jobs:
       - task: remove-concourse-IP-from-ssh-SG
         config:
           platform: linux
-          image_resource:
-            type: docker-image
-            source:
-              repository: governmentpaas/terraform
-              tag: 9cad30b5d5889a0b72173f39701d1620e24df82c
+          image_resource: *terraform-image-resource
           inputs:
           - name: paas-bootstrap
           - name: vpc-tfstate
@@ -1521,11 +1456,7 @@ jobs:
       - task: remove-concourse-IP-from-BOSH-SG
         config:
           platform: linux
-          image_resource:
-            type: docker-image
-            source:
-              repository: governmentpaas/terraform
-              tag: 9cad30b5d5889a0b72173f39701d1620e24df82c
+          image_resource: *terraform-image-resource
           inputs:
           - name: paas-bootstrap
           - name: vpc-terraform-outputs
@@ -1566,11 +1497,7 @@ jobs:
       - task: remove-concourse-IP-from-Concourse-SG
         config:
           platform: linux
-          image_resource:
-            type: docker-image
-            source:
-              repository: governmentpaas/terraform
-              tag: 9cad30b5d5889a0b72173f39701d1620e24df82c
+          image_resource: *terraform-image-resource
           inputs:
           - name: paas-bootstrap
           - name: vpc-terraform-outputs
@@ -1615,11 +1542,7 @@ jobs:
       - task: clear-passwords
         config:
           platform: linux
-          image_resource:
-            type: docker-image
-            source:
-              repository: governmentpaas/spruce
-              tag: 895cf6752c8ec64af05a3a735186b90acd3db65a
+          image_resource: *spruce-image-resource
           inputs:
             - name: paas-bootstrap
             - name: concourse-secrets
@@ -1655,11 +1578,7 @@ jobs:
       - task: clear-passwords
         config:
           platform: linux
-          image_resource:
-            type: docker-image
-            source:
-              repository: governmentpaas/spruce
-              tag: 895cf6752c8ec64af05a3a735186b90acd3db65a
+          image_resource: *spruce-image-resource
           inputs:
             - name: paas-bootstrap
             - name: bosh-secrets
@@ -1698,11 +1617,7 @@ jobs:
     - task: rotate-bosh-internal-certs
       config:
         platform: linux
-        image_resource:
-          type: docker-image
-          source:
-            repository: governmentpaas/certstrap
-            tag: 465642da06051a55630d39c899697b678f66a7f7
+        image_resource: *certstrap-image-resource
         inputs:
           - name: bosh-CA
           - name: paas-bootstrap
@@ -1741,11 +1656,7 @@ jobs:
     - task: delete-old-bosh-internal-certs
       config:
         platform: linux
-        image_resource:
-          type: docker-image
-          source:
-            repository: governmentpaas/certstrap
-            tag: 465642da06051a55630d39c899697b678f66a7f7
+        image_resource: *certstrap-image-resource
         inputs:
           - name: paas-bootstrap
           - name: bosh-certs

--- a/concourse/pipelines/create-bosh-concourse.yml
+++ b/concourse/pipelines/create-bosh-concourse.yml
@@ -40,7 +40,7 @@ meta:
       type: docker-image
       source:
         repository: governmentpaas/terraform
-        tag: 9cad30b5d5889a0b72173f39701d1620e24df82c
+        tag: 6efea7a479f9336019155cc039ad33d2c8845cb0
 
 groups:
   - name: all

--- a/concourse/pipelines/destroy-bosh-concourse.yml
+++ b/concourse/pipelines/destroy-bosh-concourse.yml
@@ -25,7 +25,7 @@ meta:
       type: docker-image
       source:
         repository: governmentpaas/terraform
-        tag: 9cad30b5d5889a0b72173f39701d1620e24df82c
+        tag: 6efea7a479f9336019155cc039ad33d2c8845cb0
 
 resource_types:
 - name: s3-iam

--- a/concourse/pipelines/destroy-bosh-concourse.yml
+++ b/concourse/pipelines/destroy-bosh-concourse.yml
@@ -1,4 +1,32 @@
 ---
+meta:
+  containers:
+    awscli: &awscli-image-resource
+      type: docker-image
+      source:
+        repository: governmentpaas/awscli
+        tag: b2495d6ed07f680125d19aa7d1701da7efabb289
+    bosh-cli-v2: &gov-paas-bosh-cli-v2-image-resource
+      type: docker-image
+      source:
+        repository: governmentpaas/bosh-cli-v2
+        tag: 93e168b4244873902cd552ae08fc4a67a7b2e6f5
+    ruby-slim: &ruby-slim-image-resource
+      type: docker-image
+      source:
+        repository: ruby
+        tag: 2.5-slim
+    self-update-pipelines: &self-update-pipelines-image-resource
+      type: docker-image
+      source:
+        repository: governmentpaas/self-update-pipelines
+        tag: 0eff5b6a9c092f865a2b19cc4e75a3b539b82fa2
+    terraform: &terraform-image-resource
+      type: docker-image
+      source:
+        repository: governmentpaas/terraform
+        tag: 9cad30b5d5889a0b72173f39701d1620e24df82c
+
 resource_types:
 - name: s3-iam
   type: docker-image
@@ -98,11 +126,7 @@ jobs:
       - task: upload-pipeline
         config:
           platform: linux
-          image_resource:
-            type: docker-image
-            source:
-              repository: governmentpaas/self-update-pipelines
-              tag: 0eff5b6a9c092f865a2b19cc4e75a3b539b82fa2
+          image_resource: *self-update-pipelines-image-resource
           inputs:
             - name: paas-bootstrap
           params:
@@ -135,11 +159,7 @@ jobs:
       - task: vpc-terraform-outputs-to-sh
         config:
           platform: linux
-          image_resource:
-            type: docker-image
-            source:
-              repository: ruby
-              tag: "2.5-slim"
+          image_resource: *ruby-slim-image-resource
           inputs:
           - name: paas-bootstrap
           - name: vpc-tfstate
@@ -159,11 +179,7 @@ jobs:
       - task: add-concourse-IP-to-BOSH-SG
         config:
           platform: linux
-          image_resource:
-            type: docker-image
-            source:
-              repository: governmentpaas/terraform
-              tag: 9cad30b5d5889a0b72173f39701d1620e24df82c
+          image_resource: *terraform-image-resource
           inputs:
             - name: paas-bootstrap
             - name: vpc-terraform-outputs
@@ -221,11 +237,7 @@ jobs:
       - task: destroy-concourse
         config:
           platform: linux
-          image_resource: &gov-paas-bosh-cli-v2-image-resource
-            type: docker-image
-            source:
-              repository: governmentpaas/bosh-cli-v2
-              tag: 93e168b4244873902cd552ae08fc4a67a7b2e6f5
+          image_resource: *gov-paas-bosh-cli-v2-image-resource
           inputs:
           - name: paas-bootstrap
           - name: bosh-secrets
@@ -259,11 +271,7 @@ jobs:
       - task: vpc-terraform-outputs-to-sh
         config:
           platform: linux
-          image_resource:
-            type: docker-image
-            source:
-              repository: ruby
-              tag: "2.5-slim"
+          image_resource: *ruby-slim-image-resource
           inputs:
           - name: paas-bootstrap
           - name: vpc-tfstate
@@ -283,11 +291,7 @@ jobs:
       - task: destroy-concourse-terraform
         config:
           platform: linux
-          image_resource:
-            type: docker-image
-            source:
-              repository: governmentpaas/terraform
-              tag: 9cad30b5d5889a0b72173f39701d1620e24df82c
+          image_resource: *terraform-image-resource
           inputs:
             - name: paas-bootstrap
             - name: vpc-terraform-outputs
@@ -331,11 +335,7 @@ jobs:
       - task: delete-acm-certs
         config:
           platform: linux
-          image_resource:
-            type: docker-image
-            source:
-              repository: governmentpaas/awscli
-              tag: b2495d6ed07f680125d19aa7d1701da7efabb289
+          image_resource: *awscli-image-resource
           inputs:
             - name: paas-bootstrap
           params:
@@ -481,11 +481,7 @@ jobs:
       - task: extract-terraform-variables
         config:
           platform: linux
-          image_resource:
-            type: docker-image
-            source:
-              repository: ruby
-              tag: "2.5-slim"
+          image_resource: *ruby-slim-image-resource
           inputs:
             - name: paas-bootstrap
             - name: vpc-tfstate
@@ -506,11 +502,7 @@ jobs:
       - task: destroy-terraform
         config:
           platform: linux
-          image_resource:
-            type: docker-image
-            source:
-              repository: governmentpaas/terraform
-              tag: 9cad30b5d5889a0b72173f39701d1620e24df82c
+          image_resource: *terraform-image-resource
           inputs:
             - name: paas-bootstrap
             - name: terraform-variables
@@ -565,11 +557,7 @@ jobs:
       - task: tf-destroy-vpc
         config:
           platform: linux
-          image_resource:
-            type: docker-image
-            source:
-              repository: governmentpaas/terraform
-              tag: 9cad30b5d5889a0b72173f39701d1620e24df82c
+          image_resource: *terraform-image-resource
           params:
               TF_VAR_env: ((deploy_env))
               AWS_DEFAULT_REGION: ((aws_region))
@@ -610,11 +598,7 @@ jobs:
       - task: tf-destroy-init-bucket
         config:
           platform: linux
-          image_resource:
-            type: docker-image
-            source:
-              repository: governmentpaas/terraform
-              tag: 9cad30b5d5889a0b72173f39701d1620e24df82c
+          image_resource: *terraform-image-resource
           params:
               TF_VAR_env: ((deploy_env))
               TF_VAR_state_bucket: ((state_bucket))

--- a/terraform/concourse/codecommit.tf
+++ b/terraform/concourse/codecommit.tf
@@ -9,28 +9,10 @@ resource "aws_iam_user" "git" {
   name = "git-${var.env}"
 }
 
-# Until this feature request is not solved https://github.com/hashicorp/terraform/issues/5778,
-# `aws_iam_group_membership` will wipe all the other members from the
-# shared group.
-#
-# The workaround is use aws cli:
-#
-#   aws iam add-user-to-group --user-name git-${DEPLOY_ENV} --group-name concourse-pool-git-rw
-#
-# We could do it using terraform provisioner local-exec calling out awscli
-# but we want to avoid this pattern so we will do it in a script in
-# the next step.
-#
-# Once they fix it upstream, we can replace it with this code:
-#
-# resource "aws_iam_group_membership" "concourse-pool-git-rw" {
-#    name = "concourse-pool-git-rw"
-#    group = "concourse-pool-git-rw"
-#    users = [
-#        "${aws_iam_user.git.name}",
-#    ]
-#    append = true
-#}
+resource "aws_iam_user_group_membership" "git_concourse_pool" {
+  user   = "${aws_iam_user.git.name}"
+  groups = ["concourse-pool-git-rw"]
+}
 
 resource "aws_iam_user_ssh_key" "git" {
   username   = "${aws_iam_user.git.name}"


### PR DESCRIPTION
What
----

This upgrades the AWS Terraform provider and fixes a workaround that's no longer needed.

This is a precursor to switching to using Terraform to generate ACM certs. The version of the provider we're currently running doesn't support the necessary resources to enable this.

I've also taken the opportunity to DRY the pipeline image_resource definitions.

How to review
-------------

Run the pipeline from this branch, verify everything works.

## 🚨 Before merging 🚨 

* Merge https://github.com/alphagov/paas-docker-cloudfoundry-tools/pull/145
* Update the TMP commit.

Who can review
--------------

Not me.