### PR TITLE
[#162869390] Update to stemcell 170.15 to cover usn-3840-1

### DIFF
--- a/manifests/bosh-manifest/bosh-manifest.yml
+++ b/manifests/bosh-manifest/bosh-manifest.yml
@@ -271,8 +271,8 @@ resource_pools:
 - name: bosh
   network: private
   stemcell:
-    url: https://bosh.io/d/stemcells/bosh-aws-xen-hvm-ubuntu-xenial-go_agent?v=170.12
-    sha1: 94acc033c57f7603bb5eb006e7057cd9c7fdee22
+    url: https://bosh.io/d/stemcells/bosh-aws-xen-hvm-ubuntu-xenial-go_agent?v=170.15
+    sha1: c12530cd9305e8fae2a3d0381481d05b7bd98693
   cloud_properties:
     instance_type: t2.medium
     ephemeral_disk: {size: 40000, type: gp2}

--- a/manifests/concourse-manifest/concourse-base.yml
+++ b/manifests/concourse-manifest/concourse-base.yml
@@ -2,7 +2,7 @@
 meta:
   stemcell:
     name: bosh-aws-xen-hvm-ubuntu-xenial-go_agent
-    version: "170.12"
+    version: "170.15"
 
   zone: (( grab terraform_outputs.zone0 ))
 


### PR DESCRIPTION
What
----

The CVE usn-3840-1 [1] affects stemcells prior 170.14. We update
to the latest available stemcell.

[1] https://www.cloudfoundry.org/blog/usn-3840-1/

How to review
-------------

Code review

Who can review
--------------

Anyone