### PR TITLE
BAU: Explain the deployer/build Concourse Lite choice

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,16 +72,20 @@ It is important that you do not use the same `DEPLOY_ENV` for both build and dep
 
 ### Deploy
 
-Create Concourse Lite with `make`. There are targets to select the target AWS account, and to select the profiles to apply. For instance for a DEV build concourse bootstrap:
+Create Concourse Lite with `make`. There are Make targets to select the target AWS account, and to select the profiles to apply.
 
-```
-make dev build-concourse bootstrap
-```
+You can create two different things: a deployer concourse or a build concourse.
 
-Or a DEV deployer concourse bootstrap:
+To start deploying a new Cloud Foundry environment:
 
 ```
 make dev deployer-concourse bootstrap
+```
+
+Or to start deploying a new build environment:
+
+```
+make dev build-concourse bootstrap
 ```
 
 `make help` will show all available options.

--- a/README.md
+++ b/README.md
@@ -82,7 +82,12 @@ To start deploying a new Cloud Foundry environment:
 make dev deployer-concourse bootstrap
 ```
 
-Or to start deploying a new build environment:
+
+The above command will deploy a Deployer Concourse which is used for deploying a PaaS.
+
+It is possible to deploy a Build Concourse instead. A Build Concourse is responsible for building and versioning releases, as well as deploying manuals, documentation, product pages, and more.
+  
+To start deploying a new build environment:
 
 ```
 make dev build-concourse bootstrap


### PR DESCRIPTION
What
----

This part of the README suggested the rare option (deploying a new `build` concourse) first. Most people using this README are deploying a new dev environment and need the `deployer` option. This commit tidies up the README a little and will hopefully make people do the right thing.

How to review
-------------

Read the README and see if this makes sense.

Who can review
--------------

Anyone except @46bit 