### PR TITLE
Default deployer concourse workers to 1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -157,7 +157,7 @@ deployer-concourse: ## Setup profiles for deploying a paas-cf deployer concourse
 	$(eval export CONCOURSE_HOSTNAME=deployer)
 	$(eval export CONCOURSE_INSTANCE_TYPE=m4.xlarge)
 	$(eval export CONCOURSE_INSTANCE_PROFILE=deployer-concourse)
-	$(eval export CONCOURSE_WORKER_INSTANCES ?= 0)
+	$(eval export CONCOURSE_WORKER_INSTANCES ?= 1)
 	@true
 
 ## Actions


### PR DESCRIPTION
What
----

Build concourses have 3 workers by default, 2 running on their own
instances and 1 colocated with the web node.

Deployer concourses used to have 1 worker by default, only colocated
with the web node.

We get concourse to talk to itself, but currently the way it does this
is using the static IP of the concourse web instance itself as part of
the security group safelist. In order to ensure that the
self-update-pipeline job ran in the right place we added tags which we
can use to select individual instances.

The unfortunate consequence of this is that for deployer concourses
which do not have an external node, resources will not be checked, as
concourse will not allocate untagged resources to tagged nodes. The result of this is a very orange concourse.

This commit defaults the deployer concourse to have 1 external worker by
default, which is where all of the actual work will happen, and only use
the colocated-with-web node for updating itself.

How to review
-------------

Code review

Who can review
--------------

Not @tlwr