### PR TITLE
Set X-Frame-Origin to allow our framesplits to display

### DIFF
--- a/manifests/concourse-manifest/operations.d/010-x-frame-options.yml
+++ b/manifests/concourse-manifest/operations.d/010-x-frame-options.yml
@@ -1,0 +1,8 @@
+---
+instance_groups:
+  - name: concourse
+    jobs:
+      - name: web
+        properties:
+          x_frame_options:
+            - "allow-from https://framesplits.cloudapps.digital/"

--- a/manifests/concourse-manifest/scripts/generate-manifest.sh
+++ b/manifests/concourse-manifest/scripts/generate-manifest.sh
@@ -19,6 +19,7 @@ spruce merge \
   --prune secrets \
   --prune terraform_outputs \
   "${PAAS_BOOTSTRAP_DIR}/manifests/concourse-manifest/concourse-base.yml" \
+  "${PAAS_BOOTSTRAP_DIR}/manifests/concourse-manifest/operations.d/010-x-frame-options.yml" \
   "${WORKDIR}/bosh-secrets/bosh-secrets.yml" \
   "${WORKDIR}/concourse-secrets/concourse-secrets.yml" \
   "${WORKDIR}/terraform-outputs/concourse-terraform-outputs.yml" \


### PR DESCRIPTION
What
----

Concourse 5 has defaulted X-Frame-Origin to Deny. Whilst good for security, this has broken our display of the pipeline status.


How to review
-------------

Code review and visit [paas hosted framesplits](https://framesplits.cloudapps.digital/index.html?title=&layout=2row&url%5B%5D=https%3A%2F%2Fdeployer.leeporte.dev.cloudpipeline.digital%2Fteams%2Fmain%2Fpipelines%2Fcreate-cloudfoundry&url%5B%5D=&url%5B%5D=&url%5B%5D=)

Who can review
--------------

Anyone
