### PR TITLE
[#166282717] Enable concatenate_cas in credhub

### DIFF
--- a/manifests/bosh-manifest/operations.d/301-credhub.yml
+++ b/manifests/bosh-manifest/operations.d/301-credhub.yml
@@ -31,6 +31,10 @@
   type: replace
   value: ((aws_rds_combined_ca_bundle))
 
+- path: /instance_groups/name=bosh/jobs/name=credhub/properties/credhub/certificates?/concatenate_cas
+  type: replace
+  value: true
+
 - path: /instance_groups/name=bosh/jobs/name=credhub/properties/credhub/authentication/uaa/url
   type: replace
   value: "https://((bosh_fqdn)):8443"


### PR DESCRIPTION
What
----

Enables `concatenate_cas` in credhub so we can combine active versions of a CA. This will allow us to rotate CA certs stored in credhub.

How to review
-------------

Code review

Who can review
--------------

Not me