### PR TITLE
Specify CREDHUB_PROXY instead of HTTP_PROXY bosh-cli

### DIFF
--- a/scripts/bosh-cli.sh
+++ b/scripts/bosh-cli.sh
@@ -45,6 +45,6 @@ docker run \
     --env "BOSH_DEPLOYMENT=${DEPLOY_ENV}" \
     --env "CREDHUB_SERVER=https://bosh.${SYSTEM_DNS_ZONE_NAME}:8844/api" \
     --env "CREDHUB_CLIENT" --env "CREDHUB_SECRET" --env "CREDHUB_CA_CERT" \
-    --env "HTTPS_PROXY=socks5://localhost:25555" \
+    --env "CREDHUB_PROXY=socks5://localhost:25555" \
     -v "${HOME}/.bosh_history/${DEPLOY_ENV}:/root/.bash_history" \
     governmentpaas/bosh-shell:4467c23cef4a5d87d531b88700300b222fbf2916


### PR DESCRIPTION
What
----

When running 'make bosh-cli' we should use the CREDHUB_PROXY environment
variable instead of HTTPS_PROXY otherwise bosh gets confused when we run
bosh commands

How to review
-------------

1. `git checkout`
1. `make dev bosh-cli`
1. `bosh vms`
1. `credhub find -p /`

Who can review
--------------

@mogds 