### PR TITLE
[#64269277] Upgrade UAA release to 70.0

### DIFF
--- a/manifests/bosh-manifest/operations.d/209-update-uaa-release.yml
+++ b/manifests/bosh-manifest/operations.d/209-update-uaa-release.yml
@@ -3,6 +3,6 @@
   path: /releases/name=uaa
   value:
     name: "uaa"
-    version: "68.0"
-    url: "https://bosh.io/d/github.com/cloudfoundry/uaa-release?v=68.0"
-    sha1: "a06e5390463c760bcbcc0bacaec063f41a5ea089"
+    version: "70.0"
+    url: "https://bosh.io/d/github.com/cloudfoundry/uaa-release?v=70.0"
+    sha1: "c23b71fb2a3d01a1f494753b7f00ae40c549838f"


### PR DESCRIPTION
What
----

This update will address a high severity CVE [1]. Although probably the exploit
is not relevant for this UAA instance we still want to use the same version as
we use for CF.

[1] https://www.cloudfoundry.org/blog/cve-2019-3775/

How to review
-------------

I ran it down on my env, so a code review should be enough.

Who can review
--------------

Not me.