### PR TITLE
Increase timeouts on all persistent concourse instances

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -106,6 +106,7 @@ stg-lon: globals ## Set Environment to stg-lon
 	$(eval export AWS_ACCOUNT=staging)
 	$(eval export MAKEFILE_ENV_TARGET=stg-lon)
 	$(eval export ENABLE_GITHUB=true)
+	$(eval export CONCOURSE_AUTH_DURATION=18h)
 	$(eval export AWS_DEFAULT_REGION=eu-west-2)
 
 .PHONY: prod
@@ -118,6 +119,7 @@ prod: globals ## Set Environment to Prod
 	$(eval export AWS_ACCOUNT=prod)
 	$(eval export MAKEFILE_ENV_TARGET=prod)
 	$(eval export ENABLE_GITHUB=true)
+	$(eval export CONCOURSE_AUTH_DURATION=18h)
 	$(eval export AWS_DEFAULT_REGION=eu-west-1)
 
 .PHONY: prod-lon
@@ -130,6 +132,7 @@ prod-lon: globals ## Set Environment to prod-lon
 	$(eval export AWS_ACCOUNT=prod)
 	$(eval export MAKEFILE_ENV_TARGET=prod-lon)
 	$(eval export ENABLE_GITHUB=true)
+	$(eval export CONCOURSE_AUTH_DURATION=18h)
 	$(eval export AWS_DEFAULT_REGION=eu-west-2)
 
 ## Concourse profiles


### PR DESCRIPTION
What
----

This commit increases the timeout on all persistent concourse environments to 18 hours to match CI. This should make support easier when investigating as there is not the need to constantly log in and lose where you were in the flow.

How to review
-------------

code review

Who can review
--------------

Not @LeePorte 