### PR TITLE
Increase auth duration for CI concourse.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -93,6 +93,7 @@ ci: globals check-env-vars ## Set Environment to CI
 	$(eval export AWS_ACCOUNT=ci)
 	$(eval export MAKEFILE_ENV_TARGET=ci)
 	$(eval export ENABLE_GITHUB=true)
+	$(eval export CONCOURSE_AUTH_DURATION=18h)
 	$(eval export AWS_DEFAULT_REGION ?= eu-west-1)
 
 .PHONY: stg-lon


### PR DESCRIPTION
## What

The default value of 5 mins makes for a frustrating experience when
working with the build concourse.

18 hours has been chosen so that a fresh login is required each day.

How to review
-------------

Verify my rationale makes sense.

Who can review
--------------

Not me.
