### PR TITLE
[#162303736] Add the deploy env tag to the Bosh and Concourse EC2 instances

### DIFF
--- a/manifests/bosh-manifest/bosh-manifest.yml
+++ b/manifests/bosh-manifest/bosh-manifest.yml
@@ -296,3 +296,6 @@ networks:
       - (( grab terraform_outputs.ssh_security_group ))
 - name: public
   type: vip
+
+tags:
+  deploy_env: (( grab terraform_outputs.environment ))

--- a/manifests/concourse-manifest/concourse-base.yml
+++ b/manifests/concourse-manifest/concourse-base.yml
@@ -172,3 +172,6 @@ update:
   max_in_flight: 1
   canary_watch_time: 30000-600000
   update_watch_time: 5000-600000
+
+tags:
+  deploy_env: (( grab terraform_outputs.environment ))


### PR DESCRIPTION
# What

This adds a `deploy_env` tag to the Bosh and Concourse EC2 instances. It will cause the Bosh director to be recreated. The Concourse instance will only get the new tag when it's recreated.

This change won't effect the instances in the CF deployment.

There is currently no EC2 tag that we can use for filtering EC2 instances based on the deployment environment.

# How to review

Deploy and run the create-bosh-concourse pipeline from this branch.

# Who can review

Not me