### PR TITLE
Upgrade Concourse and Postgres

### DIFF
--- a/manifests/concourse-manifest/concourse-base.yml
+++ b/manifests/concourse-manifest/concourse-base.yml
@@ -16,17 +16,17 @@ stemcells:
 # relevant tag of https://github.com/concourse/concourse-bosh-deployment
 releases:
   - name: "concourse"
-    version: "5.1.0"
-    url: "https://bosh.io/d/github.com/concourse/concourse-bosh-release?v=5.1.0"
-    sha1: "e6b55fa88e1bcd0d7dfc83e73cb7dc6c053734ac"
+    version: "5.6.0"
+    url: "https://bosh.io/d/github.com/concourse/concourse-bosh-release?v=5.6.0"
+    sha1: "013f78504c3acb3ddfdc3f2192bedaa4c26192b5"
   - name: postgres
-    version: 30
-    url: https://bosh.io/d/github.com/cloudfoundry/postgres-release?v=30
-    sha1: a798999d29b9f5aa12035cff907b26674b491200
+    version: "39"
+    url: "https://bosh.io/d/github.com/cloudfoundry/postgres-release?v=39"
+    sha1: "8ff395540e77a461322a01c41aa68973c10f1ffb"
   - name: "bpm"
-    version: "1.1.1"
-    url: "https://bosh.io/d/github.com/cloudfoundry/bpm-release?v=1.1.1"
-    sha1: "a7ea57aaf44a8217bae2a3df72a1afc51334e930"
+    version: "1.1.3"
+    url: "https://bosh.io/d/github.com/cloudfoundry/bpm-release?v=1.1.3"
+    sha1: "b41556af773ea9aec93dd21a9bbf129200849eed"
 
 instance_groups:
   - name: concourse

--- a/manifests/concourse-manifest/concourse-base.yml
+++ b/manifests/concourse-manifest/concourse-base.yml
@@ -65,6 +65,7 @@ instance_groups:
       - name: web
         release: concourse
         properties:
+          cluster_name: (( grab terraform_outputs_environment ))
           external_url: (( concat "https://" terraform_outputs_concourse_dns_name ))
           add_local_users:
             - admin:((concourse_web_password))

--- a/vagrant/docker-compose.yml
+++ b/vagrant/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3'
 
 services:
   concourse-db:
-    image: postgres
+    image: postgres:11.5
     environment:
     - POSTGRES_DB=${CONCOURSE_POSTGRES_DATABASE:-concourse}
     - POSTGRES_PASSWORD=${CONCOURSE_POSTGRES_PASSWORD:-concourse_pass}
@@ -10,7 +10,7 @@ services:
     - PGDATA=/database
 
   concourse-web:
-    image: concourse/concourse:5.1.0
+    image: concourse/concourse:5.6.0
     command: web
     privileged: true
     depends_on: [concourse-db]
@@ -32,7 +32,7 @@ services:
     - CONCOURSE_SESSION_SIGNING_KEY=/keys/session_signing_key
 
   concourse-worker-colocated:
-    image: concourse/concourse:5.1.0
+    image: concourse/concourse:5.6.0
     command: worker
     privileged: true
     depends_on: [concourse-db, concourse-web]
@@ -50,7 +50,7 @@ services:
     - CONCOURSE_GARDEN_DNS_SERVER=169.254.169.253
 
   concourse-worker-normal:
-    image: concourse/concourse:5.1.0
+    image: concourse/concourse:5.6.0
     command: worker
     privileged: true
     depends_on: [concourse-db, concourse-web]


### PR DESCRIPTION
Stories:
- [Concourse](https://www.pivotaltracker.com/story/show/168510427)
- [Concourse Postgres](https://www.pivotaltracker.com/story/show/168372375)

What
----

- Upgrade Concourse to 5.6
- Upgrade Concourse Postgres to 11.5 (version that 5.6 expects)

How to review
-------------

Code review

### Toby's testing

- [x] Upgrade from latest master
- [x] Bootstrap
- [x] Bootstrap destroy

Who can review
--------------

Not @tlwr