### PR TITLE
Concourse 5.2

### DIFF
--- a/manifests/concourse-manifest/concourse-base.yml
+++ b/manifests/concourse-manifest/concourse-base.yml
@@ -12,9 +12,9 @@ name: concourse
 # relevant tag of https://github.com/concourse/concourse-bosh-deployment
 releases:
   - name: "concourse"
-    version: "5.1.0"
-    url: "https://bosh.io/d/github.com/concourse/concourse-bosh-release?v=5.1.0"
-    sha1: "e6b55fa88e1bcd0d7dfc83e73cb7dc6c053734ac"
+    version: "5.2.0"
+    url: "https://bosh.io/d/github.com/concourse/concourse-bosh-release?v=5.2.0"
+    sha1: "e7c813d35e70e1a3a5334b977136ba736fae05e1"
   - name: postgres
     version: 30
     url: https://bosh.io/d/github.com/cloudfoundry/postgres-release?v=30

--- a/manifests/concourse-manifest/concourse-base.yml
+++ b/manifests/concourse-manifest/concourse-base.yml
@@ -134,6 +134,7 @@ instance_groups:
           add_local_users:
             - (( concat "admin:" secrets.concourse_web_password ))
           auth_duration: (( grab $CONCOURSE_AUTH_DURATION ))
+          cluster_name: (( grab terraform_outputs_environment ))
           main_team:
             auth:
               local:

--- a/vagrant/docker-compose.yml
+++ b/vagrant/docker-compose.yml
@@ -10,7 +10,7 @@ services:
     - PGDATA=/database
 
   concourse-web:
-    image: concourse/concourse:5.1.0
+    image: concourse/concourse:5.2.0
     command: web
     privileged: true
     depends_on: [concourse-db]
@@ -32,7 +32,7 @@ services:
     - CONCOURSE_SESSION_SIGNING_KEY=/keys/session_signing_key
 
   concourse-worker-colocated:
-    image: concourse/concourse:5.1.0
+    image: concourse/concourse:5.2.0
     command: worker
     privileged: true
     depends_on: [concourse-db, concourse-web]
@@ -50,7 +50,7 @@ services:
     - CONCOURSE_GARDEN_DNS_SERVER=169.254.169.253
 
   concourse-worker-normal:
-    image: concourse/concourse:5.1.0
+    image: concourse/concourse:5.2.0
     command: worker
     privileged: true
     depends_on: [concourse-db, concourse-web]


### PR DESCRIPTION
What
----

- Upgrades Concourse to 5.2
- Uses new `cluster_name` parameter to name the cluster using `$DEPLOY_ENV`

![image](https://user-images.githubusercontent.com/1482692/57877863-b0a62880-7810-11e9-8a1e-e28754d9a405.png)
_Screenshot of home screen in "hd" mode, which shows the `cluster_name` "tlwr"_

How to review
-------------

- Create bosh concourse on your concourse
- Create bosh concourse using `make bootstrap`
- Create cloudfoundry using your concourse
- Read the release notes

Who can review
--------------

Not @tlwr
