### PR TITLE
[#166728064] Update bosh-aws-cpi release to v75

### DIFF
--- a/concourse/pipelines/concourse-lite-self-terminate.yml
+++ b/concourse/pipelines/concourse-lite-self-terminate.yml
@@ -4,7 +4,7 @@ meta:
       type: docker-image
       source:
         repository: governmentpaas/awscli
-        tag: f3875548cbc723e9f0ea487aaba5f38302279f72
+        tag: 21e5ddc4c7265b112cbeb0993b0915fa9366a876
 
 resources:
   - name: delete-timer

--- a/concourse/pipelines/create-bosh-concourse.yml
+++ b/concourse/pipelines/create-bosh-concourse.yml
@@ -5,22 +5,22 @@ meta:
       type: docker-image
       source:
         repository: governmentpaas/awscli
-        tag: f3875548cbc723e9f0ea487aaba5f38302279f72
+        tag: 21e5ddc4c7265b112cbeb0993b0915fa9366a876
     bosh-cli-v2: &gov-paas-bosh-cli-v2-image-resource
       type: docker-image
       source:
         repository: governmentpaas/bosh-cli-v2
-        tag: f3875548cbc723e9f0ea487aaba5f38302279f72
+        tag: 21e5ddc4c7265b112cbeb0993b0915fa9366a876
     certstrap: &certstrap-image-resource
       type: docker-image
       source:
         repository: governmentpaas/certstrap
-        tag: f3875548cbc723e9f0ea487aaba5f38302279f72
+        tag: 21e5ddc4c7265b112cbeb0993b0915fa9366a876
     git-ssh: &git-ssh-image-resource
       type: docker-image
       source:
         repository: governmentpaas/git-ssh
-        tag: f3875548cbc723e9f0ea487aaba5f38302279f72
+        tag: 21e5ddc4c7265b112cbeb0993b0915fa9366a876
     ruby-slim: &ruby-slim-image-resource
       type: docker-image
       source:
@@ -30,17 +30,17 @@ meta:
       type: docker-image
       source:
         repository: governmentpaas/self-update-pipelines
-        tag: f3875548cbc723e9f0ea487aaba5f38302279f72
+        tag: 21e5ddc4c7265b112cbeb0993b0915fa9366a876
     spruce: &spruce-image-resource
       type: docker-image
       source:
         repository: governmentpaas/spruce
-        tag: f3875548cbc723e9f0ea487aaba5f38302279f72
+        tag: 21e5ddc4c7265b112cbeb0993b0915fa9366a876
     terraform: &terraform-image-resource
       type: docker-image
       source:
         repository: governmentpaas/terraform
-        tag: f3875548cbc723e9f0ea487aaba5f38302279f72
+        tag: 21e5ddc4c7265b112cbeb0993b0915fa9366a876
 
 groups:
   - name: all

--- a/concourse/pipelines/destroy-bosh-concourse.yml
+++ b/concourse/pipelines/destroy-bosh-concourse.yml
@@ -5,12 +5,12 @@ meta:
       type: docker-image
       source:
         repository: governmentpaas/awscli
-        tag: f3875548cbc723e9f0ea487aaba5f38302279f72
+        tag: 21e5ddc4c7265b112cbeb0993b0915fa9366a876
     bosh-cli-v2: &gov-paas-bosh-cli-v2-image-resource
       type: docker-image
       source:
         repository: governmentpaas/bosh-cli-v2
-        tag: f3875548cbc723e9f0ea487aaba5f38302279f72
+        tag: 21e5ddc4c7265b112cbeb0993b0915fa9366a876
     ruby-slim: &ruby-slim-image-resource
       type: docker-image
       source:
@@ -20,12 +20,12 @@ meta:
       type: docker-image
       source:
         repository: governmentpaas/self-update-pipelines
-        tag: f3875548cbc723e9f0ea487aaba5f38302279f72
+        tag: 21e5ddc4c7265b112cbeb0993b0915fa9366a876
     terraform: &terraform-image-resource
       type: docker-image
       source:
         repository: governmentpaas/terraform
-        tag: f3875548cbc723e9f0ea487aaba5f38302279f72
+        tag: 21e5ddc4c7265b112cbeb0993b0915fa9366a876
 
 resource_types:
 - name: s3-iam

--- a/manifests/bosh-manifest/operations.d/030-update-cpi.yml
+++ b/manifests/bosh-manifest/operations.d/030-update-cpi.yml
@@ -1,0 +1,7 @@
+- path: /releases/name=bosh-aws-cpi
+  type: replace
+  value:
+    name: bosh-aws-cpi
+    sha1: a6f32491067eae70f62cb03fc559654708e4f2f3
+    url: https://bosh.io/d/github.com/cloudfoundry/bosh-aws-cpi-release?v=75
+    version: "75"


### PR DESCRIPTION
[Story](https://www.pivotaltracker.com/story/show/166728064)

What
----

In order to use the latest generation of AWS EC2 instances (t3, m5, c5, etc) which use NVMe storage, we need to use a version of the AWS CPI later than v74. This pull request sneakily goes ahead of the upstream version using an opsfile.

We cannot go to a later version of the bosh-deployment distribution with the upstream aws-cpi config version bump until we have migrated our v1 bosh manifest to v2.

How to review
-------------

Code review

Run create-bosh-concourse using this PR

Run a bootstrap using this PR

Who can review
--------------

Not @tlwr