### PR TITLE
[#163220697] Upgrade stemcell to 170.19

### DIFF
--- a/manifests/bosh-manifest/operations.d/030-set-stemcell.yml
+++ b/manifests/bosh-manifest/operations.d/030-set-stemcell.yml
@@ -2,5 +2,5 @@
 - type: replace
   path: /resource_pools/name=vms/stemcell
   value:
-    url: https://bosh.io/d/stemcells/bosh-aws-xen-hvm-ubuntu-xenial-go_agent?v=170.15
-    sha1: c12530cd9305e8fae2a3d0381481d05b7bd98693
+    url: https://bosh.io/d/stemcells/bosh-aws-xen-hvm-ubuntu-xenial-go_agent?v=170.19
+    sha1: ab90ac4c0e578835eb702ac816f765302c2e5dc4

--- a/manifests/concourse-manifest/concourse-base.yml
+++ b/manifests/concourse-manifest/concourse-base.yml
@@ -2,7 +2,7 @@
 meta:
   stemcell:
     name: bosh-aws-xen-hvm-ubuntu-xenial-go_agent
-    version: "170.15"
+    version: "170.19"
 
   zone: (( grab terraform_outputs_zone0 ))
 


### PR DESCRIPTION
What
----

While reading the stemcell changelogs we've found USN-3855-1 [1], so we'll upgrade to 170.19 [2].

[1] https://usn.ubuntu.com/3855-1/
[2] https://github.com/cloudfoundry/bosh-linux-stemcell-builder/releases/tag/ubuntu-xenial%2Fv170.19

How to review
-------------

1. Run create-bosh-concourse from this branch

Who can review
--------------

Not me.