### PR TITLE
Upgrade stemcell to 456.27

### DIFF
--- a/manifests/bosh-manifest/operations.d/030-set-stemcell.yml
+++ b/manifests/bosh-manifest/operations.d/030-set-stemcell.yml
@@ -2,5 +2,5 @@
 - type: replace
   path: /resource_pools/name=vms/stemcell
   value:
-    url: https://bosh.io/d/stemcells/bosh-aws-xen-hvm-ubuntu-xenial-go_agent?v=456.14
-    sha1: bec24356a7462d8c9e128e0734fa64dc20475c47
+    url: https://bosh.io/d/stemcells/bosh-aws-xen-hvm-ubuntu-xenial-go_agent?v=456.27
+    sha1: 49dd9fc8a57571a67360bb795f58a8fb38a51f61

--- a/manifests/concourse-manifest/concourse-base.yml
+++ b/manifests/concourse-manifest/concourse-base.yml
@@ -2,7 +2,7 @@
 meta:
   stemcell:
     name: bosh-aws-xen-hvm-ubuntu-xenial-go_agent
-    version: "456.14"
+    version: "456.27"
 
   zone: (( grab terraform_outputs_zone0 ))
 


### PR DESCRIPTION
What
----

Respond to CVEs by bumping stemcell

See commit message for CVE details

How to review
-------------

Code review

See https://github.com/bosh-io/stemcells-cpi-index/blob/master/candidate-aws-light/ubuntu-xenial/v456.27.meta4 for the hash

See my pipeline finish: [tlwr](https://deployer.tlwr.dev.cloudpipeline.digital/teams/main/pipelines/create-bosh-concourse/jobs/post-deploy/builds/81) (run #81 will 404 until this it is finished)

Who can review
--------------

Not @tlwr
