### PR TITLE
[#168510734] Upgrade postgres instance class

### DIFF
--- a/terraform/bosh/rds.tf
+++ b/terraform/bosh/rds.tf
@@ -47,7 +47,7 @@ resource "aws_db_instance" "bosh" {
   storage_type               = "gp2"
   engine                     = "postgres"
   engine_version             = "11.5"
-  instance_class             = "db.t2.small"
+  instance_class             = "db.t3.small"
   username                   = "dbadmin"
   password                   = "${var.secrets_bosh_postgres_password}"
   db_subnet_group_name       = "${aws_db_subnet_group.bosh_rds.name}"


### PR DESCRIPTION
[Story](https://www.pivotaltracker.com/story/show/168510734)

See this PR first: https://github.com/alphagov/paas-bootstrap/pull/314

What
----

Now that we have upgraded Postgres to 11.5, we can change the instance class to a modern instance class, so that in the future we can reserve the instances.

How to review
-------------

Ensure you have deployed #314

Ensure your BOSH RDS is multi-AZ (default false in dev)

Deploy this PR

Ensure you still have a working CF, and that your CF environment did not experience any bad things

Who can review
--------------

Not @tlwr