### PR TITLE
[#164728826] Upgrade Bosh to v269.0.0

### DIFF
--- a/manifests/bosh-manifest/operations.d/082-update-bpm-release.yml
+++ b/manifests/bosh-manifest/operations.d/082-update-bpm-release.yml
@@ -3,6 +3,6 @@
   path: /releases/name=bpm
   value:
     name: "bpm"
-    version: "0.13.0"
-    url: "https://bosh.io/d/github.com/cloudfoundry-incubator/bpm-release?v=0.13.0"
-    sha1: "4b6ebfdaa467c04855528172b099e565d679e0f5"
+    version: "1.0.4"
+    url: "https://bosh.io/d/github.com/cloudfoundry-incubator/bpm-release?v=1.0.4"
+    sha1: "41df19697d6a69d2552bc2c132928157fa91abe0"

--- a/manifests/bosh-manifest/operations.d/109-director-misc-properties.yml
+++ b/manifests/bosh-manifest/operations.d/109-director-misc-properties.yml
@@ -4,8 +4,6 @@
 - type: remove
   path: /instance_groups/name=bosh/properties/director/enable_nats_delivered_templates
 - type: remove
-  path: /instance_groups/name=bosh/properties/director/enable_post_deploy
-- type: remove
   path: /instance_groups/name=bosh/properties/director/generate_vm_passwords
 - type: replace
   path: /instance_groups/name=bosh/properties/director/disks?/max_orphaned_age_in_days


### PR DESCRIPTION
What
----

- Upgrades Bosh from 268.4.0 to 269.0.0
- Deletes the `enable_post_deploy` removal. This was set to true in bosh.yml but removed in the ops file so it defaulted to false. Removing the the ops file removal will now set this to true
  - For more info, see https://github.com/cloudfoundry/bosh/releases/tag/v268.7.0 

How to review
-------------

- Code review
- Check that create-bosh-concourse has run successfully in a dev env (see https://deployer.towers.dev.cloudpipeline.digital/teams/main/pipelines/create-bosh-concourse)
- (optionally) Run create-bosh-concourse yourself in your own dev env

Who can review
--------------

Not @mogds or @richardTowers 
