### PR TITLE
Add colocated-with-web tag to web colocated worker

### DIFF
--- a/concourse/pipelines/create-bosh-concourse.yml
+++ b/concourse/pipelines/create-bosh-concourse.yml
@@ -346,6 +346,7 @@ jobs:
             file: updated-bucket-state/bucket.tfstate
 
       - task: self-update-pipelines
+        tags: [colocated-with-web]
         config:
           platform: linux
           image_resource: *self-update-pipelines-image-resource
@@ -1126,6 +1127,7 @@ jobs:
               [ "$(grep '|' vms.txt | grep -cEv "(^\|\ \ |\-\-|VM|running)")" -eq 0 ]
 
       - task: upload-pipeline
+        tags: [colocated-with-web]
         config:
           platform: linux
           image_resource: *self-update-pipelines-image-resource

--- a/manifests/concourse-manifest/concourse-base.yml
+++ b/manifests/concourse-manifest/concourse-base.yml
@@ -159,6 +159,7 @@ instance_groups:
             hosts: ["127.0.0.1:2222"]
             host_public_key: ((grab secrets.concourse_tsa_host_key.public_key))
             worker_key: ((grab secrets.concourse_worker_key))
+          tags: [colocated-with-web]
           garden:
             allow_host_access: true
 


### PR DESCRIPTION
Signed-off-by: Toby Lorne <toby.lornewelch-richards@digital.cabinet-office.gov.uk>

What
----

We have pipelines which update themselves, we have these across paas-release-ci, paas-cf, and paas-bootstrap. For peculiarities in the infrastructure, due to the assumption that the web node is the only node, only the web node is permitted to update itself.

This PR adds a tag to the worker which runs on the same node as the web instance, and updates the self-updating pipeline jobs to run on the `colocated-with-web` worker.

How to review
-------------

Apply this to your concourse, and ensure that it can run `create-bosh-concourse`.

Other
---

Expect other PRs for paas-cf and paas-release-ci

- https://github.com/alphagov/paas-release-ci/pull/111
- https://github.com/alphagov/paas-cf/pull/1895

Who can review
--------------

Not @tlwr