### PR TITLE
Make concourse db disk larger

### DIFF
--- a/manifests/concourse-manifest/concourse-base.yml
+++ b/manifests/concourse-manifest/concourse-base.yml
@@ -58,7 +58,7 @@ resource_pools:
 
 disk_pools:
   - name: db
-    disk_size: 10240
+    disk_size: 20480
     cloud_properties:
       type: gp2
 


### PR DESCRIPTION
What
----

10GB is a bit small and ideally we want some breathing room

This has been applied in prod-ireland by hand