### PR TITLE
Fix race in pipeline with credhub password

### DIFF
--- a/concourse/pipelines/create-bosh-concourse.yml
+++ b/concourse/pipelines/create-bosh-concourse.yml
@@ -914,6 +914,7 @@ jobs:
         - get: concourse-tfstate
           passed: ['concourse-terraform']
         - get: concourse-secrets
+          passed: ['generate-secrets']
         - get: bosh-secrets
         - get: bosh-tfstate
           passed: ['concourse-terraform']


### PR DESCRIPTION
What
----

generating the concourse manifest should get the version of
concourse-secrets that have most recently passed generate-secrets,
otherwise it will not necessarily get the most recent version, and then
randomly fail

Co-authored-by: Mo <mohamed.deerow@digital.cabinet-office.gov.uk>
Co-authored-by: Toby <toby.lornewelch-richards@digital.cabinet-office.gov.uk>
