### PR TITLE
[Support] Upgrade Go version for unit tests to 1.11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,7 +36,7 @@ before_install:
     mv spruce-linux-amd64 ~/bin/spruce && chmod +x ~/bin/spruce
   - pip install --user yamllint
 
-  - eval "$(gimme 1.6)"
+  - eval "$(gimme 1.11)"
   - export GOPATH=$HOME/gopath
   - export PATH=$HOME/gopath/bin:$PATH
   - go get github.com/onsi/ginkgo/ginkgo


### PR DESCRIPTION
## What

Gomega (which the unit tests use, but don't pin) recently started using
type aliases[1]. There were introduced in Go 1.9[2]

[1]https://github.com/onsi/gomega/commit/03b0461
[2]https://golang.org/doc/go1.9#language

How to review
-------------

Code review. Verify Travis passes

Who can review
--------------

Not me.