### PR TITLE
[#162757517] Upgrade concourse to 4.2.2

### DIFF
--- a/manifests/concourse-manifest/concourse-base.yml
+++ b/manifests/concourse-manifest/concourse-base.yml
@@ -11,10 +11,11 @@ name: concourse
 releases:
   # TODO: Use the upstream build again after the following PR was released:
   # https://github.com/concourse/concourse/pull/2785
+  # This version is 4.2.2 + the above change
   - name: concourse
-    version: 0.1.2
-    url: https://s3-eu-west-1.amazonaws.com/gds-paas-build-releases/concourse-0.1.2.tgz
-    sha1: 235619dee581f10c2eecd2e1f52bbaf64b53edfe
+    version: 0.1.3
+    url: https://s3-eu-west-1.amazonaws.com/gds-paas-build-releases/concourse-0.1.3.tgz
+    sha1: 77a0ce9f8e32a157bd40b4c4cd85325f9cc77a0c
   - name: garden-runc
     version: ((!garden_runc_version))
     url: https://bosh.io/d/github.com/cloudfoundry/garden-runc-release?v=((!garden_runc_version))


### PR DESCRIPTION
## What

This Updates concourse to an updated version of our fork which is
upstream version 4.2.2 + the change in https://github.com/concourse/concourse/pull/2785

We're upgrading to 4.2.2 to fix an open redirect vulnerability -
https://concourse-ci.org/download.html#v422

How to review
-------------

I've already deployed this version to my dev environment, so code review is probably enough.

Who can review
--------------

Not me.