### PR TITLE
[Support] Update garden-runc to 1.18.2

### DIFF
--- a/concourse/pipelines/create-bosh-concourse.yml
+++ b/concourse/pipelines/create-bosh-concourse.yml
@@ -286,12 +286,6 @@ resources:
       region_name: ((aws_region))
       versioned_file: concourse-manifest.yml
 
-  - name: concourse-bosh-deployment
-    type: git
-    source:
-      uri: https://github.com/concourse/concourse-bosh-deployment
-      tag_filter: "v4.2.1"
-
 jobs:
   - name: init-bucket
     serial: true
@@ -999,7 +993,6 @@ jobs:
           passed: ['generate-concourse-config']
         - get: bosh-CA-crt
           passed: ['generate-secrets']
-        - get: concourse-bosh-deployment
         - get: ssh-private-key
 
       - task: get-and-upload-stemcell
@@ -1051,7 +1044,6 @@ jobs:
           - name: bosh-vars-store
           - name: paas-bootstrap
           - name: bosh-CA-crt
-          - name: concourse-bosh-deployment
           - name: ssh-private-key
           params:
             BOSH_ENVIRONMENT: ((bosh_fqdn))
@@ -1077,9 +1069,7 @@ jobs:
               export BOSH_CLIENT
               export BOSH_CLIENT_SECRET
 
-              bosh deploy \
-                --vars-file concourse-bosh-deployment/versions.yml \
-                concourse-manifest/concourse-manifest.yml
+              bosh deploy concourse-manifest/concourse-manifest.yml
 
   - name: post-deploy
     serial: true

--- a/manifests/concourse-manifest/concourse-base.yml
+++ b/manifests/concourse-manifest/concourse-base.yml
@@ -19,9 +19,9 @@ releases:
     url: https://s3-eu-west-1.amazonaws.com/gds-paas-build-releases/concourse-0.1.3.tgz
     sha1: 77a0ce9f8e32a157bd40b4c4cd85325f9cc77a0c
   - name: garden-runc
-    version: 1.16.3
-    url: https://bosh.io/d/github.com/cloudfoundry/garden-runc-release?v=1.16.3
-    sha1: 2a7c813e7e4d862e19334addf022916fb6b91eb0
+    version: 1.18.2
+    url: https://bosh.io/d/github.com/cloudfoundry/garden-runc-release?v=1.18.2
+    sha1: f761349dfe829fb2e17ab53eb058267209275038
   - name: postgres
     version: 30
     url: https://bosh.io/d/github.com/cloudfoundry/postgres-release?v=30

--- a/manifests/concourse-manifest/concourse-base.yml
+++ b/manifests/concourse-manifest/concourse-base.yml
@@ -8,6 +8,8 @@ meta:
 
 name: concourse
 
+# These versions and checksums are taken from the versions.yml file from the
+# relevant tag of https://github.com/concourse/concourse-bosh-deployment
 releases:
   # TODO: Use the upstream build again after the following PR was released:
   # https://github.com/concourse/concourse/pull/2785
@@ -17,13 +19,13 @@ releases:
     url: https://s3-eu-west-1.amazonaws.com/gds-paas-build-releases/concourse-0.1.3.tgz
     sha1: 77a0ce9f8e32a157bd40b4c4cd85325f9cc77a0c
   - name: garden-runc
-    version: ((!garden_runc_version))
-    url: https://bosh.io/d/github.com/cloudfoundry/garden-runc-release?v=((!garden_runc_version))
-    sha1: ((!garden_runc_sha1))
+    version: 1.16.3
+    url: https://bosh.io/d/github.com/cloudfoundry/garden-runc-release?v=1.16.3
+    sha1: 2a7c813e7e4d862e19334addf022916fb6b91eb0
   - name: postgres
-    version: ((!postgres_version))
-    url: https://bosh.io/d/github.com/cloudfoundry/postgres-release?v=((!postgres_version))
-    sha1: ((!postgres_sha1))
+    version: 30
+    url: https://bosh.io/d/github.com/cloudfoundry/postgres-release?v=30
+    sha1: a798999d29b9f5aa12035cff907b26674b491200
 
 properties:
   aws:


### PR DESCRIPTION
What
----

To fix CVE-2019-5736

We've bumping garden-runc instead of the whole of Concourse because
that's all that is necessary to fix this CVE[1]. This avoids the need to
rebase our fork of concourse again.

As part of this I changed the pipeline to not consume the concourse-bosh-deployment repo any more, and instead merely use it as a reference point.

[1] https://github.com/concourse/concourse/issues/3276#issuecomment-464531341

How to review
-------------

* Code review
* You could deploy this to a dev env, but I've been running this in my dev env for a few days now, and all looks fine.

Who can review
--------------

Not me.