### PR TITLE
[#167571906] Update BOSH's UAA URL

### DIFF
--- a/manifests/bosh-manifest/operations.d/301-credhub.yml
+++ b/manifests/bosh-manifest/operations.d/301-credhub.yml
@@ -19,6 +19,14 @@
   type: replace
   value: "https://((bosh_fqdn)):8443"
 
+- path: /instance_groups/name=bosh/properties/director/config_server/uaa/url
+  type: replace
+  value: "https://((bosh_fqdn)):8443"
+
+- path: /instance_groups/name=bosh/properties/director/config_server/url
+  type: replace
+  value: "https://((bosh_fqdn)):8844/api/"
+
 - path: /instance_groups/name=bosh/jobs/name=uaa/properties/uaa/clients/credhub-admin/secret?
   type: replace
   value: ((bosh_credhub_admin_client_password))


### PR DESCRIPTION
What
----

Updates BOSH's UAA url to the fqdn as it was unable to access UAA when deploying cf.

How to review
-------------

- Deploy to your dev env

Who can review
--------------

Not me