### PR TITLE
[#163693174] Disable the Bosh compiled package cache.

### DIFF
--- a/manifests/bosh-manifest/eu-west-1.yml
+++ b/manifests/bosh-manifest/eu-west-1.yml
@@ -1,2 +1,0 @@
----
-s3_bucket_suffix: ""

--- a/manifests/bosh-manifest/eu-west-2.yml
+++ b/manifests/bosh-manifest/eu-west-2.yml
@@ -1,2 +1,0 @@
----
-s3_bucket_suffix: "-eu-west-2"

--- a/manifests/bosh-manifest/operations.d/050-compiled-package-cache.yml
+++ b/manifests/bosh-manifest/operations.d/050-compiled-package-cache.yml
@@ -1,6 +1,0 @@
-- type: replace
-  path: /instance_groups/name=bosh/properties/compiled_package_cache?
-  value:
-    options:
-      credentials_source: env_or_profile
-      bucket_name: gds-paas-bosh-cache-((aws_account))((s3_bucket_suffix))

--- a/manifests/bosh-manifest/scripts/generate-manifest.sh
+++ b/manifests/bosh-manifest/scripts/generate-manifest.sh
@@ -85,7 +85,6 @@ EOF
 bosh interpolate \
   --vars-file="${variables_file}" \
   --vars-file="${PAAS_BOOTSTRAP_DIR}/manifests/bosh-manifest/variables.yml" \
-  --vars-file="${PAAS_BOOTSTRAP_DIR}/manifests/bosh-manifest/${AWS_DEFAULT_REGION}.yml" \
   ${opsfile_args} \
   ${vars_store_args} \
     "${BOSH_DEPLOYMENT_DIR}/bosh.yml"


### PR DESCRIPTION
## What

This feature was used to help in dev environments by allowing
environments to share the compilation outputs thus avoiding some time
compiling things when we update boshrelease versions etc.

While this sounds advantageous, we've hit issues with it relating to how
it identifies the stemcell used in the cache keys, which results in
packages compiled for trusty being used on xenial stemcells, which
causes errors in some situations - see [1]. The discussion on that issue
revealed that this is a feature that upstream are not very interested in
maintaining. We've therefore decided that we should turn it off as the
benefits it brings aren't huge when assessed against the problems we're
having (eg we hit [2] while doing the last 2 CF upgrades, and had to
fork CAPI release).

This removes the only usage of region-specific variables in the bosh
manifest, so removes them as well.

[1]https://github.com/cloudfoundry/bosh/issues/2118
[2]https://github.com/cloudfoundry/cf-deployment/issues/663

How to review
-------------

Code review is probably enough - I've been running this in my dev environment for a while now.

Who can review
--------------

Not me.