### PR TITLE
[#164963973] Deploy Concourse To A Different AZ

### DIFF
--- a/concourse/pipelines/create-bosh-concourse.yml
+++ b/concourse/pipelines/create-bosh-concourse.yml
@@ -1073,7 +1073,8 @@ jobs:
               export BOSH_CLIENT_SECRET
 
               bosh deploy concourse-manifest/concourse-manifest.yml \
-                   -v "concourse_worker_instances=$CONCOURSE_WORKER_INSTANCES"
+                   -v "concourse_worker_instances=$CONCOURSE_WORKER_INSTANCES" \
+                   --recreate --recreate-persistent-disks
 
   - name: post-deploy
     serial: true

--- a/manifests/concourse-manifest/concourse-base.yml
+++ b/manifests/concourse-manifest/concourse-base.yml
@@ -4,7 +4,7 @@ meta:
     name: bosh-aws-xen-hvm-ubuntu-xenial-go_agent
     version: "170.69"
 
-  zone: (( grab terraform_outputs_zone0 ))
+  zone: (( grab terraform_outputs_zone1 ))
 
 name: concourse
 
@@ -92,16 +92,16 @@ networks:
   - name: concourse
     type: manual
     subnets:
-      - range: 10.0.0.0/24
+      - range: 10.0.1.0/24
         dns: [10.0.0.2]
-        gateway: 10.0.0.1
+        gateway: 10.0.1.1
         reserved:
-        - 10.0.0.0 - 10.0.0.9
+        - 10.0.1.0 - 10.0.1.9
         static:
-        - 10.0.0.10 - 10.0.0.20
+        - 10.0.1.10 - 10.0.1.20
 
         cloud_properties:
-          subnet: (( grab terraform_outputs_subnet0_id ))
+          subnet: (( grab terraform_outputs_subnet1_id ))
   - name: public
     type: vip
 

--- a/manifests/concourse-manifest/spec/manifest_generation_spec.rb
+++ b/manifests/concourse-manifest/spec/manifest_generation_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe "manifest generation" do
   it "gets values from vpc terraform outputs" do
     expect(
       manifest_with_defaults["resource_pools"].first["cloud_properties"]["availability_zone"]
-    ).to eq(terraform_fixture_value("zone0", "vpc"))
+    ).to eq(terraform_fixture_value("zone1", "vpc"))
   end
 
   it "gets values from concourse terraform outputs" do

--- a/manifests/shared/spec/fixtures/vpc-terraform-outputs.yml
+++ b/manifests/shared/spec/fixtures/vpc-terraform-outputs.yml
@@ -5,6 +5,7 @@ terraform_outputs_vpc_cidr: 10.0.0.0/16
 terraform_outputs_ssh_security_group: test-office-access-ssh
 terraform_outputs_vpc_id: vpc-12345678
 terraform_outputs_subnet0_id: subnet-12345678
+terraform_outputs_subnet1_id: subnet-87654321
 terraform_outputs_zone0: eu-west-1a
 terraform_outputs_zone1: eu-west-1b
 terraform_outputs_zone2: eu-west-1c

--- a/terraform/vpc/outputs.tf
+++ b/terraform/vpc/outputs.tf
@@ -22,6 +22,10 @@ output "subnet0_id" {
   value = "${aws_subnet.infra.0.id}"
 }
 
+output "subnet1_id" {
+  value = "${aws_subnet.infra.1.id}"
+}
+
 output "zone0" {
   value = "${var.zones["zone0"]}"
 }


### PR DESCRIPTION
What
----

- Updates the concourse manifest so it runs in a different AZ to BOSH
- Adds a `--recreate` and `--recreate-persistent-disks` so the persistent disk is recreated in the new AZ

How to review
-------------

- Using bosh-cli, run `bosh -d concourse orphan-disk vol-0000000000`
- Run `create-bosh-concourse` pipelines using this branch
- Upload pipelines using make pipelines

Who can review
--------------

Not me