### PR TITLE
[#163558206] Stop using separate ssh keypairs for bosh and concourse.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -183,7 +183,7 @@ showenv: check-env-vars ## Display environment information
 	$(eval export TARGET_CONCOURSE=bootstrap)
 	@concourse/scripts/environment.sh
 	@echo export CONCOURSE_IP=$$(aws ec2 describe-instances \
-		--filters 'Name=tag:Name,Values=concourse/*' "Name=key-name,Values=${DEPLOY_ENV}_concourse_key_pair" \
+		--filters "Name=tag:deploy_env,Values=${DEPLOY_ENV}" 'Name=tag:instance_group,Values=concourse' \
 		--query 'Reservations[].Instances[].PublicIpAddress' --output text)
 	@echo export BOOTSTRAP_CONCOURSE_IP=$$(aws ec2 describe-instances \
 		--filters 'Name=tag:Name,Values=*concourse' "Name=key-name,Values=${VAGRANT_SSH_KEY_NAME}" \

--- a/concourse/pipelines/create-bosh-concourse.yml
+++ b/concourse/pipelines/create-bosh-concourse.yml
@@ -157,24 +157,6 @@ resources:
       initial_version: "-"
       initial_content_text: ""
 
-  - name: bosh-ssh-private-key
-    type: s3-iam
-    source:
-      bucket: ((state_bucket))
-      versioned_file: bosh_id_rsa
-      region_name: ((aws_region))
-      initial_version: "-"
-      initial_content_text: ""
-
-  - name: bosh-ssh-public-key
-    type: s3-iam
-    source:
-      bucket: ((state_bucket))
-      versioned_file: bosh_id_rsa.pub
-      region_name: ((aws_region))
-      initial_version: "-"
-      initial_content_text: ""
-
   - name: ssh-private-key
     type: s3-iam
     source:
@@ -502,8 +484,6 @@ jobs:
         - get: bosh-CA
         - get: bosh-CA-crt
         - get: bosh-secrets
-        - get: bosh-ssh-private-key
-        - get: bosh-ssh-public-key
         - get: ssh-private-key
         - get: ssh-public-key
         - get: concourse-secrets
@@ -569,44 +549,6 @@ jobs:
             put: bosh-secrets
             params:
               file: generated-bosh-secrets/bosh-secrets.yml
-
-        - task: generate-bosh-ssh-keypair
-          config:
-            platform: linux
-            image_resource: *git-ssh-image-resource
-            inputs:
-              - name: paas-bootstrap
-              - name: bosh-ssh-private-key
-              - name: bosh-ssh-public-key
-            outputs:
-              - name: bosh-ssh-private-key-to-upload
-              - name: bosh-ssh-public-key-to-upload
-            run:
-              path: sh
-              args:
-                - -e
-                - -c
-                - |
-                  if [ -s bosh-ssh-private-key/bosh_id_rsa ] && [ -s bosh-ssh-public-key/bosh_id_rsa.pub ]; then
-                    echo "BOSH keys non-zero size, skipping generation..."
-                    cp bosh-ssh-private-key/bosh_id_rsa bosh-ssh-private-key-to-upload
-                    cp bosh-ssh-public-key/bosh_id_rsa.pub bosh-ssh-public-key-to-upload
-                    exit 0
-                  fi
-
-                  echo "Generating new ssh key pair for BOSH..."
-                  ssh-keygen -t rsa -b 4096 -f bosh_id_rsa -N ''
-                  cp bosh_id_rsa bosh-ssh-private-key-to-upload
-                  cp bosh_id_rsa.pub bosh-ssh-public-key-to-upload
-          on_success:
-            try:
-              aggregate:
-                - put: bosh-ssh-private-key
-                  params:
-                    file: bosh-ssh-private-key-to-upload/bosh_id_rsa
-                - put: bosh-ssh-public-key
-                  params:
-                    file: bosh-ssh-public-key-to-upload/bosh_id_rsa.pub
 
         - task: generate-deployments-ssh-keypair
           config:
@@ -685,8 +627,6 @@ jobs:
         - get: vpc-tfstate
           passed: ['vpc']
         - get: bosh-tfstate
-        - get: bosh-ssh-public-key
-          passed: ['generate-secrets']
         - get: ssh-public-key
           passed: ['generate-secrets']
 
@@ -719,7 +659,6 @@ jobs:
             - name: paas-bootstrap
             - name: terraform-variables
             - name: bosh-tfstate
-            - name: bosh-ssh-public-key
             - name: ssh-public-key
           outputs:
             - name: updated-bosh-tfstate
@@ -741,7 +680,6 @@ jobs:
                 . terraform-variables/bosh-secrets.tfvars.sh
 
                 cp ssh-public-key/id_rsa.pub paas-bootstrap/terraform/bosh
-                cp bosh-ssh-public-key/bosh_id_rsa.pub paas-bootstrap/terraform/bosh
                 CONCOURSE_EGRESS_IP=$(wget -q -O - http://169.254.169.254/latest/meta-data/public-ipv4)
 
                 cp bosh-tfstate/bosh.tfstate updated-bosh-tfstate/bosh.tfstate
@@ -862,7 +800,7 @@ jobs:
         - get: bosh-manifest
           passed: ['generate-bosh-config']
         - get: bosh-init-state
-        - get: bosh-ssh-private-key
+        - get: ssh-private-key
 
       - task: bosh-create-env
         config:
@@ -871,7 +809,7 @@ jobs:
           inputs:
             - name: bosh-manifest
             - name: bosh-init-state
-            - name: bosh-ssh-private-key
+            - name: ssh-private-key
           outputs:
             - name: bosh-init-working-dir
           params:
@@ -883,8 +821,8 @@ jobs:
               - -c
               - |
                 mkdir -p bosh-init-working-dir/.ssh
-                cp bosh-ssh-private-key/bosh_id_rsa bosh-init-working-dir/.ssh/bosh_id_rsa
-                chmod 400 bosh-init-working-dir/.ssh/bosh_id_rsa
+                cp ssh-private-key/id_rsa bosh-init-working-dir/.ssh/id_rsa
+                chmod 400 bosh-init-working-dir/.ssh/id_rsa
                 cp bosh-manifest/bosh-manifest.yml bosh-init-working-dir/bosh-manifest.yml
                 cp bosh-init-state/"${BOSH_MANIFEST_STATE}" bosh-init-working-dir/bosh-manifest-state.json
                 bosh -n create-env bosh-init-working-dir/bosh-manifest.yml \
@@ -1119,7 +1057,7 @@ jobs:
         - get: bosh-CA-crt
           passed: ['generate-secrets']
         - get: concourse-bosh-deployment
-        - get: bosh-ssh-private-key
+        - get: ssh-private-key
 
       - task: get-and-upload-stemcell
         config:
@@ -1129,7 +1067,7 @@ jobs:
             - name: bosh-vars-store
             - name: paas-bootstrap
             - name: bosh-CA-crt
-            - name: bosh-ssh-private-key
+            - name: ssh-private-key
           params:
             BOSH_ENVIRONMENT: ((bosh_fqdn))
             BOSH_CA_CERT: bosh-CA-crt/bosh-CA.crt
@@ -1138,7 +1076,7 @@ jobs:
 
             BOSH_GW_HOST: ((bosh_login_host))
             BOSH_GW_USER: vcap
-            BOSH_GW_PRIVATE_KEY: bosh-ssh-private-key/bosh_id_rsa
+            BOSH_GW_PRIVATE_KEY: ssh-private-key/id_rsa
           run:
             path: sh
             args:
@@ -1171,7 +1109,7 @@ jobs:
           - name: paas-bootstrap
           - name: bosh-CA-crt
           - name: concourse-bosh-deployment
-          - name: bosh-ssh-private-key
+          - name: ssh-private-key
           params:
             BOSH_ENVIRONMENT: ((bosh_fqdn))
             BOSH_CA_CERT: bosh-CA-crt/bosh-CA.crt
@@ -1180,7 +1118,7 @@ jobs:
 
             BOSH_GW_HOST: ((bosh_login_host))
             BOSH_GW_USER: vcap
-            BOSH_GW_PRIVATE_KEY: bosh-ssh-private-key/bosh_id_rsa
+            BOSH_GW_PRIVATE_KEY: ssh-private-key/id_rsa
           run:
             path: sh
             args:
@@ -1213,7 +1151,7 @@ jobs:
           passed: ['concourse-deploy']
         - get: bosh-CA-crt
           passed: ['generate-secrets']
-        - get: bosh-ssh-private-key
+        - get: ssh-private-key
 
       - task: test-bosh-vms
         config:
@@ -1223,7 +1161,7 @@ jobs:
           - name: paas-bootstrap
           - name: bosh-vars-store
           - name: bosh-CA-crt
-          - name: bosh-ssh-private-key
+          - name: ssh-private-key
           params:
             BOSH_ENVIRONMENT: ((bosh_fqdn))
             BOSH_CA_CERT: bosh-CA-crt/bosh-CA.crt
@@ -1232,7 +1170,7 @@ jobs:
 
             BOSH_GW_HOST: ((bosh_login_host))
             BOSH_GW_USER: vcap
-            BOSH_GW_PRIVATE_KEY: bosh-ssh-private-key/bosh_id_rsa
+            BOSH_GW_PRIVATE_KEY: ssh-private-key/id_rsa
           run:
             path: sh
             args:

--- a/concourse/pipelines/create-bosh-concourse.yml
+++ b/concourse/pipelines/create-bosh-concourse.yml
@@ -286,22 +286,6 @@ resources:
       region_name: ((aws_region))
       versioned_file: concourse-manifest.yml
 
-  - name: concourse-ssh-public-key
-    type: s3-iam
-    source:
-      bucket: ((state_bucket))
-      region_name: ((aws_region))
-      versioned_file: concourse_id_rsa.pub
-      initial_version: "-"
-
-  - name: concourse-ssh-private-key
-    type: s3-iam
-    source:
-      bucket: ((state_bucket))
-      region_name: ((aws_region))
-      versioned_file: concourse_id_rsa
-      initial_version: "-"
-
   - name: concourse-bosh-deployment
     type: git
     source:
@@ -847,8 +831,6 @@ jobs:
           passed: ['bosh-terraform']
         - get: concourse-tfstate
         - get: git-ssh-public-key
-        - get: concourse-ssh-public-key
-        - get: concourse-ssh-private-key
 
       - task: terraform-outputs-to-sh
         config:
@@ -876,43 +858,6 @@ jobs:
               > bosh-terraform-outputs/tfvars.sh
               ls -l bosh-terraform-outputs/tfvars.sh
 
-      - task: generate-concourse-ssh-keys
-        config:
-          platform: linux
-          image_resource: *awscli-image-resource
-          inputs:
-          - name: paas-bootstrap
-          - name: concourse-ssh-public-key
-          - name: concourse-ssh-private-key
-          outputs:
-          - name: generated-concourse-ssh-keys
-          params:
-            AWS_DEFAULT_REGION: ((aws_region))
-          run:
-            path: sh
-            args:
-            - -e
-            - -c
-            - |
-              if [ -s concourse-ssh-public-key/concourse_id_rsa.pub ] && [ -s concourse-ssh-private-key/concourse_id_rsa ]; then
-                echo "Concourse SSH keys already exist, skipping."
-                cp concourse-ssh-public-key/concourse_id_rsa.pub generated-concourse-ssh-keys
-                cp concourse-ssh-private-key/concourse_id_rsa generated-concourse-ssh-keys
-                exit 0
-              fi
-
-              apk add --update openssh
-              cd generated-concourse-ssh-keys
-              ssh-keygen -t rsa -b 4096 -f concourse_id_rsa -N ''
-        on_success:
-          aggregate:
-            - put: concourse-ssh-public-key
-              params:
-                file: generated-concourse-ssh-keys/concourse_id_rsa.pub
-            - put: concourse-ssh-private-key
-              params:
-                file: generated-concourse-ssh-keys/concourse_id_rsa
-
       - task: terraform-apply
         config:
           platform: linux
@@ -923,7 +868,6 @@ jobs:
           - name: bosh-terraform-outputs
           - name: concourse-tfstate
           - name: git-ssh-public-key
-          - name: generated-concourse-ssh-keys
           outputs:
           - name: updated-concourse-tfstate
           params:
@@ -938,7 +882,6 @@ jobs:
             - -e
             - -c
             - |
-              cp generated-concourse-ssh-keys/concourse_id_rsa.pub paas-bootstrap/terraform/concourse
               . vpc-terraform-outputs/tfvars.sh
               . bosh-terraform-outputs/tfvars.sh
               export TF_VAR_git_rsa_id_pub

--- a/concourse/pipelines/create-bosh-concourse.yml
+++ b/concourse/pipelines/create-bosh-concourse.yml
@@ -1096,6 +1096,22 @@ jobs:
           passed: ['generate-secrets']
         - get: ssh-private-key
 
+      # FIXME: remove this task once it's run everywhere
+      - task: cleanup-unused-ssh-keys
+        config:
+          platform: linux
+          image_resource: *awscli-image-resource
+          run:
+            path: sh
+            args:
+              - -e
+              - -c
+              - |
+                aws s3 rm "s3://((state_bucket))/bosh_id_rsa"
+                aws s3 rm "s3://((state_bucket))/bosh_id_rsa.pub"
+                aws s3 rm "s3://((state_bucket))/concourse_id_rsa"
+                aws s3 rm "s3://((state_bucket))/concourse_id_rsa.pub"
+
       - task: test-bosh-vms
         config:
           platform: linux

--- a/concourse/pipelines/destroy-bosh-concourse.yml
+++ b/concourse/pipelines/destroy-bosh-concourse.yml
@@ -118,11 +118,11 @@ resources:
       region_name: ((aws_region))
       versioned_file: bosh-CA.crt
 
-  - name: bosh-ssh-private-key
+  - name: ssh-private-key
     type: s3-iam
     source:
       bucket: ((state_bucket))
-      versioned_file: bosh_id_rsa
+      versioned_file: id_rsa
       region_name: ((aws_region))
 
 jobs:
@@ -238,7 +238,7 @@ jobs:
         - get: vpc-tfstate
         - get: concourse-tfstate
         - get: bosh-CA-crt
-        - get: bosh-ssh-private-key
+        - get: ssh-private-key
 
       - task: destroy-concourse
         config:
@@ -248,7 +248,7 @@ jobs:
           - name: paas-bootstrap
           - name: bosh-vars-store
           - name: bosh-CA-crt
-          - name: bosh-ssh-private-key
+          - name: ssh-private-key
           params:
             BOSH_ENVIRONMENT: ((bosh_fqdn))
             BOSH_CA_CERT: bosh-CA-crt/bosh-CA.crt
@@ -257,7 +257,7 @@ jobs:
 
             BOSH_GW_HOST: ((bosh_login_host))
             BOSH_GW_USER: vcap
-            BOSH_GW_PRIVATE_KEY: bosh-ssh-private-key/bosh_id_rsa
+            BOSH_GW_PRIVATE_KEY: ssh-private-key/id_rsa
           run:
             path: sh
             args:
@@ -353,7 +353,7 @@ jobs:
         - get: vpc-tfstate
         - get: bosh-tfstate
         - get: bosh-CA-crt
-        - get: bosh-ssh-private-key
+        - get: ssh-private-key
 
       - task: check-existing-deployments
         config:
@@ -363,7 +363,7 @@ jobs:
             - name: paas-bootstrap
             - name: bosh-vars-store
             - name: bosh-CA-crt
-            - name: bosh-ssh-private-key
+            - name: ssh-private-key
           params:
             BOSH_ENVIRONMENT: ((bosh_fqdn))
             BOSH_CA_CERT: bosh-CA-crt/bosh-CA.crt
@@ -372,7 +372,7 @@ jobs:
 
             BOSH_GW_HOST: ((bosh_login_host))
             BOSH_GW_USER: vcap
-            BOSH_GW_PRIVATE_KEY: bosh-ssh-private-key/bosh_id_rsa
+            BOSH_GW_PRIVATE_KEY: ssh-private-key/id_rsa
           run:
             path: sh
             args:
@@ -402,7 +402,7 @@ jobs:
             - name: paas-bootstrap
             - name: bosh-vars-store
             - name: bosh-CA-crt
-            - name: bosh-ssh-private-key
+            - name: ssh-private-key
           params:
             BOSH_ENVIRONMENT: ((bosh_fqdn))
             BOSH_CA_CERT: bosh-CA-crt/bosh-CA.crt
@@ -411,7 +411,7 @@ jobs:
 
             BOSH_GW_HOST: ((bosh_login_host))
             BOSH_GW_USER: vcap
-            BOSH_GW_PRIVATE_KEY: bosh-ssh-private-key/bosh_id_rsa
+            BOSH_GW_PRIVATE_KEY: ssh-private-key/id_rsa
           run:
             path: sh
             args:
@@ -436,7 +436,7 @@ jobs:
             - name: paas-bootstrap
             - name: bosh-manifest
             - name: bosh-init-state
-            - name: bosh-ssh-private-key
+            - name: ssh-private-key
           params:
             BOSH_MANIFEST_STATE: ((bosh_manifest_state))
           outputs:
@@ -450,7 +450,7 @@ jobs:
                 cp bosh-manifest/bosh-manifest.yml bosh-init-working-dir/bosh-manifest.yml
                 cp bosh-init-state/"${BOSH_MANIFEST_STATE}" bosh-init-working-dir/bosh-manifest-state.json
                 mkdir bosh-init-working-dir/.ssh
-                cp bosh-ssh-private-key/bosh_id_rsa bosh-init-working-dir/.ssh/bosh_id_rsa
+                cp ssh-private-key/id_rsa bosh-init-working-dir/.ssh/id_rsa
                 bosh -n delete-env bosh-init-working-dir/bosh-manifest.yml \
                   --state bosh-init-working-dir/bosh-manifest-state.json
                 # If the delete is successful, the file will be missing
@@ -512,7 +512,7 @@ jobs:
                 . terraform-variables/vpc.tfvars.sh
                 . terraform-variables/bosh-secrets.tfvars.sh
 
-                touch paas-bootstrap/terraform/bosh/id_rsa.pub paas-bootstrap/terraform/bosh/bosh_id_rsa.pub
+                touch paas-bootstrap/terraform/bosh/id_rsa.pub
                 CONCOURSE_EGRESS_IP=$(wget -q -O - http://169.254.169.254/latest/meta-data/public-ipv4)
 
                 cp bosh-tfstate/bosh.tfstate updated-bosh-tfstate/bosh.tfstate

--- a/concourse/pipelines/destroy-bosh-concourse.yml
+++ b/concourse/pipelines/destroy-bosh-concourse.yml
@@ -318,7 +318,7 @@ jobs:
             - -c
             - |
               . vpc-terraform-outputs/tfvars.sh
-              touch concourse.crt concourse.key paas-bootstrap/terraform/concourse/concourse_id_rsa.pub
+              touch concourse.crt concourse.key
 
               cp concourse-tfstate/concourse.tfstate updated-concourse-tfstate/concourse.tfstate
 

--- a/concourse/scripts/ssh.sh
+++ b/concourse/scripts/ssh.sh
@@ -34,11 +34,11 @@ EOF
 }
 
 download_key() {
-  key=/tmp/concourse_id_rsa.$RANDOM
+  key=/tmp/id_rsa.$RANDOM
   trap 'rm -f $key' EXIT
 
   eval "$(make "${MAKEFILE_ENV_TARGET}" showenv | grep CONCOURSE_IP=)"
-  aws s3 cp "s3://gds-paas-${DEPLOY_ENV}-state/concourse_id_rsa" $key && chmod 400 $key
+  aws s3 cp "s3://gds-paas-${DEPLOY_ENV}-state/id_rsa" $key && chmod 400 $key
 }
 
 ssh_concourse() {

--- a/manifests/bosh-manifest/operations.d/120-cpi.yml
+++ b/manifests/bosh-manifest/operations.d/120-cpi.yml
@@ -1,6 +1,3 @@
 - type: replace
   path: /instance_groups/name=bosh/properties/aws/max_retries?
   value: 16
-- type: replace
-  path: /instance_groups/name=bosh/properties/aws/default_key_name
-  value: ((bosh_managed_default_key_name))

--- a/manifests/bosh-manifest/scripts/generate-manifest.sh
+++ b/manifests/bosh-manifest/scripts/generate-manifest.sh
@@ -47,8 +47,7 @@ az: ((terraform_outputs_bosh_az))
 region: ((terraform_outputs_region))
 subnet_id: ((terraform_outputs_bosh_subnet_id))
 
-default_key_name: ((terraform_outputs_bosh_ssh_key_pair_name))
-bosh_managed_default_key_name: ((terraform_outputs_key_pair_name))
+default_key_name: ((terraform_outputs_key_pair_name))
 
 default_security_groups:
 - ((terraform_outputs_bosh_managed_security_group))
@@ -66,7 +65,7 @@ external_db_adapter: "postgres"
 
 bosh_blobstore_bucket_name: ((terraform_outputs_bosh_blobstore_bucket_name))
 
-private_key: ".ssh/bosh_id_rsa"
+private_key: ".ssh/id_rsa"
 
 default_ca:
   ca: ((default_ca.certificate))

--- a/manifests/concourse-manifest/concourse-base.yml
+++ b/manifests/concourse-manifest/concourse-base.yml
@@ -45,7 +45,6 @@ resource_pools:
       ephemeral_disk:
         size: 102400
         type: gp2
-      key_name: (( grab terraform_outputs_concourse_key_pair_name ))
       security_groups:
       - (( grab terraform_outputs_bosh_managed_security_group ))
       - (( grab terraform_outputs_concourse_security_group ))

--- a/manifests/shared/spec/fixtures/bosh-terraform-outputs.yml
+++ b/manifests/shared/spec/fixtures/bosh-terraform-outputs.yml
@@ -13,8 +13,7 @@ terraform_outputs_bosh_az: eu-west-1a
 terraform_outputs_bosh_az_label: z1
 terraform_outputs_bosh_default_gw: 10.0.0.1
 terraform_outputs_bosh_subnet_cidr: 10.0.0.0/24
-terraform_outputs_bosh_ssh_key_pair_name: bosh_keypair
-terraform_outputs_key_pair_name: ssh_key_pair
+terraform_outputs_key_pair_name: test_key_pair
 terraform_outputs_bosh_api_client_security_group: bosh_api_client_sg
 terraform_outputs_bosh_ssh_client_security_group: bosh_ssh_client_sg
 terraform_outputs_default_security_group: test-bosh-managed

--- a/manifests/shared/spec/fixtures/concourse-terraform-outputs.yml
+++ b/manifests/shared/spec/fixtures/concourse-terraform-outputs.yml
@@ -5,4 +5,3 @@ terraform_outputs_concourse_security_group_id: sg-12345678
 terraform_outputs_concourse_elb_name: env1234-concourse
 terraform_outputs_concourse_dns_name: concourse.env1234.dev.cloudpipeline.digital
 terraform_outputs_git_concourse_pool_clone_full_url_ssh: "ssh://user@git-codecommit.us-east-1.amazonaws.com/v1/repos/concourse-pool-test"
-terraform_outputs_concourse_key_pair_name: concourse_ssh_key_pair

--- a/scripts/bosh
+++ b/scripts/bosh
@@ -27,14 +27,14 @@ case "$AWS_ACCOUNT" in
   ;;
 esac
 
-BOSH_ID_RSA="$(aws s3 cp "s3://gds-paas-${DEPLOY_ENV}-state/bosh_id_rsa" - | base64)"
+BOSH_ID_RSA="$(aws s3 cp "s3://gds-paas-${DEPLOY_ENV}-state/id_rsa" - | base64)"
 export BOSH_ID_RSA
 
 BOSH_CA_CERT="$(aws s3 cp "s3://gds-paas-${DEPLOY_ENV}-state/bosh-CA.crt" -)"
 export BOSH_CA_CERT
 
 BOSH_IP=$(aws ec2 describe-instances \
-	--filters "Name=key-name,Values=${DEPLOY_ENV}_bosh_ssh_key_pair" \
+	--filters "Name=tag:deploy_env,Values=${DEPLOY_ENV}" 'Name=tag:instance_group,Values=bosh' \
 	--query 'Reservations[].Instances[].PublicIpAddress' --output text)
 export BOSH_IP
 

--- a/scripts/bosh-cli.sh
+++ b/scripts/bosh-cli.sh
@@ -2,14 +2,14 @@
 
 set -eu
 
-BOSH_ID_RSA="$(aws s3 cp "s3://gds-paas-${DEPLOY_ENV}-state/bosh_id_rsa" - | base64)"
+BOSH_ID_RSA="$(aws s3 cp "s3://gds-paas-${DEPLOY_ENV}-state/id_rsa" - | base64)"
 export BOSH_ID_RSA
 
 BOSH_CA_CERT="$(aws s3 cp "s3://gds-paas-${DEPLOY_ENV}-state/bosh-CA.crt" -)"
 export BOSH_CA_CERT
 
 BOSH_IP=$(aws ec2 describe-instances \
-    --filters "Name=key-name,Values=${DEPLOY_ENV}_bosh_ssh_key_pair" \
+    --filters "Name=tag:deploy_env,Values=${DEPLOY_ENV}" 'Name=tag:instance_group,Values=bosh' \
     --query 'Reservations[].Instances[].PublicIpAddress' --output text)
 export BOSH_IP
 

--- a/scripts/ssh_bosh.sh
+++ b/scripts/ssh_bosh.sh
@@ -1,14 +1,14 @@
 #!/bin/bash
 set -euo pipefail
 
-BOSH_KEY=/tmp/bosh_id_rsa.$RANDOM
+BOSH_KEY=/tmp/id_rsa.$RANDOM
 BOSH_IP=$(aws ec2 describe-instances \
-    --filters "Name=key-name,Values=${DEPLOY_ENV}_bosh_ssh_key_pair" \
+    --filters "Name=tag:deploy_env,Values=${DEPLOY_ENV}" 'Name=tag:instance_group,Values=bosh' \
     --query 'Reservations[].Instances[].PublicIpAddress' --output text)
 
 trap 'rm -f ${BOSH_KEY}' EXIT
 
-aws s3 cp "s3://gds-paas-${DEPLOY_ENV}-state/bosh_id_rsa" ${BOSH_KEY} && chmod 400 ${BOSH_KEY}
+aws s3 cp "s3://gds-paas-${DEPLOY_ENV}-state/id_rsa" ${BOSH_KEY} && chmod 400 ${BOSH_KEY}
 
 aws s3 cp "s3://gds-paas-${DEPLOY_ENV}-state/bosh-secrets.yml" - | \
   ruby -ryaml -e 'puts "Sudo password is " + YAML.load(STDIN)["secrets"]["vcap_password_orig"]'

--- a/terraform/bosh/outputs.tf
+++ b/terraform/bosh/outputs.tf
@@ -54,10 +54,6 @@ output "bosh_az_label" {
   value = "${lookup(var.zone_labels, var.bosh_az)}"
 }
 
-output "bosh_ssh_key_pair_name" {
-  value = "${aws_key_pair.bosh_ssh_key_pair.key_name}"
-}
-
 output "key_pair_name" {
   value = "${aws_key_pair.env_key_pair.key_name}"
 }

--- a/terraform/bosh/ssh-key-pairs.tf
+++ b/terraform/bosh/ssh-key-pairs.tf
@@ -1,8 +1,3 @@
-resource "aws_key_pair" "bosh_ssh_key_pair" {
-  key_name   = "${var.env}_bosh_ssh_key_pair"
-  public_key = "${file("${path.module}/bosh_id_rsa.pub")}"
-}
-
 resource "aws_key_pair" "env_key_pair" {
   key_name   = "${var.env}_key_pair"
   public_key = "${file("${path.module}/id_rsa.pub")}"

--- a/terraform/concourse/outputs.tf
+++ b/terraform/concourse/outputs.tf
@@ -22,7 +22,3 @@ output "git_concourse_pool_clone_full_url_ssh" {
   # convert the ssh:// url to a scp like connect string and add the git user
   value = "ssh://${aws_iam_user_ssh_key.git.ssh_public_key_id}@${replace(aws_codecommit_repository.concourse-pool.clone_url_ssh, "/^ssh://([^/]+)//", "$1/")}"
 }
-
-output "concourse_key_pair_name" {
-  value = "${aws_key_pair.concourse_key_pair.key_name}"
-}

--- a/terraform/concourse/ssh-key-pair.tf
+++ b/terraform/concourse/ssh-key-pair.tf
@@ -1,4 +1,0 @@
-resource "aws_key_pair" "concourse_key_pair" {
-  key_name   = "${var.env}_concourse_key_pair"
-  public_key = "${file("${path.module}/concourse_id_rsa.pub")}"
-}


### PR DESCRIPTION
What
----

There's no need for these to have a separate key pair - it's just 
more things for the pipeline to manage, and extra points of
complexity.

This removes the bosh and concourse keypairs, and makes them use the default
keypair instead.

How to review
-------------

* Code review is probably enough.
* I've run this down my dev environment. I've also tested creating and destroying a new bosh and concourse.

Who can review
--------------

Not me.