### PR TITLE
[Firebreak] Persist bash_history between bosh-cli sessions

### DIFF
--- a/scripts/bosh-cli.sh
+++ b/scripts/bosh-cli.sh
@@ -17,6 +17,10 @@ BOSH_CLIENT_SECRET=$(aws s3 cp "s3://gds-paas-${DEPLOY_ENV}-state/bosh-vars-stor
     ruby -ryaml -e 'print YAML.load(STDIN)["admin_password"]')
 export BOSH_CLIENT_SECRET
 
+[ ! -d "${HOME}/.bosh_history" ] && mkdir ~/.bosh_history
+
+touch "${HOME}/.bosh_history/${DEPLOY_ENV}"
+
 docker run \
     -it \
     --rm \
@@ -27,4 +31,5 @@ docker run \
     --env "BOSH_ENVIRONMENT=bosh.${SYSTEM_DNS_ZONE_NAME}" \
     --env "BOSH_CA_CERT" \
     --env "BOSH_DEPLOYMENT=${DEPLOY_ENV}" \
+    -v "${HOME}/.bosh_history/${DEPLOY_ENV}:/root/.bash_history" \
     governmentpaas/bosh-shell:54f216386ad6de88da6365ebb2a587504b6a3837


### PR DESCRIPTION
What
----

It's annoying that the bash_history is lost between bosh_cli sessions.

This will map `~/.bash_history` in the container to a per-environment file in `~/.bosh_history/` on the local machine.

How to review
-------------

1. Check out this branch
2. Run the bosh-cli make task against some environment
3. Run some commands inside of the container
4. Terminate the bosh-cli session 
5. Ensure that a file has been created at `~/.bosh_history/${DEPLOY_ENV}` and that this file has the history from your `bosh-cli` session
6. Start another `bosh-cli` session, and ensure that the history can be seen with ^R / `history` / ⬆️

Who can review
--------------

Anyone