### PR TITLE
[#165340377] Upgrade Concourse to 5.1.0

### DIFF
--- a/manifests/concourse-manifest/concourse-base.yml
+++ b/manifests/concourse-manifest/concourse-base.yml
@@ -15,14 +15,14 @@ releases:
     version: "5.1.0"
     url: "https://bosh.io/d/github.com/concourse/concourse-bosh-release?v=5.1.0"
     sha1: "e6b55fa88e1bcd0d7dfc83e73cb7dc6c053734ac"
-  - name: garden-runc
-    version: 1.18.2
-    url: https://bosh.io/d/github.com/cloudfoundry/garden-runc-release?v=1.18.2
-    sha1: f761349dfe829fb2e17ab53eb058267209275038
   - name: postgres
     version: 30
     url: https://bosh.io/d/github.com/cloudfoundry/postgres-release?v=30
     sha1: a798999d29b9f5aa12035cff907b26674b491200
+  - name: "bpm"
+    version: "1.0.4"
+    url: "https://bosh.io/d/github.com/cloudfoundry-incubator/bpm-release?v=1.0.4"
+    sha1: "41df19697d6a69d2552bc2c132928157fa91abe0"
 
 properties:
   aws:
@@ -86,6 +86,10 @@ instance_groups:
     persistent_disk_pool: db
 
     jobs:
+      - name: bpm
+        release: bpm
+        properties: {}
+
       - name: postgres
         release: postgres
         properties:
@@ -97,7 +101,7 @@ instance_groups:
               - name: atc
                 password: (( grab secrets.concourse_postgres_password ))
 
-      - name: atc
+      - name: web
         release: concourse
         properties:
           external_url: (( concat "https://" terraform_outputs_concourse_dns_name ))
@@ -118,40 +122,19 @@ instance_groups:
           prometheus:
             bind_ip: 0.0.0.0
             bind_port: 9391
+          worker_gateway:
+            host_key: (( grab secrets.concourse_tsa_host_key ))
+            authorized_keys: [(( grab secrets.concourse_worker_key.public_key ))]
 
       - name: worker
         release: concourse
         properties:
-          baggageclaim:
-            url: "http://127.0.0.1:7788"
-          tsa:
-            host: 127.0.0.1
-            port: 2222
-            host_public_key: (( grab secrets.concourse_tsa_host_key.public_key ))
-            worker_key: (( grab secrets.concourse_worker_key ))
-
-      - name: tsa
-        release: concourse
-        properties:
-          forward_host: 127.0.0.1
-          atc:
-            address: 127.0.0.1:8080
-          host_key: (( grab secrets.concourse_tsa_host_key ))
-          token_signing_key: (( grab secrets.concourse_token_signing_key ))
-          authorized_keys: [(( grab secrets.concourse_worker_key.public_key ))]
-
-      - name: baggageclaim
-        release: concourse
-
-      - name: garden
-        release: garden-runc
-        properties:
+          worker_gateway:
+            hosts: ["127.0.0.1:2222"]
+            host_public_key: ((grab secrets.concourse_tsa_host_key.public_key))
+            worker_key: ((grab secrets.concourse_worker_key))
           garden:
-            listen_network: tcp
-            listen_address: 0.0.0.0:7777
-            graph_cleanup_threshold_in_mb: 3072
-            max_containers: 1024
-            network_pool: "10.254.0.0/20"
+            allow_host_access: true
 
     networks:
       - name: public

--- a/manifests/concourse-manifest/concourse-base.yml
+++ b/manifests/concourse-manifest/concourse-base.yml
@@ -11,13 +11,10 @@ name: concourse
 # These versions and checksums are taken from the versions.yml file from the
 # relevant tag of https://github.com/concourse/concourse-bosh-deployment
 releases:
-  # TODO: Use the upstream build again after the following PR was released:
-  # https://github.com/concourse/concourse/pull/2785
-  # This version is 4.2.2 + the above change
-  - name: concourse
-    version: 0.1.3
-    url: https://s3-eu-west-1.amazonaws.com/gds-paas-build-releases/concourse-0.1.3.tgz
-    sha1: 77a0ce9f8e32a157bd40b4c4cd85325f9cc77a0c
+  - name: "concourse"
+    version: "5.1.0"
+    url: "https://bosh.io/d/github.com/concourse/concourse-bosh-release?v=5.1.0"
+    sha1: "e6b55fa88e1bcd0d7dfc83e73cb7dc6c053734ac"
   - name: garden-runc
     version: 1.18.2
     url: https://bosh.io/d/github.com/cloudfoundry/garden-runc-release?v=1.18.2

--- a/manifests/concourse-manifest/github_auth/config.yml
+++ b/manifests/concourse-manifest/github_auth/config.yml
@@ -3,7 +3,7 @@
 instance_groups:
   - name: concourse
     jobs:
-      - name: atc
+      - name: web
         properties:
           github_auth:
             client_id: (( grab $GITHUB_CLIENT_ID ))

--- a/manifests/concourse-manifest/github_auth/dev_ci_additional_users.yml
+++ b/manifests/concourse-manifest/github_auth/dev_ci_additional_users.yml
@@ -4,7 +4,7 @@
 instance_groups:
   - name: concourse
     jobs:
-      - name: atc
+      - name: web
         properties:
           main_team:
             auth:

--- a/manifests/concourse-manifest/spec/manifest_generation_spec.rb
+++ b/manifests/concourse-manifest/spec/manifest_generation_spec.rb
@@ -3,7 +3,7 @@ require 'open3'
 RSpec.describe "manifest generation" do
   let(:manifest) { manifest_with_defaults }
   let(:concourse_instance_group) { manifest.fetch("instance_groups").find { |ig| ig["name"] == "concourse" } }
-  let(:atc_job) { concourse_instance_group.fetch("jobs").find { |j| j["name"] == "atc" } }
+  let(:web_job) { concourse_instance_group.fetch("jobs").find { |j| j["name"] == "web" } }
 
   it "gets values from vpc terraform outputs" do
     expect(
@@ -13,13 +13,13 @@ RSpec.describe "manifest generation" do
 
   it "gets values from concourse terraform outputs" do
     expect(
-      atc_job.fetch("properties").fetch("external_url")
+      web_job.fetch("properties").fetch("external_url")
     ).to eq("https://" + terraform_fixture_value("concourse_dns_name", "concourse"))
   end
 
   it "gets values from secrets" do
     expect(
-      atc_job.fetch("properties").fetch("add_local_users")[0].split(':', 2)[1]
+      web_job.fetch("properties").fetch("add_local_users")[0].split(':', 2)[1]
     ).to eq(concourse_secrets_value("concourse_atc_password"))
   end
 
@@ -28,16 +28,16 @@ RSpec.describe "manifest generation" do
 
     it "sets up the client_id and secret" do
       expect(
-        atc_job.dig("properties", "github_auth", "client_id")
+        web_job.dig("properties", "github_auth", "client_id")
       ).not_to be_empty
       expect(
-        atc_job.dig("properties", "github_auth", "client_secret")
+        web_job.dig("properties", "github_auth", "client_secret")
       ).not_to be_empty
     end
 
     it "sets up the main team users" do
       expect(
-        atc_job.dig("properties", "main_team", "auth", "github", "users")
+        web_job.dig("properties", "main_team", "auth", "github", "users")
       ).not_to be_empty
     end
   end


### PR DESCRIPTION
What
----

Upgrades Concourse to 5.1.0 and updates the relevant jobs.

Changes include
- Updates `atc` to `web` to provide the web UI and API, along with a worker gateway for registering workers via SSH
- Removes `tsa` because worker registration is now handled by the `web` job
- Removes `garden-runc` release and `baggageclaim` job they're included in the `worker` job
- Adds `bpm` release

Relevant release notes
- https://github.com/concourse/concourse/releases/tag/v5.0.0
- https://github.com/concourse/concourse/releases/tag/v5.0.1
- https://github.com/concourse/concourse/releases/tag/v5.1.0

How to review
-------------

- Code review
- Run the `create-bosh-concourse` pipeline in a dev env

Who can review
--------------

Not me or Tom