### PR TITLE
[#163521334] Stemcell upgrade to 170.38 as part of cf7.5.0 upgrade

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 dist: trusty
 sudo: false
 rvm:
-  - 2.5
+  - 2.5.3
 env:
   global:
     - TF_VERSION="0.11.1"

--- a/manifests/bosh-manifest/operations.d/030-set-stemcell.yml
+++ b/manifests/bosh-manifest/operations.d/030-set-stemcell.yml
@@ -2,5 +2,5 @@
 - type: replace
   path: /resource_pools/name=vms/stemcell
   value:
-    url: https://bosh.io/d/stemcells/bosh-aws-xen-hvm-ubuntu-xenial-go_agent?v=170.30
-    sha1: 494057433d35582af65cf976d8f55c6f4b2c8bcf
+    url: https://bosh.io/d/stemcells/bosh-aws-xen-hvm-ubuntu-xenial-go_agent?v=170.38
+    sha1: c42f5de98fc6419f341af1732ff0c1e885a25227

--- a/manifests/concourse-manifest/concourse-base.yml
+++ b/manifests/concourse-manifest/concourse-base.yml
@@ -2,7 +2,7 @@
 meta:
   stemcell:
     name: bosh-aws-xen-hvm-ubuntu-xenial-go_agent
-    version: "170.30"
+    version: "170.38"
 
   zone: (( grab terraform_outputs_zone0 ))
 


### PR DESCRIPTION
What
----

Whilst cf7.5.0 includes stemcell 250.x, we're choosing not to do a major
stemcell bump as part of this upgrade. This is partly due to the non-trivial
BOSH-related issues we've seen `create-env`'ing on top of 250.x, but also
because both 170 and 250 are (a) Xenial-based and (b) supported and fully
patched against known CVEs.

The 250 upgrade will be created as a follow-up story after the cf7.5.0 upgrade.

How to review
-------------

- Code review

Who can review
--------------

@AP-Hunt and @jpluscplusm paired on this including running it down multiple dev envs, and will pair-merge it after code review.