### PR TITLE
Multiple concourse workers

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ rvm:
 env:
   global:
     - TF_VERSION="0.11.1"
-    - SPRUCE_VERSION="1.8.9"
+    - SPRUCE_VERSION="1.14.0"
     - BOSH_CLI_VERSION="2.0.48"
     - CERTSTRAP_VERSION="1.1.1"
 

--- a/Makefile
+++ b/Makefile
@@ -145,6 +145,7 @@ build-concourse: ## Setup profiles for deploying a build concourse
 	$(eval export CONCOURSE_HOSTNAME=concourse)
 	$(eval export CONCOURSE_INSTANCE_TYPE=m4.large)
 	$(eval export CONCOURSE_INSTANCE_PROFILE=concourse-build)
+	$(eval export CONCOURSE_WORKER_INSTANCES ?= 2)
 	@true
 
 .PHONY: deployer-concourse
@@ -156,6 +157,7 @@ deployer-concourse: ## Setup profiles for deploying a paas-cf deployer concourse
 	$(eval export CONCOURSE_HOSTNAME=deployer)
 	$(eval export CONCOURSE_INSTANCE_TYPE=m4.xlarge)
 	$(eval export CONCOURSE_INSTANCE_PROFILE=deployer-concourse)
+	$(eval export CONCOURSE_WORKER_INSTANCES ?= 0)
 	@true
 
 ## Actions

--- a/concourse/pipelines/create-bosh-concourse.yml
+++ b/concourse/pipelines/create-bosh-concourse.yml
@@ -35,7 +35,7 @@ meta:
       type: docker-image
       source:
         repository: governmentpaas/spruce
-        tag: 895cf6752c8ec64af05a3a735186b90acd3db65a
+        tag: 758eef2a762bc3a4d7df2a41f655b7a884b492fa
     terraform: &terraform-image-resource
       type: docker-image
       source:
@@ -1054,6 +1054,8 @@ jobs:
             BOSH_GW_HOST: ((bosh_login_host))
             BOSH_GW_USER: vcap
             BOSH_GW_PRIVATE_KEY: ssh-private-key/id_rsa
+
+            CONCOURSE_WORKER_INSTANCES: ((concourse_worker_instances))
           run:
             path: sh
             args:
@@ -1069,7 +1071,8 @@ jobs:
               export BOSH_CLIENT
               export BOSH_CLIENT_SECRET
 
-              bosh deploy concourse-manifest/concourse-manifest.yml
+              bosh deploy concourse-manifest/concourse-manifest.yml \
+                   -v "concourse_worker_instances=$CONCOURSE_WORKER_INSTANCES"
 
   - name: post-deploy
     serial: true

--- a/concourse/scripts/pipelines.sh
+++ b/concourse/scripts/pipelines.sh
@@ -33,6 +33,7 @@ target_concourse: ${TARGET_CONCOURSE}
 concourse_type: ${CONCOURSE_TYPE}
 concourse_instance_type: ${CONCOURSE_INSTANCE_TYPE}
 concourse_instance_profile: ${CONCOURSE_INSTANCE_PROFILE}
+concourse_worker_instances: ${CONCOURSE_WORKER_INSTANCES}
 enable_github: ${ENABLE_GITHUB}
 github_client_id: ${GITHUB_CLIENT_ID:-}
 github_client_secret: ${GITHUB_CLIENT_SECRET:-}

--- a/manifests/concourse-manifest/concourse-base.yml
+++ b/manifests/concourse-manifest/concourse-base.yml
@@ -47,6 +47,32 @@ resource_pools:
       security_groups:
       - (( grab terraform_outputs_bosh_managed_security_group ))
       - (( grab terraform_outputs_concourse_security_group ))
+      - (( grab terraform_outputs_concourse_nocycle_security_group ))
+      - (( grab terraform_outputs_ssh_security_group ))
+      - (( grab terraform_outputs_bosh_api_client_security_group ))
+      - (( grab terraform_outputs_bosh_ssh_client_security_group ))
+    env:
+      bosh:
+        password: (( grab secrets.vcap_password ))
+        ipv6:
+          enable: true
+
+  - name: concourse_worker
+    network: concourse
+    stemcell:
+      name: (( grab meta.stemcell.name ))
+      version: (( grab meta.stemcell.version ))
+    cloud_properties:
+      instance_type: (( grab $CONCOURSE_INSTANCE_TYPE ))
+      availability_zone: (( grab meta.zone ))
+      iam_instance_profile: (( grab $CONCOURSE_INSTANCE_PROFILE ))
+      auto_assign_public_ip: true
+      ephemeral_disk:
+        size: 102400
+        type: gp2
+      security_groups:
+      - (( grab terraform_outputs_bosh_managed_security_group ))
+      - (( grab terraform_outputs_concourse_worker_security_group ))
       - (( grab terraform_outputs_ssh_security_group ))
       - (( grab terraform_outputs_bosh_api_client_security_group ))
       - (( grab terraform_outputs_bosh_ssh_client_security_group ))
@@ -142,6 +168,28 @@ instance_groups:
         - (( grab terraform_outputs_concourse_elastic_ip ))
       - name: concourse
         static_ips: (( static_ips(0) ))
+        default: [dns, gateway]
+
+  - name: concourse-worker
+    instances: ((concourse_worker_instances))
+    resource_pool: concourse_worker
+
+    jobs:
+      - name: bpm
+        release: bpm
+        properties: {}
+
+      - name: worker
+        release: concourse
+        properties:
+          worker_gateway:
+            worker_key: ((grab secrets.concourse_worker_key))
+            host_public_key: ((grab secrets.concourse_tsa_host_key.public_key))
+          garden:
+            allow_host_access: true
+
+    networks:
+      - name: concourse
         default: [dns, gateway]
 
 compilation:

--- a/manifests/shared/spec/fixtures/concourse-terraform-outputs.yml
+++ b/manifests/shared/spec/fixtures/concourse-terraform-outputs.yml
@@ -2,6 +2,10 @@
 terraform_outputs_concourse_elastic_ip: 1.2.3.4
 terraform_outputs_concourse_security_group: concourse_sg
 terraform_outputs_concourse_security_group_id: sg-12345678
+terraform_outputs_concourse_nocycle_security_group: concourse_nocycle_sg
+terraform_outputs_concourse_nocycle_security_group_id: sg-87654321
+terraform_outputs_concourse_worker_security_group: concourse_worker_sg
+terraform_outputs_concourse_worker_security_group_id: sg-00001111
 terraform_outputs_concourse_elb_name: env1234-concourse
 terraform_outputs_concourse_dns_name: concourse.env1234.dev.cloudpipeline.digital
 terraform_outputs_git_concourse_pool_clone_full_url_ssh: "ssh://user@git-codecommit.us-east-1.amazonaws.com/v1/repos/concourse-pool-test"

--- a/terraform/bosh/outputs.tf
+++ b/terraform/bosh/outputs.tf
@@ -69,3 +69,7 @@ output "bosh_ssh_client_security_group" {
 output "default_security_group" {
   value = "${aws_security_group.bosh_managed.name}"
 }
+
+output "bosh_security_group_id" {
+  value = "${aws_security_group.bosh.id}"
+}

--- a/terraform/concourse/outputs.tf
+++ b/terraform/concourse/outputs.tf
@@ -10,6 +10,22 @@ output "concourse_security_group_id" {
   value = "${aws_security_group.concourse.id}"
 }
 
+output "concourse_nocycle_security_group" {
+  value = "${aws_security_group.concourse-nocycle.name}"
+}
+
+output "concourse_nocycle_security_group_id" {
+  value = "${aws_security_group.concourse-nocycle.id}"
+}
+
+output "concourse_worker_security_group" {
+  value = "${aws_security_group.concourse-worker.name}"
+}
+
+output "concourse_worker_security_group_id" {
+  value = "${aws_security_group.concourse-worker.id}"
+}
+
 output "concourse_elb_name" {
   value = "${aws_elb.concourse.name}"
 }

--- a/terraform/concourse/security_group.tf
+++ b/terraform/concourse/security_group.tf
@@ -1,4 +1,6 @@
 resource "aws_security_group" "concourse" {
+  # Web
+
   name        = "${var.env}-concourse"
   description = "Concourse security group"
   vpc_id      = "${var.vpc_id}"
@@ -26,5 +28,71 @@ resource "aws_security_group" "concourse" {
 
   tags {
     Name = "${var.env}-concourse"
+  }
+}
+
+resource "aws_security_group" "concourse-worker" {
+  # Worker
+
+  name        = "${var.env}-concourse-worker"
+  description = "Concourse worker security group"
+  vpc_id      = "${var.vpc_id}"
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  ingress {
+    # ATC -> Garden
+    from_port       = 7777
+    to_port         = 7777
+    protocol        = "tcp"
+    security_groups = ["${aws_security_group.concourse.id}"]
+  }
+
+  ingress {
+    # ATC -> Baggageclaim
+    from_port       = 7788
+    to_port         = 7788
+    protocol        = "tcp"
+    security_groups = ["${aws_security_group.concourse.id}"]
+  }
+
+  ingress {
+    from_port   = 6868
+    to_port     = 6868
+    protocol    = "tcp"
+    cidr_blocks = ["${compact(concat(var.admin_cidrs, list(format("%s/32", var.microbosh_static_private_ip))))}"]
+  }
+
+  tags {
+    Name = "${var.env}-concourse-worker"
+  }
+}
+
+resource "aws_security_group" "concourse-nocycle" {
+  # Web (again)
+
+  # This security group exists because we use ingress/egress rules inline
+
+  # We cannot use inline rules where there are cycles
+
+  name        = "${var.env}-concourse-nocycle"
+  description = "Concourse nocycle security group"
+  vpc_id      = "${var.vpc_id}"
+
+  ingress {
+    # TSA <- Beacon
+    from_port       = 2222
+    to_port         = 2222
+    protocol        = "tcp"
+    security_groups = ["${aws_security_group.concourse-worker.id}"]
+  }
+
+  tags {
+    Name = "${var.env}-concourse-no-cycle"
   }
 }


### PR DESCRIPTION
What
----

commit message:
```
we are running into some bad behaviour with scheduling and building
particularly on our build concourse. before this commit we ran worker
and web on the same instances and had only once instance. this commit
enables us to have an arbitrary number of workers, in addition to the
one which runs on the web instance.

this is perhaps a partial step towards multiaz concourse (but this
commit is not a full solution)

---

There are a couple of weird things in this commit

- use --var when doing bosh deploy
- security group "-nocycle"

--var is because spruce renders the value as a string instead of a
number, which is then rejected by bosh because it wants a number. we
don't need spruce to do anything. Spruce ignores ((var)) without spaces
around the parens

-nocycle security groups is because we use ingress/egress rules inline.
we cant add the rules we need inline because it creates a cycle which
terraform is defeated by

I updated the spruce version to get the ignory behaviour, we were
building this version anyway

---

I do not think that we need more instances for deployer, so the number
of worker instances to give it is 0, however for build i chose to give
it two instances which should speed up builds and/or make them more
reliable
```

This only really works right now for build-concourses because of how IP safelisting works with CF

How to review
-------------

```
export DEPLOY_ENV=???

cd paas-bootstrap
git fetch
git checkout -b wip-tlwr origin/wip-tlwr

SELF_UPDATE_PIPELINE=false \
BRANCH=wip-tlwr\
 CONCOURSE_WORKER_INSTANCES=2 \
make dev deployer-concourse pipelines

fly -t $DEPLOY_ENV check-resource -r create-bosh-concourse/paas-bootstrap
fly -t $DEPLOY_ENV trigger-job -j create-bosh-concourse/init-bucket

sleep 300

fly -t $DEPLOY_ENV workers # should be 3
```

This only really works for build concourses right now due to how IP safelisting with `create-cloudfoundry`

Who can review
--------------

Not @tlwr
