### PR TITLE
Update stemcell to match paas-cf; bump Concourse

### DIFF
--- a/manifests/bosh-manifest/operations.d/030-set-stemcell.yml
+++ b/manifests/bosh-manifest/operations.d/030-set-stemcell.yml
@@ -2,5 +2,5 @@
 - type: replace
   path: /resource_pools/name=vms/stemcell
   value:
-    url: https://bosh.io/d/stemcells/bosh-aws-xen-hvm-ubuntu-xenial-go_agent?v=456.27
-    sha1: 49dd9fc8a57571a67360bb795f58a8fb38a51f61
+    url: https://bosh.io/d/stemcells/bosh-aws-xen-hvm-ubuntu-xenial-go_agent?v=456.40
+    sha1: 32108371c005ccc333edfa9122140b475700b243

--- a/manifests/concourse-manifest/concourse-base.yml
+++ b/manifests/concourse-manifest/concourse-base.yml
@@ -16,17 +16,17 @@ stemcells:
 # relevant tag of https://github.com/concourse/concourse-bosh-deployment
 releases:
   - name: "concourse"
-    version: "5.6.0"
-    url: "https://bosh.io/d/github.com/concourse/concourse-bosh-release?v=5.6.0"
-    sha1: "013f78504c3acb3ddfdc3f2192bedaa4c26192b5"
-  - name: postgres
+    version: "5.7.0"
+    url: "https://bosh.io/d/github.com/concourse/concourse-bosh-release?v=5.7.0"
+    sha1: "7fa513c5059c44eb5cc57c1fc5aaf9f845112bf3"
+  - name: "postgres"
     version: "39"
     url: "https://bosh.io/d/github.com/cloudfoundry/postgres-release?v=39"
     sha1: "8ff395540e77a461322a01c41aa68973c10f1ffb"
   - name: "bpm"
-    version: "1.1.3"
-    url: "https://bosh.io/d/github.com/cloudfoundry/bpm-release?v=1.1.3"
-    sha1: "b41556af773ea9aec93dd21a9bbf129200849eed"
+    version: "1.1.5"
+    url: "https://bosh.io/d/github.com/cloudfoundry/bpm-release?v=1.1.5"
+    sha1: "e612e88543012ae5d376dd3746159d5abe748076"
 
 instance_groups:
   - name: concourse

--- a/manifests/concourse-manifest/concourse-base.yml
+++ b/manifests/concourse-manifest/concourse-base.yml
@@ -2,7 +2,7 @@
 meta:
   stemcell:
     name: bosh-aws-xen-hvm-ubuntu-xenial-go_agent
-    version: "456.27"
+    version: "456.40"
 
 name: concourse
 

--- a/vagrant/docker-compose.yml
+++ b/vagrant/docker-compose.yml
@@ -10,7 +10,7 @@ services:
     - PGDATA=/database
 
   concourse-web:
-    image: concourse/concourse:5.6.0
+    image: concourse/concourse:5.7.0
     command: web
     privileged: true
     depends_on: [concourse-db]
@@ -32,7 +32,7 @@ services:
     - CONCOURSE_SESSION_SIGNING_KEY=/keys/session_signing_key
 
   concourse-worker-colocated:
-    image: concourse/concourse:5.6.0
+    image: concourse/concourse:5.7.0
     command: worker
     privileged: true
     depends_on: [concourse-db, concourse-web]
@@ -50,7 +50,7 @@ services:
     - CONCOURSE_GARDEN_DNS_SERVER=169.254.169.253
 
   concourse-worker-normal:
-    image: concourse/concourse:5.6.0
+    image: concourse/concourse:5.7.0
     command: worker
     privileged: true
     depends_on: [concourse-db, concourse-web]


### PR DESCRIPTION
What
----

Bump stemcells to 456.40

Bump Concourse to 5.7

How to review
-------------

Code review

Check [tlwr Concourse version](https://grafana-1.tlwr.dev.cloudpipeline.digital/explore?left=%5B%222019-11-01T09:43:30.398Z%22,%222019-11-01T10:06:58.578Z%22,%22prometheus%22,%7B%22expr%22:%22bosh_deployment_release_info%7Bbosh_release_name%3D%5C%22concourse%5C%22%7D%22%7D,%7B%22ui%22:%5Btrue,true,true,%22none%22%5D%7D%5D)

Check [tlwr stemcell version](https://grafana-1.tlwr.dev.cloudpipeline.digital/explore?left=%5B%222019-11-01T09:43:30.398Z%22,%222019-11-01T10:06:58.578Z%22,%22prometheus%22,%7B%22expr%22:%22bosh_deployment_stemcell_info%22%7D,%7B%22ui%22:%5Btrue,true,true,%22none%22%5D%7D%5D)

Who can review
--------------

Not @tlwr