### PR TITLE
[#161591823] Set cert SANs with new bosh-deployment manifest.

### DIFF
--- a/manifests/bosh-manifest/operations.d/030-set-bosh-cert-san.yml
+++ b/manifests/bosh-manifest/operations.d/030-set-bosh-cert-san.yml
@@ -1,0 +1,8 @@
+
+- type: replace
+  path: /variables/name=director_ssl/options/alternative_names/-
+  value: ((bosh_fqdn))
+
+- type: replace
+  path: /variables/name=director_ssl/options/alternative_names/-
+  value: ((bosh_fqdn_external))

--- a/manifests/bosh-manifest/operations.d/031-set-vcap-password.yml
+++ b/manifests/bosh-manifest/operations.d/031-set-vcap-password.yml
@@ -2,7 +2,3 @@
 - type: replace
   path: /resource_pools/name=vms/env/bosh/password
   value: ((bosh_vcap_password))
-
-- type: replace
-  path: /resource_pools/name=vms/env/bosh/password
-  value: ((bosh_vcap_password))

--- a/manifests/bosh-manifest/operations.d/140-nats.yml
+++ b/manifests/bosh-manifest/operations.d/140-nats.yml
@@ -9,3 +9,7 @@
 - type: replace
   path: /instance_groups/name=bosh/properties/agent/mbus
   value: "nats://((bosh_fqdn)):4222"
+
+- type: replace
+  path: /variables/name=nats_server_tls/options/alternative_names/-
+  value: ((bosh_fqdn))

--- a/manifests/bosh-manifest/operations.d/201-uaa.yml
+++ b/manifests/bosh-manifest/operations.d/201-uaa.yml
@@ -19,3 +19,11 @@
     - tag: admin
       name: uaa
       password: ((uaa_postgres_password))
+
+- type: replace
+  path: /variables/name=uaa_ssl/options/alternative_names/-
+  value: ((bosh_fqdn))
+
+- type: replace
+  path: /variables/name=uaa_service_provider_ssl/options/alternative_names/-
+  value: ((bosh_fqdn))


### PR DESCRIPTION
What
----
We configure both the pipelines, and internal bosh components to connect
to bosh using a DNS name to allow us to failover to another AZ if
necessary. In order for this to work, the certs used need to include
these DNS names in their SAN. This updates the certs generated in the
manifest to have the DNS names added to the SAN to match how they were
being generated prior to the bosh-deployment migration[1].

[1]https://github.com/alphagov/paas-bootstrap/blob/f8abf3b/manifests/bosh-manifest/scripts/generate-bosh-certs.sh#L15-L22

I've also cleaned up a duplicated operation in an opsfile that I spotted.

How to review
-------------

* Deploy a brand new environment from this branch and verify that it works. (I've already done with with my `alext` env, that may be enough...)

Who can review
--------------

Not me.