### PR TITLE
[#163558206] Use a common vcap password for all VMs

### DIFF
--- a/concourse/pipelines/create-bosh-concourse.yml
+++ b/concourse/pipelines/create-bosh-concourse.yml
@@ -796,10 +796,10 @@ jobs:
               - |
                 ruby paas-bootstrap/concourse/scripts/extract_terraform_state_to_yaml.rb \
                   < vpc-tfstate/vpc.tfstate \
-                  > terraform-outputs/vpc.terraform-outputs.yml
+                  > terraform-outputs/vpc-terraform-outputs.yml
                 ruby paas-bootstrap/concourse/scripts/extract_terraform_state_to_yaml.rb \
                   < bosh-tfstate/bosh.tfstate \
-                  > terraform-outputs/bosh.terraform-outputs.yml
+                  > terraform-outputs/bosh-terraform-outputs.yml
 
       - task: render-bosh-manifest
         config:

--- a/concourse/pipelines/create-bosh-concourse.yml
+++ b/concourse/pipelines/create-bosh-concourse.yml
@@ -1076,12 +1076,6 @@ jobs:
           params:
             AWS_ACCOUNT: ((aws_account))
             CONCOURSE_AUTH_DURATION: ((concourse_auth_duration))
-            CONCOURSE_MANIFEST_STUBS: |
-              ./paas-bootstrap/manifests/concourse-manifest/concourse-base.yml
-              concourse-secrets/concourse-secrets.yml
-              terraform-outputs/concourse-terraform-outputs.yml
-              terraform-outputs/vpc-terraform-outputs.yml
-              terraform-outputs/bosh-terraform-outputs.yml
             CONCOURSE_INSTANCE_TYPE: ((concourse_instance_type))
             CONCOURSE_INSTANCE_PROFILE: ((concourse_instance_profile))
             ENABLE_GITHUB: ((enable_github))
@@ -1100,17 +1094,7 @@ jobs:
             - -e
             - -c
             - |
-              if [ "${ENABLE_GITHUB}" = "true" ] ; then
-                CONCOURSE_MANIFEST_STUBS="${CONCOURSE_MANIFEST_STUBS}
-                                ./paas-bootstrap/manifests/concourse-manifest/github_auth/config.yml"
-                if [ "${AWS_ACCOUNT}" = "dev" ] || [ "${AWS_ACCOUNT}" = "ci" ]; then
-                  CONCOURSE_MANIFEST_STUBS="${CONCOURSE_MANIFEST_STUBS}
-                                ./paas-bootstrap/manifests/concourse-manifest/github_auth/dev_ci_additional_users.yml"
-                fi
-              fi
-              # shellcheck disable=SC2086
-              ./paas-bootstrap/manifests/shared/build_manifest.sh $CONCOURSE_MANIFEST_STUBS \
-                > concourse-manifest/concourse-manifest.yml
+              ./paas-bootstrap/manifests/concourse-manifest/scripts/generate-manifest.sh > concourse-manifest/concourse-manifest.yml
               ls -l concourse-manifest/concourse-manifest.yml
         on_success:
           put: concourse-manifest

--- a/concourse/pipelines/create-bosh-concourse.yml
+++ b/concourse/pipelines/create-bosh-concourse.yml
@@ -1035,6 +1035,7 @@ jobs:
         - get: concourse-tfstate
           passed: ['concourse-terraform']
         - get: concourse-secrets
+        - get: bosh-secrets
         - get: bosh-tfstate
           passed: ['concourse-terraform']
       - task: terraform-outputs-to-yaml
@@ -1085,6 +1086,7 @@ jobs:
           inputs:
           - name: paas-bootstrap
           - name: concourse-secrets
+          - name: bosh-secrets
           - name: terraform-outputs
           outputs:
           - name: concourse-manifest

--- a/concourse/scripts/ssh.sh
+++ b/concourse/scripts/ssh.sh
@@ -43,8 +43,8 @@ download_key() {
 
 ssh_concourse() {
   echo
-  aws s3 cp "s3://gds-paas-${DEPLOY_ENV}-state/concourse-secrets.yml" - | \
-    ruby -ryaml -e 'puts "Sudo password is " + YAML.load(STDIN)["secrets"]["concourse_vcap_password_orig"]'
+  aws s3 cp "s3://gds-paas-${DEPLOY_ENV}-state/bosh-secrets.yml" - | \
+    ruby -ryaml -e 'puts "Sudo password is " + YAML.load(STDIN)["secrets"]["vcap_password_orig"]'
   echo
 
   # shellcheck disable=SC2029

--- a/manifests/bosh-manifest/operations.d/031-set-vcap-password.yml
+++ b/manifests/bosh-manifest/operations.d/031-set-vcap-password.yml
@@ -1,4 +1,4 @@
 ---
 - type: replace
   path: /resource_pools/name=vms/env/bosh/password
-  value: ((bosh_vcap_password))
+  value: ((vcap_password))

--- a/manifests/bosh-manifest/scripts/generate-bosh-secrets.rb
+++ b/manifests/bosh-manifest/scripts/generate-bosh-secrets.rb
@@ -6,7 +6,7 @@ require File.expand_path("../../../shared/lib/secret_generator", __FILE__)
 
 generator = SecretGenerator.new(
   "bosh_postgres_password" => :simple,
-  "bosh_vcap_password" => :sha512_crypted,
+  "vcap_password" => :sha512_crypted,
 )
 
 option_parser = OptionParser.new do |opts|

--- a/manifests/bosh-manifest/scripts/generate-manifest.sh
+++ b/manifests/bosh-manifest/scripts/generate-manifest.sh
@@ -78,7 +78,7 @@ nats_ca:
   certificate: ((default_ca.certificate))
   private_key: ((default_ca.private_key))
 
-bosh_vcap_password: ((secrets.bosh_vcap_password))
+vcap_password: ((secrets.vcap_password))
 EOF
 
 

--- a/manifests/bosh-manifest/scripts/generate-manifest.sh
+++ b/manifests/bosh-manifest/scripts/generate-manifest.sh
@@ -22,8 +22,8 @@ trap 'rm -f "${variables_file}"' INT TERM EXIT
 bosh interpolate - \
   --var-errs \
   --vars-file "${WORKDIR}/bosh-secrets/bosh-secrets.yml" \
-  --vars-file "${WORKDIR}/terraform-outputs/bosh.terraform-outputs.yml" \
-  --vars-file "${WORKDIR}/terraform-outputs/vpc.terraform-outputs.yml" \
+  --vars-file "${WORKDIR}/terraform-outputs/bosh-terraform-outputs.yml" \
+  --vars-file "${WORKDIR}/terraform-outputs/vpc-terraform-outputs.yml" \
   --var-file="default_ca.certificate=${WORKDIR}/certs/bosh-CA.crt" \
   --var-file="default_ca.private_key=${WORKDIR}/certs/bosh-CA.key" \
   > "${variables_file}" \

--- a/manifests/bosh-manifest/spec/release_versions_spec.rb
+++ b/manifests/bosh-manifest/spec/release_versions_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe "release versions" do
     match do |version|
       if url =~ %r{\?v=(.+)\z}
         url_version = $1
-      elsif url =~ %r{-([\d.]+)(-[0-9a-z-.]+)?\.tgz\z}
+      elsif url =~ %r{-([\d.]+)(-[0-9a-z\-.]+)?\.tgz\z}
         url_version = $1
       else
         raise "Failed to extract version from URL '#{url}'"

--- a/manifests/bosh-manifest/spec/secret_generation_spec.rb
+++ b/manifests/bosh-manifest/spec/secret_generation_spec.rb
@@ -3,10 +3,17 @@ require 'tempfile'
 RSpec.describe "secret generation" do
   describe "generate-bosh-secrets" do
     specify "it should produce lint-free YAML" do
-      output, status = Open3.capture2e('yamllint', '-c', File.expand_path("../../../../yamllint.yml", __FILE__), bosh_secrets_file)
+      dir = Dir.mktmpdir('paas-bootstrap-test')
+      begin
+        generate_bosh_secrets_fixture(dir)
 
-      expect(status).to be_success, "yamllint exited #{status.exitstatus}, output:\n#{output}"
-      expect(output).to be_empty
+        output, status = Open3.capture2e('yamllint', '-c', File.expand_path("../../../yamllint.yml", __dir__), "#{dir}/bosh-secrets.yml")
+
+        expect(status).to be_success, "yamllint exited #{status.exitstatus}, output:\n#{output}"
+        expect(output).to be_empty
+      ensure
+        FileUtils.rm_rf(dir)
+      end
     end
   end
 end

--- a/manifests/bosh-manifest/spec/spec_helper.rb
+++ b/manifests/bosh-manifest/spec/spec_helper.rb
@@ -99,4 +99,5 @@ end
 # end with _spec.rb. You can configure this pattern with the --pattern
 # option on the command line or in ~/.rspec, .rspec or `.rspec-local`.
 #
+Dir[File.expand_path("../../shared/spec/support/**/*.rb", __dir__)].each { |f| require f }
 Dir[File.expand_path("../support/**/*.rb", __FILE__)].each { |f| require f }

--- a/manifests/concourse-manifest/concourse-base.yml
+++ b/manifests/concourse-manifest/concourse-base.yml
@@ -54,7 +54,7 @@ resource_pools:
       - (( grab terraform_outputs_bosh_ssh_client_security_group ))
     env:
       bosh:
-        password: (( grab secrets.concourse_vcap_password ))
+        password: (( grab secrets.vcap_password ))
         ipv6:
           enable: true
 

--- a/manifests/concourse-manifest/scripts/generate-concourse-secrets.rb
+++ b/manifests/concourse-manifest/scripts/generate-concourse-secrets.rb
@@ -5,7 +5,6 @@ require 'yaml'
 require File.expand_path("../../../shared/lib/secret_generator", __FILE__)
 
 generator = SecretGenerator.new(
-  "concourse_vcap_password" => :sha512_crypted,
   "concourse_atc_password" => :simple,
   "concourse_postgres_password" => :simple,
   "concourse_token_signing_key" => :bosh_rsa_key,

--- a/manifests/concourse-manifest/scripts/generate-manifest.sh
+++ b/manifests/concourse-manifest/scripts/generate-manifest.sh
@@ -1,0 +1,26 @@
+#!/bin/sh
+
+set -eu
+
+PAAS_BOOTSTRAP_DIR=${PAAS_BOOTSTRAP_DIR:-paas-bootstrap}
+WORKDIR=${WORKDIR:-.}
+
+github_auth_files=""
+if [ "${ENABLE_GITHUB}" = "true" ] ; then
+  github_auth_files="${github_auth_files} ${PAAS_BOOTSTRAP_DIR}/manifests/concourse-manifest/github_auth/config.yml"
+  if [ "${AWS_ACCOUNT}" = "dev" ] || [ "${AWS_ACCOUNT}" = "ci" ]; then
+    github_auth_files="${github_auth_files} ${PAAS_BOOTSTRAP_DIR}/manifests/concourse-manifest/github_auth/dev_ci_additional_users.yml"
+  fi
+fi
+
+# shellcheck disable=SC2086
+spruce merge \
+  --prune meta \
+  --prune secrets \
+  --prune terraform_outputs \
+  "${PAAS_BOOTSTRAP_DIR}/manifests/concourse-manifest/concourse-base.yml" \
+  "${WORKDIR}/concourse-secrets/concourse-secrets.yml" \
+  "${WORKDIR}/terraform-outputs/concourse-terraform-outputs.yml" \
+  "${WORKDIR}/terraform-outputs/vpc-terraform-outputs.yml" \
+  "${WORKDIR}/terraform-outputs/bosh-terraform-outputs.yml" \
+  ${github_auth_files}

--- a/manifests/concourse-manifest/scripts/generate-manifest.sh
+++ b/manifests/concourse-manifest/scripts/generate-manifest.sh
@@ -19,6 +19,7 @@ spruce merge \
   --prune secrets \
   --prune terraform_outputs \
   "${PAAS_BOOTSTRAP_DIR}/manifests/concourse-manifest/concourse-base.yml" \
+  "${WORKDIR}/bosh-secrets/bosh-secrets.yml" \
   "${WORKDIR}/concourse-secrets/concourse-secrets.yml" \
   "${WORKDIR}/terraform-outputs/concourse-terraform-outputs.yml" \
   "${WORKDIR}/terraform-outputs/vpc-terraform-outputs.yml" \

--- a/manifests/concourse-manifest/spec/manifest_generation_spec.rb
+++ b/manifests/concourse-manifest/spec/manifest_generation_spec.rb
@@ -1,40 +1,44 @@
 require 'open3'
 
-def merge_fixtures(fixtures)
-  final = {}
-  fixtures.each do |fixture|
-    new_fixture = YAML.load_file(File.expand_path(fixture, __FILE__))
-    final.merge!(new_fixture) { |_key, a_val, b_val| a_val.merge b_val }
-  end
-  final
-end
-
 RSpec.describe "manifest generation" do
-  let(:fixtures) {
-    merge_fixtures [
-      "../../../shared/spec/fixtures/concourse-terraform-outputs.yml",
-      "../../../shared/spec/fixtures/vpc-terraform-outputs.yml",
-    ]
-  }
-
-  let(:concourse_instance_group) { manifest_with_defaults.fetch("instance_groups").find { |ig| ig["name"] == "concourse" } }
+  let(:manifest) { manifest_with_defaults }
+  let(:concourse_instance_group) { manifest.fetch("instance_groups").find { |ig| ig["name"] == "concourse" } }
   let(:atc_job) { concourse_instance_group.fetch("jobs").find { |j| j["name"] == "atc" } }
 
   it "gets values from vpc terraform outputs" do
     expect(
       manifest_with_defaults["resource_pools"].first["cloud_properties"]["availability_zone"]
-    ).to eq(fixtures["terraform_outputs_zone0"])
+    ).to eq(terraform_fixture_value("zone0", "vpc"))
   end
 
   it "gets values from concourse terraform outputs" do
     expect(
       atc_job.fetch("properties").fetch("external_url")
-    ).to eq("https://" + fixtures["terraform_outputs_concourse_dns_name"])
+    ).to eq("https://" + terraform_fixture_value("concourse_dns_name", "concourse"))
   end
 
   it "gets values from secrets" do
     expect(
       atc_job.fetch("properties").fetch("add_local_users")[0].split(':', 2)[1]
     ).to eq(concourse_secrets_value("concourse_atc_password"))
+  end
+
+  context "with github auth enabled" do
+    let(:manifest) { manifest_with_github_auth }
+
+    it "sets up the client_id and secret" do
+      expect(
+        atc_job.dig("properties", "github_auth", "client_id")
+      ).not_to be_empty
+      expect(
+        atc_job.dig("properties", "github_auth", "client_secret")
+      ).not_to be_empty
+    end
+
+    it "sets up the main team users" do
+      expect(
+        atc_job.dig("properties", "main_team", "auth", "github", "users")
+      ).not_to be_empty
+    end
   end
 end

--- a/manifests/concourse-manifest/spec/spec_helper.rb
+++ b/manifests/concourse-manifest/spec/spec_helper.rb
@@ -99,4 +99,5 @@ end
 # end with _spec.rb. You can configure this pattern with the --pattern
 # option on the command line or in ~/.rspec, .rspec or `.rspec-local`.
 #
+Dir[File.expand_path("../../shared/spec/support/**/*.rb", __dir__)].each { |f| require f }
 Dir[File.expand_path("../support/**/*.rb", __FILE__)].each { |f| require f }

--- a/manifests/concourse-manifest/spec/support/manifest_helpers.rb
+++ b/manifests/concourse-manifest/spec/support/manifest_helpers.rb
@@ -9,12 +9,23 @@ module ManifestHelpers
   class Cache
     include Singleton
     attr_accessor :manifest_with_defaults
+    attr_accessor :manifest_with_github_auth
     attr_accessor :concourse_secrets_file
     attr_accessor :concourse_secrets_data
   end
 
   def manifest_with_defaults
-    Cache.instance.manifest_with_defaults ||= load_default_manifest
+    Cache.instance.manifest_with_defaults ||= render_manifest
+  end
+
+  def manifest_with_github_auth
+    Cache.instance.manifest_with_github_auth ||= render_manifest(
+      override_env: {
+        'ENABLE_GITHUB' => 'true',
+        'GITHUB_CLIENT_ID' => 'dummy_github_client_id',
+        'GITHUB_CLIENT_SECRET' => 'dummy_github_client_secret',
+      }
+    )
   end
 
   def concourse_secrets_file
@@ -29,31 +40,43 @@ module ManifestHelpers
 
 private
 
-  def fake_env_vars
-    ENV["AWS_ACCOUNT"] = "dev"
-    ENV["CONCOURSE_INSTANCE_TYPE"] = "t2.small"
-    ENV["CONCOURSE_INSTANCE_PROFILE"] = "concourse-build"
-    ENV["CONCOURSE_AUTH_DURATION"] = "5m"
-    ENV["SYSTEM_DNS_ZONE_NAME"] = ManifestHelpers::SYSTEM_DNS_ZONE_NAME
+  def root
+    Pathname(File.expand_path("../../../..", __dir__))
   end
 
-  def load_default_manifest
-    fake_env_vars
+  def fake_env_vars
+    env = {}
+    env["AWS_ACCOUNT"] = "dev"
+    env["CONCOURSE_INSTANCE_TYPE"] = "t2.small"
+    env["CONCOURSE_INSTANCE_PROFILE"] = "concourse-build"
+    env["CONCOURSE_AUTH_DURATION"] = "5m"
+    env["SYSTEM_DNS_ZONE_NAME"] = ManifestHelpers::SYSTEM_DNS_ZONE_NAME
+    env["ENABLE_GITHUB"] = "false"
+    env
+  end
+
+  def render_manifest(override_env: {})
+    workdir = Pathname(Dir.mktmpdir('paas-bootstrap-test'))
+
+    env = fake_env_vars.merge(override_env)
+    env['PAAS_BOOTSTRAP_DIR'] = root.to_s
+    env['WORKDIR'] = workdir.to_s
+
+    copy_terraform_fixtures("#{workdir}/terraform-outputs", %w(vpc bosh concourse))
+    FileUtils.mkdir("#{workdir}/concourse-secrets")
+    FileUtils.cp(concourse_secrets_file, "#{workdir}/concourse-secrets/concourse-secrets.yml")
+
     output, error, status = Open3.capture3(
-      [
-        File.expand_path("../../../../shared/build_manifest.sh", __FILE__),
-        File.expand_path("../../../concourse-base.yml", __FILE__),
-        concourse_secrets_file,
-        File.expand_path("../../../../shared/spec/fixtures/concourse-terraform-outputs.yml", __FILE__),
-        File.expand_path("../../../../shared/spec/fixtures/bosh-terraform-outputs.yml", __FILE__),
-        File.expand_path("../../../../shared/spec/fixtures/vpc-terraform-outputs.yml", __FILE__),
-      ].join(' ')
+      env,
+      root.join("manifests/concourse-manifest/scripts/generate-manifest.sh").to_s,
     )
-    expect(status).to be_success, "build_manifest.sh exited #{status.exitstatus}, stderr:\n#{error}"
+    expect(status).to be_success, "generate_manifest.sh exited #{status.exitstatus}, stderr:\n#{error}"
 
     # Deep freeze the object so that it's safe to use across multiple examples
     # without risk of state leaking.
     deep_freeze(YAML.safe_load(output))
+  ensure
+    FileUtils.rm_rf(workdir)
   end
 
   def generate_concourse_secrets

--- a/manifests/concourse-manifest/spec/support/manifest_helpers.rb
+++ b/manifests/concourse-manifest/spec/support/manifest_helpers.rb
@@ -63,6 +63,7 @@ private
     env['WORKDIR'] = workdir.to_s
 
     copy_terraform_fixtures("#{workdir}/terraform-outputs", %w(vpc bosh concourse))
+    generate_bosh_secrets_fixture("#{workdir}/bosh-secrets")
     FileUtils.mkdir("#{workdir}/concourse-secrets")
     FileUtils.cp(concourse_secrets_file, "#{workdir}/concourse-secrets/concourse-secrets.yml")
 

--- a/manifests/shared/build_manifest.sh
+++ b/manifests/shared/build_manifest.sh
@@ -1,9 +1,0 @@
-#!/bin/sh
-
-set -eu
-
-spruce merge \
-  --prune meta \
-  --prune secrets \
-  --prune terraform_outputs \
-  "$@"

--- a/manifests/shared/spec/support/fixture_helpers.rb
+++ b/manifests/shared/spec/support/fixture_helpers.rb
@@ -14,6 +14,17 @@ module FixtureHelpers
     FileUtils.cp(fixtures_dir.join(file), "#{target_dir}/#{target_file}")
   end
 
+  def generate_bosh_secrets_fixture(target_dir)
+    FileUtils.mkdir(target_dir) unless Dir.exist?(target_dir)
+    File.open("#{target_dir}/bosh-secrets.yml", 'w') do |file|
+      output, error, status = Open3.capture3(File.expand_path("../../../bosh-manifest/scripts/generate-bosh-secrets.rb", __dir__))
+      unless status.success?
+        raise "Error generating bosh-secrets, exit: #{status.exitstatus}, output:\n#{output}\n#{error}"
+      end
+      file.write(output)
+    end
+  end
+
 private
 
   def fixtures_dir

--- a/manifests/shared/spec/support/fixture_helpers.rb
+++ b/manifests/shared/spec/support/fixture_helpers.rb
@@ -1,0 +1,24 @@
+module FixtureHelpers
+  def terraform_fixture_value(key, fixture)
+    YAML.load_file(fixtures_dir.join("#{fixture}-terraform-outputs.yml")).fetch("terraform_outputs_#{key}")
+  end
+
+  def copy_terraform_fixtures(target_dir, fixtures)
+    fixtures.each do |fixture|
+      copy_fixture_file("#{fixture}-terraform-outputs.yml", target_dir)
+    end
+  end
+
+  def copy_fixture_file(file, target_dir, target_file = file)
+    FileUtils.mkdir(target_dir) unless Dir.exist?(target_dir)
+    FileUtils.cp(fixtures_dir.join(file), "#{target_dir}/#{target_file}")
+  end
+
+private
+
+  def fixtures_dir
+    Pathname.new(File.expand_path('../fixtures', __dir__))
+  end
+end
+
+RSpec.configuration.include FixtureHelpers

--- a/scripts/ssh_bosh.sh
+++ b/scripts/ssh_bosh.sh
@@ -11,7 +11,7 @@ trap 'rm -f ${BOSH_KEY}' EXIT
 aws s3 cp "s3://gds-paas-${DEPLOY_ENV}-state/bosh_id_rsa" ${BOSH_KEY} && chmod 400 ${BOSH_KEY}
 
 aws s3 cp "s3://gds-paas-${DEPLOY_ENV}-state/bosh-secrets.yml" - | \
-  ruby -ryaml -e 'puts "Sudo password is " + YAML.load(STDIN)["secrets"]["bosh_vcap_password_orig"]'
+  ruby -ryaml -e 'puts "Sudo password is " + YAML.load(STDIN)["secrets"]["vcap_password_orig"]'
 echo
 
 # shellcheck disable=SC2029


### PR DESCRIPTION
What
----

This is the first part of this. It renames the bosh_vcap_password to just vcap_password, and uses it for both the bosh and concourse VMs.

The second part will be in paas-cf to make the CF and Prometheus deployments also use this password.

As part of this I've taken the opportunity to cleanup some of the manifest generation where too much logic had escaped into the pipeline.

How to review
-------------

* Code review (might be easier commit at a time).
* Run this down a dev pipeline, and verify you can ssh to the bosh and concourse VMs (`make dev ssh_bosh` and `make dev ssh_concourse`), and then sudo using the password from bosh-secrets.yml

Who can review
--------------

Not me.