### PR TITLE
Upgrade stemcells to 315.45

### DIFF
--- a/manifests/bosh-manifest/operations.d/030-set-stemcell.yml
+++ b/manifests/bosh-manifest/operations.d/030-set-stemcell.yml
@@ -2,5 +2,5 @@
 - type: replace
   path: /resource_pools/name=vms/stemcell
   value:
-    url: https://bosh.io/d/stemcells/bosh-aws-xen-hvm-ubuntu-xenial-go_agent?v=315.41
-    sha1: 9ce1d7634f6010302de88110eb95e94ba3226abb
+    url: https://bosh.io/d/stemcells/bosh-aws-xen-hvm-ubuntu-xenial-go_agent?v=315.45
+    sha1: 0502ba37e931193269eb75c60c408be3f249d0de

--- a/manifests/concourse-manifest/concourse-base.yml
+++ b/manifests/concourse-manifest/concourse-base.yml
@@ -2,7 +2,7 @@
 meta:
   stemcell:
     name: bosh-aws-xen-hvm-ubuntu-xenial-go_agent
-    version: "315.41"
+    version: "315.45"
 
   zone: (( grab terraform_outputs_zone0 ))
 


### PR DESCRIPTION
[Story](https://www.pivotaltracker.com/story/show/167170663)

What
----


Address USN BOSH Agent version: 2.215.3 USNs https://usn.ubuntu.com/3977-3/ by upgrading to latest PCF stemcells. https://docs.pivotal.io/pivotalcf/2-5/stemcells/stemcells.html#315-line

How to review
-------------

- 🔍 Code review

- 👀 [tlwr pipeline](https://deployer.tlwr.dev.cloudpipeline.digital/teams/main/pipelines/create-bosh-concourse/jobs/expunge-concourse/builds/17) (check the `paas-bootstrap` resource)

See also
---

https://github.com/alphagov/paas-cf/pull/1969

Who can review
--------------

Not @tlwr
