### PR TITLE
[#161591823] Align bosh-manifest.yml to upstream bosh-deployment manifest

### DIFF
--- a/concourse/scripts/extract_terraform_state_to_yaml.rb
+++ b/concourse/scripts/extract_terraform_state_to_yaml.rb
@@ -5,9 +5,9 @@ require 'yaml'
 
 outputs = JSON.parse($stdin.read)
 
-terraform_outputs = { 'terraform_outputs' => {} }
+terraform_outputs = {}
 outputs['modules'][0]['outputs'].each { |k, v|
-  terraform_outputs['terraform_outputs'][k] = v.fetch("value")
+  terraform_outputs["terraform_outputs_#{k}"] = v.fetch("value")
 }
 
 puts YAML.dump(terraform_outputs)

--- a/concourse/scripts/extract_terraform_state_to_yaml_test.go
+++ b/concourse/scripts/extract_terraform_state_to_yaml_test.go
@@ -66,10 +66,9 @@ var _ = Describe("ExtractTerraformStateToYAML", func() {
 
 		It("returns a YAML containing all the output values", func() {
 			Eventually(session).Should(gexec.Exit(0))
-			Expect(session.Out).To(gbytes.Say("terraform_outputs:\n"))
-			Expect(session.Out).To(gbytes.Say("\\s+foo_dns_name: foo.example.com"))
-			Expect(session.Out).To(gbytes.Say("\\s+foo_elastic_ip: 10.210.221.248"))
-			Expect(session.Out).To(gbytes.Say("\\s+foo_security_group_id: sg-12345678"))
+			Expect(session.Out).To(gbytes.Say("terraform_outputs_foo_dns_name: foo.example.com"))
+			Expect(session.Out).To(gbytes.Say("terraform_outputs_foo_elastic_ip: 10.210.221.248"))
+			Expect(session.Out).To(gbytes.Say("terraform_outputs_foo_security_group_id: sg-12345678"))
 		})
 	})
 

--- a/manifests/bosh-manifest/bosh-manifest.yml
+++ b/manifests/bosh-manifest/bosh-manifest.yml
@@ -65,8 +65,8 @@ instance_groups:
       uaa:
         url: (( concat "https://" $BOSH_FQDN ":8443" ))
         port: -1
-        sslPrivateKey: (( grab secrets.bosh_uaa_cert ))
-        sslCertificate: (( grab secrets.bosh_uaa_key ))
+        sslPrivateKey: (( grab secrets.bosh_uaa_key ))
+        sslCertificate: (( grab secrets.bosh_uaa_cert ))
         jwt:
           policy:
             active_key_id: uaa-jwt-key-1

--- a/manifests/bosh-manifest/bosh-manifest.yml
+++ b/manifests/bosh-manifest/bosh-manifest.yml
@@ -2,22 +2,22 @@
 name: bosh
 
 meta:
-  environment: (( grab terraform_outputs.environment ))
+  environment: (( grab terraform_outputs_environment ))
   rds:
-    host: (( grab terraform_outputs.bosh_db_address ))
-    port: (( grab terraform_outputs.bosh_db_port ))
-    user: (( grab terraform_outputs.bosh_db_username ))
+    host: (( grab terraform_outputs_bosh_db_address ))
+    port: (( grab terraform_outputs_bosh_db_port ))
+    user: (( grab terraform_outputs_bosh_db_username ))
     password: (( grab secrets.bosh_postgres_password ))
-    database: (( grab terraform_outputs.bosh_db_dbname ))
+    database: (( grab terraform_outputs_bosh_db_dbname ))
     adapter: postgres
   aws:
     default_security_groups:
-    - (( grab terraform_outputs.bosh_managed_security_group ))
-    region: (( grab terraform_outputs.region ))
+    - (( grab terraform_outputs_bosh_managed_security_group ))
+    region: (( grab terraform_outputs_region ))
     max_retries: 16
 
-  bosh_private_ip: (( grab terraform_outputs.microbosh_static_private_ip ))
-  bosh_public_ip: (( grab terraform_outputs.microbosh_static_public_ip ))
+  bosh_private_ip: (( grab terraform_outputs_microbosh_static_private_ip ))
+  bosh_public_ip: (( grab terraform_outputs_microbosh_static_public_ip ))
 
 releases:
 - name: "bosh"
@@ -113,8 +113,8 @@ instance_groups:
               passphrase: ""
 
       uaadb:
-        address: (( grab terraform_outputs.bosh_db_address ))
-        port: (( grab terraform_outputs.bosh_db_port ))
+        address: (( grab terraform_outputs_bosh_db_address ))
+        port: (( grab terraform_outputs_bosh_db_port ))
         db_scheme: postgresql
         databases:
         - tag: uaa
@@ -139,7 +139,7 @@ instance_groups:
   properties:
 
     init-db:
-      connection_string: (( concat "postgres://" terraform_outputs.bosh_db_username ":" secrets.bosh_postgres_password "@" terraform_outputs.bosh_db_address ":" terraform_outputs.bosh_db_port "/postgres" ))
+      connection_string: (( concat "postgres://" terraform_outputs_bosh_db_username ":" secrets.bosh_postgres_password "@" terraform_outputs_bosh_db_address ":" terraform_outputs_bosh_db_port "/postgres" ))
       databases:
       - name: uaa
         owner: uaa
@@ -149,7 +149,7 @@ instance_groups:
       roles:
       - name: uaa
         password: (( grab secrets.bosh_uaa_postgres_password ))
-        parent_role: (( grab terraform_outputs.bosh_db_username ))
+        parent_role: (( grab terraform_outputs_bosh_db_username ))
     nats:
       address: (( grab meta.bosh_private_ip ))
       tls:
@@ -225,12 +225,12 @@ instance_groups:
     blobstore:
       provider: s3
       credentials_source: env_or_profile
-      bucket_name: (( grab terraform_outputs.bosh_blobstore_bucket_name ))
+      bucket_name: (( grab terraform_outputs_bosh_blobstore_bucket_name ))
       s3_region: (( grab meta.aws.region ))
 
     aws:
       credentials_source: env_or_profile
-      default_key_name: (( grab terraform_outputs.key_pair_name ))
+      default_key_name: (( grab terraform_outputs_key_pair_name ))
       default_security_groups: (( grab meta.aws.default_security_groups ))
       default_iam_instance_profile: bosh-managed
       region: (( grab meta.aws.region ))
@@ -260,7 +260,7 @@ cloud_provider:
       path: /var/vcap/micro_bosh/data/cache
     aws:
       credentials_source: env_or_profile
-      default_key_name: (( grab terraform_outputs.bosh_ssh_key_pair_name ))
+      default_key_name: (( grab terraform_outputs_bosh_ssh_key_pair_name ))
       default_security_groups: (( grab meta.aws.default_security_groups ))
       region: (( grab meta.aws.region ))
       max_retries: (( grab meta.aws.max_retries ))
@@ -282,7 +282,7 @@ resource_pools:
   cloud_properties:
     instance_type: t2.medium
     ephemeral_disk: {size: 25000, type: gp2}
-    availability_zone: (( grab terraform_outputs.bosh_az ))
+    availability_zone: (( grab terraform_outputs_bosh_az ))
     iam_instance_profile: (( grab $BOSH_INSTANCE_PROFILE ))
   env:
     bosh:
@@ -292,17 +292,17 @@ networks:
 - name: default
   type: manual
   subnets:
-  - range: (( grab terraform_outputs.bosh_subnet_cidr ))
-    gateway: (( grab terraform_outputs.bosh_default_gw ))
+  - range: (( grab terraform_outputs_bosh_subnet_cidr ))
+    gateway: (( grab terraform_outputs_bosh_default_gw ))
     dns: [10.0.0.2]
     cloud_properties:
-      subnet: (( grab terraform_outputs.bosh_subnet_id ))
+      subnet: (( grab terraform_outputs_bosh_subnet_id ))
       security_groups:
-      - (( grab terraform_outputs.bosh_security_group ))
-      - (( grab terraform_outputs.ssh_security_group ))
+      - (( grab terraform_outputs_bosh_security_group ))
+      - (( grab terraform_outputs_ssh_security_group ))
     static: [10.0.0.6]
 - name: public
   type: vip
 
 tags:
-  deploy_env: (( grab terraform_outputs.environment ))
+  deploy_env: (( grab terraform_outputs_environment ))

--- a/manifests/bosh-manifest/bosh-manifest.yml
+++ b/manifests/bosh-manifest/bosh-manifest.yml
@@ -9,6 +9,7 @@ meta:
     user: (( grab terraform_outputs.bosh_db_username ))
     password: (( grab secrets.bosh_postgres_password ))
     database: (( grab terraform_outputs.bosh_db_dbname ))
+    adapter: postgres
   aws:
     default_security_groups:
     - (( grab terraform_outputs.bosh_managed_security_group ))
@@ -55,11 +56,11 @@ instance_groups:
   - {name: init-db, release: db-admin}
   - {name: uaa, release: uaa}
 
-  resource_pool: bosh
+  resource_pool: vms
   persistent_disk_pool: disks
 
   networks:
-  - name: private
+  - name: default
     static_ips:
     - (( grab meta.bosh_private_ip ))
     default: [dns, gateway]
@@ -148,7 +149,7 @@ instance_groups:
         password: (( grab secrets.bosh_uaa_postgres_password ))
         parent_role: (( grab terraform_outputs.bosh_db_username ))
     nats:
-      address: 127.0.0.1
+      address: (( grab meta.bosh_private_ip ))
       tls:
         ca: (( grab secrets.bosh_ca_cert ))
         client_ca:
@@ -204,11 +205,14 @@ instance_groups:
       db: (( grab meta.rds ))
       http:
         # Properties used by director and registry jobs
-        user: admin
+        user: registry
         password: (( grab secrets.bosh_registry_password ))
+        port: 25777
       # Properties used by AWS CPI
-      host: (( grab $BOSH_FQDN ))
-      username: admin
+      host: (( grab meta.bosh_private_ip ))
+      address: (( grab meta.bosh_private_ip ))
+      port: 25777
+      username: registry
       password: (( grab secrets.bosh_registry_password ))
 
     compiled_package_cache:
@@ -263,19 +267,19 @@ cloud_provider:
 
 disk_pools:
 - name: disks
-  disk_size: 32768
+  disk_size: 65536
   cloud_properties:
     type: gp2
 
 resource_pools:
-- name: bosh
-  network: private
+- name: vms
+  network: default
   stemcell:
     url: https://bosh.io/d/stemcells/bosh-aws-xen-hvm-ubuntu-xenial-go_agent?v=170.15
     sha1: c12530cd9305e8fae2a3d0381481d05b7bd98693
   cloud_properties:
     instance_type: t2.medium
-    ephemeral_disk: {size: 40000, type: gp2}
+    ephemeral_disk: {size: 25000, type: gp2}
     availability_zone: (( grab terraform_outputs.bosh_az ))
     iam_instance_profile: (( grab $BOSH_INSTANCE_PROFILE ))
   env:
@@ -283,7 +287,7 @@ resource_pools:
       password: (( grab secrets.bosh_vcap_password ))
 
 networks:
-- name: private
+- name: default
   type: manual
   subnets:
   - range: (( grab terraform_outputs.bosh_subnet_cidr ))
@@ -294,6 +298,7 @@ networks:
       security_groups:
       - (( grab terraform_outputs.bosh_security_group ))
       - (( grab terraform_outputs.ssh_security_group ))
+    static: [10.0.0.6]
 - name: public
   type: vip
 

--- a/manifests/bosh-manifest/bosh-manifest.yml
+++ b/manifests/bosh-manifest/bosh-manifest.yml
@@ -54,7 +54,75 @@ instance_groups:
   - {name: registry, release: bosh}
   - {name: aws_cpi, release: bosh-aws-cpi}
   - {name: init-db, release: db-admin}
-  - {name: uaa, release: uaa}
+  - name: uaa
+    release: uaa
+    properties:
+      encryption:
+        encryption_keys:
+        - label: uaa-encryption-key-1
+          passphrase: (( grab secrets.bosh_uaa_uaa_encryption_key_1 ))
+        active_key_label: uaa-encryption-key-1
+      uaa:
+        url: (( concat "https://" $BOSH_FQDN ":8443" ))
+        port: -1
+        sslPrivateKey: (( grab secrets.bosh_uaa_cert ))
+        sslCertificate: (( grab secrets.bosh_uaa_key ))
+        jwt:
+          policy:
+            active_key_id: uaa-jwt-key-1
+            keys:
+              uaa-jwt-key-1:
+                signingKey: (( grab secrets.bosh_uaa_jwt_signing_key.private_key ))
+        scim:
+          groups:
+            bosh.admin: 'User has admin access on any Director'
+            bosh.read: 'User has read access on any Director'
+            bosh.stemcells.upload: 'User can upload new stemcells'
+            bosh.releases.upload: 'User can upload new releases'
+
+        clients:
+          admin:
+            override: true
+            authorized-grant-types: client_credentials
+            scope: ""
+            authorities: bosh.admin
+            secret: (( grab secrets.bosh_admin_password ))
+          hm:
+            override: true
+            authorized-grant-types: client_credentials
+            scope: ""
+            authorities: bosh.admin
+            secret: (( grab secrets.bosh_hm_director_password ))
+          bosh_exporter:
+            override: true
+            authorized-grant-types: client_credentials
+            scope: ""
+            authorities: bosh.read
+            secret: (( grab secrets.bosh_bosh_exporter_password ))
+        login:
+          client_secret: (( grab secrets.bosh_uaa_login_client_password ))
+        zones: {internal: {hostnames: []}}
+
+      login:
+        saml:
+          activeKeyId: uaa-saml-key-1
+          keys:
+            uaa-saml-key-1:
+              key: (( grab secrets.bosh_uaa_service_provider_ssl_key))
+              certificate: (( grab secrets.bosh_uaa_service_provider_ssl_cert))
+              passphrase: ""
+
+      uaadb:
+        address: (( grab terraform_outputs.bosh_db_address ))
+        port: (( grab terraform_outputs.bosh_db_port ))
+        db_scheme: postgresql
+        databases:
+        - tag: uaa
+          name: uaa
+        roles:
+        - tag: admin
+          name: uaa
+          password: (( grab secrets.bosh_uaa_postgres_password ))
 
   resource_pool: vms
   persistent_disk_pool: disks
@@ -69,72 +137,6 @@ instance_groups:
     - (( grab meta.bosh_public_ip ))
 
   properties:
-    encryption:
-      encryption_keys:
-      - label: uaa-encryption-key-1
-        passphrase: (( grab secrets.bosh_uaa_uaa_encryption_key_1 ))
-      active_key_label: uaa-encryption-key-1
-    uaa:
-      url: (( concat "https://" $BOSH_FQDN ":8443" ))
-      port: -1
-      sslPrivateKey: (( grab secrets.bosh_uaa_cert ))
-      sslCertificate: (( grab secrets.bosh_uaa_key ))
-      jwt:
-        policy:
-          active_key_id: uaa-jwt-key-1
-          keys:
-            uaa-jwt-key-1:
-              signingKey: (( grab secrets.bosh_uaa_jwt_signing_key.private_key ))
-      scim:
-        groups:
-          bosh.admin: 'User has admin access on any Director'
-          bosh.read: 'User has read access on any Director'
-          bosh.stemcells.upload: 'User can upload new stemcells'
-          bosh.releases.upload: 'User can upload new releases'
-
-      clients:
-        admin:
-          override: true
-          authorized-grant-types: client_credentials
-          scope: ""
-          authorities: bosh.admin
-          secret: (( grab secrets.bosh_admin_password ))
-        hm:
-          override: true
-          authorized-grant-types: client_credentials
-          scope: ""
-          authorities: bosh.admin
-          secret: (( grab secrets.bosh_hm_director_password ))
-        bosh_exporter:
-          override: true
-          authorized-grant-types: client_credentials
-          scope: ""
-          authorities: bosh.read
-          secret: (( grab secrets.bosh_bosh_exporter_password ))
-      login:
-        client_secret: (( grab secrets.bosh_uaa_login_client_password ))
-      zones: {internal: {hostnames: []}}
-
-    login:
-      saml:
-        activeKeyId: uaa-saml-key-1
-        keys:
-          uaa-saml-key-1:
-            key: (( grab secrets.bosh_uaa_service_provider_ssl_key))
-            certificate: (( grab secrets.bosh_uaa_service_provider_ssl_cert))
-            passphrase: ""
-
-    uaadb:
-      address: (( grab terraform_outputs.bosh_db_address ))
-      port: (( grab terraform_outputs.bosh_db_port ))
-      db_scheme: postgresql
-      databases:
-      - tag: uaa
-        name: uaa
-      roles:
-      - tag: admin
-        name: uaa
-        password: (( grab secrets.bosh_uaa_postgres_password ))
 
     init-db:
       connection_string: (( concat "postgres://" terraform_outputs.bosh_db_username ":" secrets.bosh_postgres_password "@" terraform_outputs.bosh_db_address ":" terraform_outputs.bosh_db_port "/postgres" ))

--- a/manifests/bosh-manifest/bosh-manifest.yml
+++ b/manifests/bosh-manifest/bosh-manifest.yml
@@ -220,7 +220,7 @@ instance_groups:
     compiled_package_cache:
       options:
         credentials_source: env_or_profile
-        bucket_name: (( concat "gds-paas-bosh-cache-" $AWS_ACCOUNT meta.bosh.compiled_package_cache.s3_bucket_suffix ))
+        bucket_name: (( concat "gds-paas-bosh-cache-" $AWS_ACCOUNT s3_bucket_suffix ))
 
     blobstore:
       provider: s3

--- a/manifests/bosh-manifest/eu-west-1.yml
+++ b/manifests/bosh-manifest/eu-west-1.yml
@@ -1,6 +1,2 @@
 ---
-
-meta:
-  bosh:
-    compiled_package_cache:
-      s3_bucket_suffix: ""
+s3_bucket_suffix: ""

--- a/manifests/bosh-manifest/eu-west-2.yml
+++ b/manifests/bosh-manifest/eu-west-2.yml
@@ -1,6 +1,2 @@
 ---
-
-meta:
-  bosh:
-    compiled_package_cache:
-      s3_bucket_suffix: "-eu-west-2"
+s3_bucket_suffix: "-eu-west-2"

--- a/manifests/concourse-manifest/concourse-base.yml
+++ b/manifests/concourse-manifest/concourse-base.yml
@@ -4,7 +4,7 @@ meta:
     name: bosh-aws-xen-hvm-ubuntu-xenial-go_agent
     version: "170.15"
 
-  zone: (( grab terraform_outputs.zone0 ))
+  zone: (( grab terraform_outputs_zone0 ))
 
 name: concourse
 
@@ -28,7 +28,7 @@ releases:
 properties:
   aws:
     credentials_source: env_or_profile
-    region: (( grab terraform_outputs.region ))
+    region: (( grab terraform_outputs_region ))
 
 resource_pools:
   - name: concourse
@@ -41,17 +41,17 @@ resource_pools:
       availability_zone: (( grab meta.zone ))
       iam_instance_profile: (( grab $CONCOURSE_INSTANCE_PROFILE ))
       elbs:
-      - (( grab terraform_outputs.concourse_elb_name ))
+      - (( grab terraform_outputs_concourse_elb_name ))
       ephemeral_disk:
         size: 102400
         type: gp2
-      key_name: (( grab terraform_outputs.concourse_key_pair_name ))
+      key_name: (( grab terraform_outputs_concourse_key_pair_name ))
       security_groups:
-      - (( grab terraform_outputs.bosh_managed_security_group ))
-      - (( grab terraform_outputs.concourse_security_group ))
-      - (( grab terraform_outputs.ssh_security_group ))
-      - (( grab terraform_outputs.bosh_api_client_security_group ))
-      - (( grab terraform_outputs.bosh_ssh_client_security_group ))
+      - (( grab terraform_outputs_bosh_managed_security_group ))
+      - (( grab terraform_outputs_concourse_security_group ))
+      - (( grab terraform_outputs_ssh_security_group ))
+      - (( grab terraform_outputs_bosh_api_client_security_group ))
+      - (( grab terraform_outputs_bosh_ssh_client_security_group ))
     env:
       bosh:
         password: (( grab secrets.concourse_vcap_password ))
@@ -77,7 +77,7 @@ networks:
         - 10.0.0.10 - 10.0.0.20
 
         cloud_properties:
-          subnet: (( grab terraform_outputs.subnet0_id ))
+          subnet: (( grab terraform_outputs_subnet0_id ))
   - name: public
     type: vip
 
@@ -102,7 +102,7 @@ instance_groups:
       - name: atc
         release: concourse
         properties:
-          external_url: (( concat "https://" terraform_outputs.concourse_dns_name ))
+          external_url: (( concat "https://" terraform_outputs_concourse_dns_name ))
           add_local_users:
             - (( concat "admin:" secrets.concourse_atc_password ))
           auth_duration: (( grab $CONCOURSE_AUTH_DURATION ))
@@ -158,7 +158,7 @@ instance_groups:
     networks:
       - name: public
         static_ips:
-        - (( grab terraform_outputs.concourse_elastic_ip ))
+        - (( grab terraform_outputs_concourse_elastic_ip ))
       - name: concourse
         static_ips: (( static_ips(0) ))
         default: [dns, gateway]
@@ -180,4 +180,4 @@ update:
   update_watch_time: 5000-600000
 
 tags:
-  deploy_env: (( grab terraform_outputs.environment ))
+  deploy_env: (( grab terraform_outputs_environment ))

--- a/manifests/concourse-manifest/spec/manifest_generation_spec.rb
+++ b/manifests/concourse-manifest/spec/manifest_generation_spec.rb
@@ -23,13 +23,13 @@ RSpec.describe "manifest generation" do
   it "gets values from vpc terraform outputs" do
     expect(
       manifest_with_defaults["resource_pools"].first["cloud_properties"]["availability_zone"]
-    ).to eq(fixtures["terraform_outputs"]["zone0"])
+    ).to eq(fixtures["terraform_outputs_zone0"])
   end
 
   it "gets values from concourse terraform outputs" do
     expect(
       atc_job.fetch("properties").fetch("external_url")
-    ).to eq("https://" + fixtures["terraform_outputs"]["concourse_dns_name"])
+    ).to eq("https://" + fixtures["terraform_outputs_concourse_dns_name"])
   end
 
   it "gets values from secrets" do

--- a/manifests/shared/spec/fixtures/bosh-terraform-outputs.yml
+++ b/manifests/shared/spec/fixtures/bosh-terraform-outputs.yml
@@ -1,21 +1,20 @@
 ---
-terraform_outputs:
-  bosh_subnet_id: subnet-bosh
-  bosh_security_group: bosh_security_group
-  bosh_blobstore_bucket_name: gds-paas-test-bosh-blobstore
-  bosh_managed_security_group: test-bosh-managed
-  microbosh_static_private_ip: 10.0.0.6
-  microbosh_static_public_ip: 194.1.2.4
-  bosh_db_address: 1.2.3.4
-  bosh_db_port: 5432
-  bosh_db_username: bosh
-  bosh_db_dbname: bosh
-  bosh_az: eu-west-1a
-  bosh_az_label: z1
-  bosh_default_gw: 10.0.0.1
-  bosh_subnet_cidr: 10.0.0.0/24
-  bosh_ssh_key_pair_name: bosh_keypair
-  key_pair_name: ssh_key_pair
-  bosh_api_client_security_group: bosh_api_client_sg
-  bosh_ssh_client_security_group: bosh_ssh_client_sg
-  default_security_group: test-bosh-managed
+terraform_outputs_bosh_subnet_id: subnet-bosh
+terraform_outputs_bosh_security_group: bosh_security_group
+terraform_outputs_bosh_blobstore_bucket_name: gds-paas-test-bosh-blobstore
+terraform_outputs_bosh_managed_security_group: test-bosh-managed
+terraform_outputs_microbosh_static_private_ip: 10.0.0.6
+terraform_outputs_microbosh_static_public_ip: 194.1.2.4
+terraform_outputs_bosh_db_address: 1.2.3.4
+terraform_outputs_bosh_db_port: 5432
+terraform_outputs_bosh_db_username: bosh
+terraform_outputs_bosh_db_dbname: bosh
+terraform_outputs_bosh_az: eu-west-1a
+terraform_outputs_bosh_az_label: z1
+terraform_outputs_bosh_default_gw: 10.0.0.1
+terraform_outputs_bosh_subnet_cidr: 10.0.0.0/24
+terraform_outputs_bosh_ssh_key_pair_name: bosh_keypair
+terraform_outputs_key_pair_name: ssh_key_pair
+terraform_outputs_bosh_api_client_security_group: bosh_api_client_sg
+terraform_outputs_bosh_ssh_client_security_group: bosh_ssh_client_sg
+terraform_outputs_default_security_group: test-bosh-managed

--- a/manifests/shared/spec/fixtures/concourse-terraform-outputs.yml
+++ b/manifests/shared/spec/fixtures/concourse-terraform-outputs.yml
@@ -1,9 +1,8 @@
 ---
-terraform_outputs:
-  concourse_elastic_ip: 1.2.3.4
-  concourse_security_group: concourse_sg
-  concourse_security_group_id: sg-12345678
-  concourse_elb_name: env1234-concourse
-  concourse_dns_name: concourse.env1234.dev.cloudpipeline.digital
-  git_concourse_pool_clone_full_url_ssh: "ssh://user@git-codecommit.us-east-1.amazonaws.com/v1/repos/concourse-pool-test"
-  concourse_key_pair_name: concourse_ssh_key_pair
+terraform_outputs_concourse_elastic_ip: 1.2.3.4
+terraform_outputs_concourse_security_group: concourse_sg
+terraform_outputs_concourse_security_group_id: sg-12345678
+terraform_outputs_concourse_elb_name: env1234-concourse
+terraform_outputs_concourse_dns_name: concourse.env1234.dev.cloudpipeline.digital
+terraform_outputs_git_concourse_pool_clone_full_url_ssh: "ssh://user@git-codecommit.us-east-1.amazonaws.com/v1/repos/concourse-pool-test"
+terraform_outputs_concourse_key_pair_name: concourse_ssh_key_pair

--- a/manifests/shared/spec/fixtures/vpc-terraform-outputs.yml
+++ b/manifests/shared/spec/fixtures/vpc-terraform-outputs.yml
@@ -1,12 +1,11 @@
 ---
-terraform_outputs:
-  environment: test
-  region: eu-west-1
-  vpc_cidr: 10.0.0.0/16
-  ssh_security_group: test-office-access-ssh
-  vpc_id: vpc-12345678
-  subnet0_id: subnet-12345678
-  zone0: eu-west-1a
-  zone1: eu-west-1b
-  zone2: eu-west-1c
-  infra_subnet_ids: "subnet-12345678,subnet-23456789,subnet-34567890"
+terraform_outputs_environment: test
+terraform_outputs_region: eu-west-1
+terraform_outputs_vpc_cidr: 10.0.0.0/16
+terraform_outputs_ssh_security_group: test-office-access-ssh
+terraform_outputs_vpc_id: vpc-12345678
+terraform_outputs_subnet0_id: subnet-12345678
+terraform_outputs_zone0: eu-west-1a
+terraform_outputs_zone1: eu-west-1b
+terraform_outputs_zone2: eu-west-1c
+terraform_outputs_infra_subnet_ids: "subnet-12345678,subnet-23456789,subnet-34567890"


### PR DESCRIPTION
What
----

We want to migrate to use bosh-deployment for our manifest[1]

In this PR we adapt the existing manifest to align it as much as
possible to the one in bosh deployment. The changes include:

 - rename networks and pools.
 - move some properties into jobs (uaa)
 - fix some properties
 - adapt disks sizes

once this PR is merged, the next PR to migrate to bosh-deployment
will generate a manifest without changes.

NOTE: This PR is optional, you can merge directly all the code from
https://github.com/alphagov/paas-bootstrap/pull/230 if you consider
that the changes are OK and can be deployed all together.

Also includes commit to update the stemcell for https://www.cloudfoundry.org/blog/usn-3840-1/


[1] https://github.com/cloudfoundry/bosh-deployment

Dependencies
------------

https://github.com/alphagov/paas-bootstrap/pull/230


How to review
-------------

Code review and test the deployment.


Who can review
--------------

Not me