### PR TITLE
Fix bootstrap Concourse at a pre-5.0 version

### DIFF
--- a/vagrant/docker-compose.yml
+++ b/vagrant/docker-compose.yml
@@ -10,7 +10,7 @@ services:
     - PGDATA=/database
 
   concourse:
-    image: concourse/concourse
+    image: concourse/concourse:4.2.2
     command: quickstart
     privileged: true
     depends_on: [concourse-db]


### PR DESCRIPTION
What
----

When Concourse 5.0 was released, our bootstrap-from-scratch stopped working as our docker-compose.yml file referenced the `latest` docker hub container.

This fixes it until we have time to investigate why.

How to review
-------------

Tested during the March 2019 gameday prep.

Who can review
--------------

Anyone.