### PR TITLE
[SUPPORT] Fix path to bosh-vars-store.yml in destroy-concourse job

### DIFF
--- a/concourse/pipelines/destroy-bosh-concourse.yml
+++ b/concourse/pipelines/destroy-bosh-concourse.yml
@@ -268,7 +268,7 @@ jobs:
 
               VAL_FROM_YAML=$(pwd)/paas-bootstrap/concourse/scripts/val_from_yaml.rb
               BOSH_CLIENT=admin
-              BOSH_CLIENT_SECRET=$($VAL_FROM_YAML admin_password bosh-vars-store.yml)
+              BOSH_CLIENT_SECRET=$($VAL_FROM_YAML admin_password bosh-vars-store/bosh-vars-store.yml)
               export BOSH_CLIENT
               export BOSH_CLIENT_SECRET
 


### PR DESCRIPTION
What
----

Fix path to bosh-vars-store.yml in destroy-concourse job.

The destroy-bosh-concourse pipeline fails because of this.

How to review
-------------

Code review.

Who can review
--------------

Not me.