### PR TITLE
Upgrade Credhub Release to v2.5.6

### DIFF
--- a/manifests/bosh-manifest/operations.d/301-credhub.yml
+++ b/manifests/bosh-manifest/operations.d/301-credhub.yml
@@ -1,4 +1,12 @@
 ---
+- path: /releases/name=credhub
+  type: replace
+  value:
+    name: credhub
+    sha1: "788c7da077480fc76a49a69095debbd887c9250e"
+    url: "https://bosh.io/d/github.com/pivotal-cf/credhub-release?v=2.5.6"
+    version: "2.5.6"
+
 - path: /instance_groups/name=bosh/jobs/name=credhub/properties/credhub/data_storage/host
   type: replace
   value: ((external_db_host))


### PR DESCRIPTION
What
----

Upgrades credhub from 2.4 to 2.5.6 (latest version). This is due to a [bug fix](https://www.pivotaltracker.com/n/projects/1977341/stories/167496651) in [2.5.3](https://github.com/pivotal-cf/credhub-release/releases/tag/2.5.3) that's required to rotate CA certs.

How to review
-------------

Deploy to your dev env

Who can review
--------------

Not me