### PR TITLE
Concourse 5.2 aggregate

### DIFF
--- a/concourse/pipelines/create-bosh-concourse.yml
+++ b/concourse/pipelines/create-bosh-concourse.yml
@@ -290,7 +290,7 @@ jobs:
   - name: init-bucket
     serial: true
     plan:
-      - aggregate:
+      - in_parallel:
         - get: paas-bootstrap
 
       - task: try-fetch-bucket-state
@@ -371,7 +371,7 @@ jobs:
   - name: vpc
     serial: true
     plan:
-      - aggregate:
+      - in_parallel:
         - get: paas-bootstrap
           trigger: true
           passed: ['init-bucket']
@@ -410,7 +410,7 @@ jobs:
               cd generated-git-ssh-keys
               ssh-keygen -t rsa -b 4096 -f git_id_rsa -N ''
         on_success:
-          aggregate:
+          in_parallel:
             - put: git-ssh-public-key
               params:
                 file: generated-git-ssh-keys/git_id_rsa.pub
@@ -454,7 +454,7 @@ jobs:
   - name: generate-secrets
     serial: true
     plan:
-      - aggregate:
+      - in_parallel:
         - get: paas-bootstrap
           passed: ['init-bucket']
         - get: pipeline-trigger
@@ -494,7 +494,7 @@ jobs:
                 fi
                 cp out/bosh-CA.crt generated-bosh-CA/bosh-CA.crt
         on_success:
-          aggregate:
+          in_parallel:
             - put: bosh-CA
               params:
                 file: generated-bosh-CA/bosh-CA.tar.gz
@@ -502,7 +502,7 @@ jobs:
               params:
                 file: generated-bosh-CA/bosh-CA.crt
 
-      - aggregate:
+      - in_parallel:
         - task: generate-bosh-secrets
           config:
             platform: linux
@@ -559,7 +559,7 @@ jobs:
                   cp id_rsa.pub ssh-public-key-to-upload
           on_success:
             try:
-              aggregate:
+              in_parallel:
                 - put: ssh-private-key
                   params:
                     file: ssh-private-key-to-upload/id_rsa
@@ -595,7 +595,7 @@ jobs:
   - name: bosh-terraform
     serial: true
     plan:
-      - aggregate:
+      - in_parallel:
         - get: pipeline-trigger
           trigger: true
           passed: ['generate-secrets', 'vpc']
@@ -680,7 +680,7 @@ jobs:
     serial_groups: [bosh-deploy]
     serial: true
     plan:
-      - aggregate:
+      - in_parallel:
         - get: pipeline-trigger
           trigger: true
           passed: ['bosh-terraform']
@@ -758,7 +758,7 @@ jobs:
                   paas-bootstrap/manifests/bosh-manifest/scripts/generate-manifest.sh \
                     > bosh-manifest/bosh-manifest.yml
         on_success:
-          aggregate:
+          in_parallel:
           - put: bosh-manifest
             params:
               file: bosh-manifest/bosh-manifest.yml
@@ -772,7 +772,7 @@ jobs:
   - name: bosh-deploy
     serial: true
     plan:
-      - aggregate:
+      - in_parallel:
         - get: pipeline-trigger
           passed: ['generate-bosh-config']
           trigger: true
@@ -814,7 +814,7 @@ jobs:
   - name: concourse-terraform
     serial: true
     plan:
-      - aggregate:
+      - in_parallel:
         - get: paas-bootstrap
           passed: ['bosh-terraform']
         - get: pipeline-trigger
@@ -900,7 +900,7 @@ jobs:
   - name: generate-concourse-config
     serial: true
     plan:
-      - aggregate:
+      - in_parallel:
         - get: paas-bootstrap
           passed: ['concourse-terraform']
         - get: pipeline-trigger
@@ -983,7 +983,7 @@ jobs:
     serial: true
     interruptible: true
     plan:
-      - aggregate:
+      - in_parallel:
         - get: paas-bootstrap
           passed: ['generate-concourse-config']
         - get: pipeline-trigger
@@ -1078,7 +1078,7 @@ jobs:
   - name: post-deploy
     serial: true
     plan:
-      - aggregate:
+      - in_parallel:
         - get: pipeline-trigger
           passed: ['concourse-deploy']
           trigger: true
@@ -1153,7 +1153,7 @@ jobs:
   - name: expunge-concourse
     serial: true
     plan:
-      - aggregate:
+      - in_parallel:
         - get: paas-bootstrap
           passed: ['post-deploy']
         - get: pipeline-trigger
@@ -1342,7 +1342,7 @@ jobs:
 
   - name: rotate-bosh-credentials
     plan:
-      - aggregate:
+      - in_parallel:
         - get: bosh-vars-store
         - get: bosh-manifest-pre-vars
         - get: paas-bootstrap
@@ -1374,7 +1374,7 @@ jobs:
                   --rsa \
                   > modified-bosh-vars-store/bosh-vars-store.yml
         on_success:
-          aggregate:
+          in_parallel:
           - put: bosh-vars-store
             params:
               file: modified-bosh-vars-store/bosh-vars-store.yml
@@ -1391,7 +1391,7 @@ jobs:
   - name: rotate-bosh-leaf-certs
     serial: true
     plan:
-    - aggregate:
+    - in_parallel:
       - get: paas-bootstrap
       - get: bosh-vars-store
       - get: bosh-manifest-pre-vars
@@ -1423,7 +1423,7 @@ jobs:
   - name: delete-old-bosh-certs
     serial: true
     plan:
-    - aggregate:
+    - in_parallel:
       - get: paas-bootstrap
       - get: bosh-vars-store
     - task: delete-old-bosh-internal-certs

--- a/concourse/pipelines/destroy-bosh-concourse.yml
+++ b/concourse/pipelines/destroy-bosh-concourse.yml
@@ -154,7 +154,7 @@ jobs:
   - name: enable-bosh-access
     serial: true
     plan:
-      - aggregate:
+      - in_parallel:
         - get: pipeline-trigger
           trigger: true
           passed: ['self-update-pipeline']
@@ -228,7 +228,7 @@ jobs:
   - name: destroy-concourse
     serial: true
     plan:
-      - aggregate:
+      - in_parallel:
         - get: paas-bootstrap
           passed: ['enable-bosh-access']
         - get: pipeline-trigger
@@ -341,7 +341,7 @@ jobs:
   - name: destroy-bosh
     serial: true
     plan:
-      - aggregate:
+      - in_parallel:
         - get: pipeline-trigger
           trigger: true
           passed: ['destroy-concourse']
@@ -532,7 +532,7 @@ jobs:
   - name: destroy-vpc
     serial: true
     plan:
-      - aggregate:
+      - in_parallel:
         - get: paas-bootstrap
           passed: ['destroy-bosh']
         - get: vpc-tfstate
@@ -573,7 +573,7 @@ jobs:
   - name: destroy-init-bucket
     serial: true
     plan:
-      - aggregate:
+      - in_parallel:
         - get: paas-bootstrap
           passed: ['destroy-vpc']
         - get: bucket-terraform-state

--- a/concourse/scripts/pipecleaner.py
+++ b/concourse/scripts/pipecleaner.py
@@ -102,7 +102,7 @@ class Pipecleaner(object):
                 discovered_blocks = []
 
                 # Flatten array blocks as we don't care
-                for block_type in ('aggregate', 'do'):
+                for block_type in ('in_parallel', 'aggregate', 'do'):
                     if block_type in item:
                         discovered_blocks.extend(item[block_type])
                         del item[block_type]

--- a/manifests/concourse-manifest/concourse-base.yml
+++ b/manifests/concourse-manifest/concourse-base.yml
@@ -12,9 +12,9 @@ name: concourse
 # relevant tag of https://github.com/concourse/concourse-bosh-deployment
 releases:
   - name: "concourse"
-    version: "5.1.0"
-    url: "https://bosh.io/d/github.com/concourse/concourse-bosh-release?v=5.1.0"
-    sha1: "e6b55fa88e1bcd0d7dfc83e73cb7dc6c053734ac"
+    version: "5.2.0"
+    url: "https://bosh.io/d/github.com/concourse/concourse-bosh-release?v=5.2.0"
+    sha1: "e7c813d35e70e1a3a5334b977136ba736fae05e1"
   - name: postgres
     version: 30
     url: https://bosh.io/d/github.com/cloudfoundry/postgres-release?v=30

--- a/manifests/concourse-manifest/concourse-base.yml
+++ b/manifests/concourse-manifest/concourse-base.yml
@@ -134,6 +134,7 @@ instance_groups:
           add_local_users:
             - (( concat "admin:" secrets.concourse_web_password ))
           auth_duration: (( grab $CONCOURSE_AUTH_DURATION ))
+          cluster_name: (( grab terraform_outputs_environment ))
           main_team:
             auth:
               local:

--- a/vagrant/docker-compose.yml
+++ b/vagrant/docker-compose.yml
@@ -10,7 +10,7 @@ services:
     - PGDATA=/database
 
   concourse-web:
-    image: concourse/concourse:5.1.0
+    image: concourse/concourse:5.2.0
     command: web
     privileged: true
     depends_on: [concourse-db]
@@ -32,7 +32,7 @@ services:
     - CONCOURSE_SESSION_SIGNING_KEY=/keys/session_signing_key
 
   concourse-worker-colocated:
-    image: concourse/concourse:5.1.0
+    image: concourse/concourse:5.2.0
     command: worker
     privileged: true
     depends_on: [concourse-db, concourse-web]
@@ -50,7 +50,7 @@ services:
     - CONCOURSE_GARDEN_DNS_SERVER=169.254.169.253
 
   concourse-worker-normal:
-    image: concourse/concourse:5.1.0
+    image: concourse/concourse:5.2.0
     command: worker
     privileged: true
     depends_on: [concourse-db, concourse-web]


### PR DESCRIPTION
What
----

- Predicated on [Concourse 5.2 PR](https://github.com/alphagov/paas-bootstrap/pull/282)
- Updates all `aggregate` steps to `in_parallel` in a dumb way (aggregate is deprecated)
- Updates pipecleaner to know about `in_parallel`

Aggregate is a deprecated `step` in Concourse 5.2

How to review
-------------

- Create bosh concourse on your concourse
- Create bosh concourse using `make bootstrap`

Who can review
--------------

Not @tlwr
