### PR TITLE
Retry the concourse-deploy::deploy-concourse step once

### DIFF
--- a/concourse/pipelines/create-bosh-concourse.yml
+++ b/concourse/pipelines/create-bosh-concourse.yml
@@ -1036,6 +1036,7 @@ jobs:
                 bosh -n upload-stemcell stemcell.tgz
 
       - task: deploy-concourse
+        attempts: 2
         config:
           platform: linux
           image_resource: *gov-paas-bosh-cli-v2-image-resource


### PR DESCRIPTION
What
----


All Concourse-VM-modifying pipeline runs will produce an error, as the worker
redeploys itself and the task step errors.

Once a newly-minted worker comes back up, the manual operator action is
*always* to re-run the concourse-deploy job. Adding `attempts: 2` to this
specific step which errors will:

a) result in a green pipeline without operator intervention and
b) run more quickly, as only the step, not the entire job, is rerun.

How to review
-------------

This has not yet been tested, except to apply the pipeline definition and hence assert its Concourse-correctness.

- Make a dev env change which rolls the Concourse VM (e.g. turning ENABLE_GITHUB to its opposite setting).
- Observe that after a while your pipeline is green, without you having had to rerun the `concourse-deploy` job.

Who can review
--------------

Anyone.