### PR TITLE
[#164728987] Upgrade to the latest line of stemcells (315.x)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -143,7 +143,7 @@ build-concourse: ## Setup profiles for deploying a build concourse
 	$(eval export BOSH_INSTANCE_PROFILE=bosh-director-build)
 	$(eval export CONCOURSE_TYPE=build-concourse)
 	$(eval export CONCOURSE_HOSTNAME=concourse)
-	$(eval export CONCOURSE_INSTANCE_TYPE=m4.large)
+	$(eval export CONCOURSE_INSTANCE_TYPE=m5.large)
 	$(eval export CONCOURSE_INSTANCE_PROFILE=concourse-build)
 	$(eval export CONCOURSE_WORKER_INSTANCES ?= 2)
 	@true
@@ -155,7 +155,7 @@ deployer-concourse: ## Setup profiles for deploying a paas-cf deployer concourse
 	$(eval export BOSH_INSTANCE_PROFILE=bosh-director-cf)
 	$(eval export CONCOURSE_TYPE=deployer-concourse)
 	$(eval export CONCOURSE_HOSTNAME=deployer)
-	$(eval export CONCOURSE_INSTANCE_TYPE=m4.xlarge)
+	$(eval export CONCOURSE_INSTANCE_TYPE=m5.xlarge)
 	$(eval export CONCOURSE_INSTANCE_PROFILE=deployer-concourse)
 	$(eval export CONCOURSE_WORKER_INSTANCES ?= 1)
 	@true

--- a/concourse/pipelines/create-bosh-concourse.yml
+++ b/concourse/pipelines/create-bosh-concourse.yml
@@ -5,22 +5,22 @@ meta:
       type: docker-image
       source:
         repository: governmentpaas/awscli
-        tag: 21e5ddc4c7265b112cbeb0993b0915fa9366a876
+        tag: 7a7678281e1f152183c7359546912df68f298664
     bosh-cli-v2: &gov-paas-bosh-cli-v2-image-resource
       type: docker-image
       source:
         repository: governmentpaas/bosh-cli-v2
-        tag: 21e5ddc4c7265b112cbeb0993b0915fa9366a876
+        tag: 7a7678281e1f152183c7359546912df68f298664
     certstrap: &certstrap-image-resource
       type: docker-image
       source:
         repository: governmentpaas/certstrap
-        tag: 21e5ddc4c7265b112cbeb0993b0915fa9366a876
+        tag: 7a7678281e1f152183c7359546912df68f298664
     git-ssh: &git-ssh-image-resource
       type: docker-image
       source:
         repository: governmentpaas/git-ssh
-        tag: 21e5ddc4c7265b112cbeb0993b0915fa9366a876
+        tag: 7a7678281e1f152183c7359546912df68f298664
     ruby-slim: &ruby-slim-image-resource
       type: docker-image
       source:
@@ -30,17 +30,17 @@ meta:
       type: docker-image
       source:
         repository: governmentpaas/self-update-pipelines
-        tag: 21e5ddc4c7265b112cbeb0993b0915fa9366a876
+        tag: 7a7678281e1f152183c7359546912df68f298664
     spruce: &spruce-image-resource
       type: docker-image
       source:
         repository: governmentpaas/spruce
-        tag: 21e5ddc4c7265b112cbeb0993b0915fa9366a876
+        tag: 7a7678281e1f152183c7359546912df68f298664
     terraform: &terraform-image-resource
       type: docker-image
       source:
         repository: governmentpaas/terraform
-        tag: 21e5ddc4c7265b112cbeb0993b0915fa9366a876
+        tag: 7a7678281e1f152183c7359546912df68f298664
 
 groups:
   - name: all

--- a/concourse/pipelines/create-bosh-concourse.yml
+++ b/concourse/pipelines/create-bosh-concourse.yml
@@ -754,6 +754,9 @@ jobs:
 
                 cp bosh-vars-store/bosh-vars-store.yml bosh-vars-store-updated/bosh-vars-store.yml
 
+                paas-bootstrap/manifests/bosh-manifest/scripts/cleanup-bosh-vars-store.rb \
+                  bosh-vars-store-updated/bosh-vars-store.yml
+
                 VARS_STORE=bosh-vars-store-updated/bosh-vars-store.yml \
                   paas-bootstrap/manifests/bosh-manifest/scripts/generate-manifest.sh \
                     > bosh-manifest/bosh-manifest.yml

--- a/concourse/pipelines/destroy-bosh-concourse.yml
+++ b/concourse/pipelines/destroy-bosh-concourse.yml
@@ -5,12 +5,12 @@ meta:
       type: docker-image
       source:
         repository: governmentpaas/awscli
-        tag: 21e5ddc4c7265b112cbeb0993b0915fa9366a876
+        tag: 7a7678281e1f152183c7359546912df68f298664
     bosh-cli-v2: &gov-paas-bosh-cli-v2-image-resource
       type: docker-image
       source:
         repository: governmentpaas/bosh-cli-v2
-        tag: 21e5ddc4c7265b112cbeb0993b0915fa9366a876
+        tag: 7a7678281e1f152183c7359546912df68f298664
     ruby-slim: &ruby-slim-image-resource
       type: docker-image
       source:
@@ -20,12 +20,12 @@ meta:
       type: docker-image
       source:
         repository: governmentpaas/self-update-pipelines
-        tag: 21e5ddc4c7265b112cbeb0993b0915fa9366a876
+        tag: 7a7678281e1f152183c7359546912df68f298664
     terraform: &terraform-image-resource
       type: docker-image
       source:
         repository: governmentpaas/terraform
-        tag: 21e5ddc4c7265b112cbeb0993b0915fa9366a876
+        tag: 7a7678281e1f152183c7359546912df68f298664
 
 resource_types:
 - name: s3-iam

--- a/manifests/bosh-manifest/operations.d/030-set-stemcell.yml
+++ b/manifests/bosh-manifest/operations.d/030-set-stemcell.yml
@@ -2,5 +2,5 @@
 - type: replace
   path: /resource_pools/name=vms/stemcell
   value:
-    url: https://bosh.io/d/stemcells/bosh-aws-xen-hvm-ubuntu-xenial-go_agent?v=170.69
-    sha1: b64d497d7a2260c7d1e4d12c93f500e7ad3f98cb
+    url: https://bosh.io/d/stemcells/bosh-aws-xen-hvm-ubuntu-xenial-go_agent?v=315.41
+    sha1: 9ce1d7634f6010302de88110eb95e94ba3226abb

--- a/manifests/bosh-manifest/operations.d/030-update-instance-type.yml
+++ b/manifests/bosh-manifest/operations.d/030-update-instance-type.yml
@@ -1,4 +1,4 @@
 ---
 - type: replace
   path: /resource_pools/name=vms/cloud_properties/instance_type
-  value: t2.medium
+  value: t3.medium

--- a/manifests/bosh-manifest/operations.d/031-set-mbus-cert-san.yml
+++ b/manifests/bosh-manifest/operations.d/031-set-mbus-cert-san.yml
@@ -1,0 +1,8 @@
+
+- type: replace
+  path: /variables/name=mbus_bootstrap_ssl/options/alternative_names/-
+  value: ((bosh_fqdn))
+
+- type: replace
+  path: /variables/name=mbus_bootstrap_ssl/options/alternative_names/-
+  value: ((bosh_fqdn_external))

--- a/manifests/bosh-manifest/operations.d/049-cloud-provider-remove-cert.yml
+++ b/manifests/bosh-manifest/operations.d/049-cloud-provider-remove-cert.yml
@@ -1,3 +1,0 @@
----
-- type: remove
-  path: /cloud_provider/cert

--- a/manifests/bosh-manifest/operations.d/049-remove-mbus-cert.yml
+++ b/manifests/bosh-manifest/operations.d/049-remove-mbus-cert.yml
@@ -1,3 +1,0 @@
----
-- type: remove
-  path: /resource_pools/name=vms/env/bosh/mbus

--- a/manifests/bosh-manifest/scripts/cleanup-bosh-vars-store.rb
+++ b/manifests/bosh-manifest/scripts/cleanup-bosh-vars-store.rb
@@ -1,0 +1,44 @@
+#!/usr/bin/env ruby
+
+require 'openssl'
+require 'yaml'
+
+filename = ARGV.first
+raise "#{$0} requires a vars store filename argument" if filename.nil?
+
+puts "Loading file #{filename}"
+contents = YAML.load_file(filename)
+puts "Loaded file #{filename}"
+
+raise "Could not parse vars file #{filename}" unless contents.is_a?(Hash)
+
+puts "Old variable names: #{contents.keys}"
+
+mbus_bootstrap_ssl_cert = contents.dig('mbus_bootstrap_ssl', 'certificate')
+unless mbus_bootstrap_ssl_cert.nil?
+  puts 'Found mbus_bootstrap_ssl, checking it'
+  # We need mbus_bootstrap_ssl to have:
+  # Common name => bosh-external.((system_domain))
+  begin
+    puts 'Parsing mbus_bootstrap_ssl'
+    cert = OpenSSL::X509::Certificate.new(mbus_bootstrap_ssl_cert)
+    san = cert.extensions.find { |ext| ext.oid == 'subjectAltName' }.value
+    puts 'Parsed mbus_bootstrap_ssl'
+
+    if san.match?(/bosh-external/)
+      puts 'Nothing to do for mbus_bootstrap_ssl'
+    else
+      puts 'Deleting mbus_bootstrap_ssl'
+      contents.delete('mbus_bootstrap_ssl')
+    end
+  rescue StandardError => e
+    puts "Handled error => #{e}\n#{e.backtrace}."
+    puts 'Deleting mbus_bootstrap_ssl, due to unforeseen error, this is okay'
+    contents.delete('mbus_bootstrap_ssl')
+  end
+end
+
+puts "New variable names: #{contents.keys}"
+
+puts "Writing file #{filename}"
+File.write(filename, contents.to_yaml)

--- a/manifests/concourse-manifest/concourse-base.yml
+++ b/manifests/concourse-manifest/concourse-base.yml
@@ -2,7 +2,7 @@
 meta:
   stemcell:
     name: bosh-aws-xen-hvm-ubuntu-xenial-go_agent
-    version: "170.69"
+    version: "315.41"
 
   zone: (( grab terraform_outputs_zone0 ))
 

--- a/vagrant/Vagrantfile
+++ b/vagrant/Vagrantfile
@@ -99,7 +99,7 @@ Vagrant.configure(2) do |config|
     aws.region = AWS_REGION
 
     # Only HVM instances with ephemeral disks can be used
-    aws.instance_type = 'm4.large'
+    aws.instance_type = 'm5.large'
 
     aws.subnet_id = AWS_ACCOUNT_VARIABLES.fetch(:subnet_id)
     aws.security_groups = [AWS_ACCOUNT_VARIABLES.fetch(:security_group)]


### PR DESCRIPTION
[Story](https://www.pivotaltracker.com/story/show/164728987)

What
----

We use stemcells as our base operating system images. These come in series (i.e. 170, 250, 315) for each OS (170, 250, 315 are Ubuntu Xenial), where the series number (170) correlates to the bosh-agent version number (amongst other things). This pull request upgrades from 170 to 315 (bypassing 250), as well as upgrading the EC2 instance type from t2->t3 and m4->m5.



### Upgrade the docker images used.

In https://github.com/alphagov/paas-bootstrap/pull/289 we upgraded the bosh-aws-cpi-release to v75 in order to be able to use the latest machine types. In order to upgrade the version, we need a later version of the bosh-cli-v2 (>5.4). The corresponding docker PR is https://github.com/alphagov/paas-docker-cloudfoundry-tools/pull/165.

### Remove some of the ops files from the bosh-deployment migration.

Eons ago (a few months), we moved from our own system for deploying bosh, to a variant of bosh-deployment (to match how we use cf-deployment). This was done in #230 and #231. A goal of that migration was to have a no-op bosh manifest. Before we didn't use TLS when bootstrapping MBUS (bosh message bus) over HTTP (NATS is used when not doing `bosh create-env`.

Since this [cf/bosh](https://www.pivotaltracker.com/n/projects/2197707/stories/162291567) story using MBUS TLS is mandatory, which is what caused the spooky bosh failure that people previously encountered when trying to upgrade.

Therefore to enable TLS when doing `bosh create-env` we need to remove our opsfile removing TLS. We also use bosh-director externally so the self-signed cert used by mbus needs to have `bosh-external.((system_domain))` as a subject alt name, which requires a custom bosh opsfile. Lastly, bosh may previously have generated a certificate for `mbus_bootstrap_ssl` which would not have the correct subject alt name (SAN). Bosh does not look at the `options` key for variables so will not regenerate the cert if the options change. Therefore we can add a `bosh-vars-store.yml` preprocessor in the pipeline which will delete the existing cert if it is wrong, this is fine because it is only ever used for bootstrapping.

### Upgrade the stemcells to 315.41

(latest at time of writing)

This is a doddle. Do this for Concourse and Bosh.

### Update the instance types

For Vagrant Concourse, Bosh and Bosh Concourse, as this was the original goal anyway.

How to review
-------------

Run this down your pipeline.

Bootstrap a new director.

Who can review
--------------

Not @tlwr