### PR TITLE
Set Github oauth to default to on in dev

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -83,7 +83,7 @@ dev: globals check-env-vars ## Set Environment to DEV
 	$(eval export AWS_ACCOUNT=dev)
 	$(eval export MAKEFILE_ENV_TARGET=dev)
 	$(eval export ENABLE_DESTROY=true)
-	$(eval export ENABLE_GITHUB ?= false)
+	$(eval export ENABLE_GITHUB ?= true)
 	$(eval export CONCOURSE_AUTH_DURATION=48h)
 	$(eval export SKIP_COMMIT_VERIFICATION=true)
 	$(eval export AWS_DEFAULT_REGION ?= eu-west-1)

--- a/README.md
+++ b/README.md
@@ -123,6 +123,8 @@ make dev bootstrap-destroy
 
 You will need a working [Concourse Lite](#concourse-lite).
 
+You will need to either configure a [Github oauth application](https://team-manual.cloud.service.gov.uk/guides/Github_oAuth_in-Dev/) or pass `ENABLE_GITHUB=false` when uploading pipelines from this repo
+
 ### Deploy
 
 Run the `create-bosh-concourse` pipeline from your *Concourse Lite*. The pipeline will upload itself to the Concourse it has created, which means future runs of the pipeline can be done from there. In theory, we should only need the *Concourse Lite* for the initial bootstrapping.


### PR DESCRIPTION
What
----

Github auth has been working well and is what is used in production. as a result it is valuable to have it enabled by default in dev. It is also advantageous when working with other engineers and sharing environments.

How to review
-------------

Code review alongside https://github.com/alphagov/paas-team-manual/pull/314

Who can review
--------------

Anyone
