### PR TITLE
[#167894707] Ship BOSH director logs to CloudWatch

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -70,6 +70,7 @@ PASSWORD_STORE_DIR?=${HOME}/.paas-pass
 globals:
 	$(eval export PASSWORD_STORE_DIR=${PASSWORD_STORE_DIR})
 	$(eval export GITHUB_PASSWORD_STORE_DIR?=${HOME}/.paas-pass)
+	$(eval export CYBER_PASSWORD_STORE_DIR?=${HOME}/.paas-pass)
 	@true
 
 ## Environments
@@ -220,7 +221,7 @@ stop-tunnel: check-env-vars ## Stop SSH tunnel
 	@./concourse/scripts/ssh.sh tunnel stop
 
 .PHONY: upload-all-secrets
-upload-all-secrets: upload-github-oauth
+upload-all-secrets: upload-github-oauth upload-cyber-tfvars
 
 .PHONY: upload-github-oauth
 upload-github-oauth: check-env-vars ## Decrypt and upload github OAuth credentials to S3
@@ -228,6 +229,13 @@ upload-github-oauth: check-env-vars ## Decrypt and upload github OAuth credentia
 	$(if ${GITHUB_PASSWORD_STORE_DIR},,$(error Must pass GITHUB_PASSWORD_STORE_DIR=<path_to_password_store>))
 	$(if $(wildcard ${GITHUB_PASSWORD_STORE_DIR}),,$(error Password store ${GITHUB_PASSWORD_STORE_DIR} does not exist))
 	@scripts/manage-github-secrets.sh upload
+
+.PHONY: upload-cyber-tfvars
+upload-cyber-tfvars: check-env-vars ## Decrypt and upload cyber tfvars to S3
+	$(if ${MAKEFILE_ENV_TARGET},,$(error Must set MAKEFILE_ENV_TARGET))
+	$(if ${CYBER_PASSWORD_STORE_DIR},,$(error Must pass CYBER_PASSWORD_STORE_DIR=<path_to_password_store>))
+	$(if $(wildcard ${CYBER_PASSWORD_STORE_DIR}),,$(error Password store ${CYBER_PASSWORD_STORE_DIR} does not exist))
+	@scripts/upload-cyber-tfvars.sh
 
 merge_pr: ## Merge a PR. Must specify number in a PR=<number> form.
 	$(if ${PR},,$(error Must pass PR=<number>))

--- a/concourse/pipelines/create-bosh-concourse.yml
+++ b/concourse/pipelines/create-bosh-concourse.yml
@@ -54,6 +54,7 @@ groups:
       - concourse-terraform
       - generate-concourse-config
       - concourse-deploy
+      - cyber-terraform
       - post-deploy
       - expunge-concourse
 
@@ -156,6 +157,37 @@ resources:
       versioned_file: bosh-secrets.yml
       initial_version: "-"
       initial_content_text: ""
+
+  - name: bootstrap-cyber-tfvars
+    type: s3-iam
+    source:
+      bucket: ((state_bucket))
+      region_name: ((aws_region))
+      versioned_file: bootstrap-cyber.tfvars
+      initial_version: "-"
+      initial_content_text: ""
+
+  - name: bootstrap-cyber-tfstate
+    type: s3-iam
+    source:
+      bucket: ((state_bucket))
+      versioned_file: bootstrap-cyber.tfstate
+      region_name: ((aws_region))
+      initial_version: "-"
+      initial_content_text: |
+        {
+            "version": 1,
+            "serial": 0,
+            "modules": [
+                {
+                    "path": [
+                        "root"
+                    ],
+                    "outputs": {},
+                    "resources": {}
+                }
+            ]
+        }
 
   - name: ssh-private-key
     type: s3-iam
@@ -1319,6 +1351,60 @@ jobs:
               bosh deploy concourse-manifest/concourse-manifest.yml \
                    -v "concourse_worker_instances=$CONCOURSE_WORKER_INSTANCES" \
                    --var-file=credhub_ca_cert=credhub-ca-cert.yml
+
+  - name: cyber-terraform
+    serial: true
+    # This is not in the mainline of the pipeline
+    # because we do not want to couple our deployment to Cyber
+    plan:
+      - in_parallel:
+        - get: pipeline-trigger
+          trigger: true
+          passed: ['concourse-deploy']
+        - get: paas-bootstrap
+          passed: ['concourse-deploy']
+        - get: bootstrap-cyber-tfvars
+        - get: bootstrap-cyber-tfstate
+
+      - task: terraform-apply
+        config:
+          platform: linux
+          image_resource: *terraform-image-resource
+          inputs:
+            - name: paas-bootstrap
+            - name: bootstrap-cyber-tfstate
+            - name: bootstrap-cyber-tfvars
+          outputs:
+            - name: updated-bootstrap-cyber-tfstate
+          params:
+            DEPLOY_ENV: ((deploy_env))
+            AWS_DEFAULT_REGION: ((aws_region))
+            TF_VAR_system_dns_zone_name: ((system_dns_zone_name))
+            TF_VAR_system_dns_zone_id: ((system_dns_zone_id))
+          run:
+            path: sh
+            args:
+              - -e
+              - -c
+              - |
+                cp bootstrap-cyber-tfstate/bootstrap-cyber.tfstate \
+                   updated-bootstrap-cyber-tfstate/bootstrap-cyber.tfstate
+
+                terraform init paas-bootstrap/terraform/cyber
+
+                terraform apply \
+                  -auto-approve=true \
+                  -var env="((deploy_env))" \
+                  -var-file="paas-bootstrap/terraform/((aws_account)).tfvars" \
+                  -var-file="paas-bootstrap/terraform/((aws_region)).tfvars" \
+                  -var-file="bootstrap-cyber-tfvars/bootstrap-cyber.tfvars" \
+                  -state=updated-bootstrap-cyber-tfstate/bootstrap-cyber.tfstate \
+                  paas-bootstrap/terraform/cyber
+
+        ensure:
+          put: bootstrap-cyber-tfstate
+          params:
+            file: updated-bootstrap-cyber-tfstate/bootstrap-cyber.tfstate
 
   - name: post-deploy
     serial: true

--- a/concourse/scripts/pipecleaner.py
+++ b/concourse/scripts/pipecleaner.py
@@ -102,7 +102,7 @@ class Pipecleaner(object):
                 discovered_blocks = []
 
                 # Flatten array blocks as we don't care
-                for block_type in ('aggregate', 'do'):
+                for block_type in ('in_parallel', 'aggregate', 'do'):
                     if block_type in item:
                         discovered_blocks.extend(item[block_type])
                         del item[block_type]

--- a/manifests/bosh-manifest/operations.d/400-audit.yml
+++ b/manifests/bosh-manifest/operations.d/400-audit.yml
@@ -1,0 +1,61 @@
+---
+
+- type: replace
+  path: /releases/-
+  value:
+    name: awslogs
+    version: 0.1.1
+    url: https://s3-eu-west-1.amazonaws.com/gds-paas-build-releases/awslogs-0.1.1.tgz
+    sha1: dd307700e55c6c45376a5d76583243601e7559e6
+
+- type: replace
+  path: /instance_groups/name=bosh/jobs?/-
+  value:
+    name: awslogs-xenial
+    release: awslogs
+    properties:
+      awslogs-xenial:
+        region: ((region))
+        awslogs_files_config:
+
+          - name: /var/vcap/sys/log/credhub/credhub_security_events.log
+            file: /var/vcap/sys/log/credhub/credhub_security_events.log
+            log_group_name: bosh_d_credhub_security_events_((deploy_env))
+            log_stream_name: "{{instance_id}}"
+            initial_position: start_of_file
+            datetime_format: "%Y-%m-%dT%H:%M:%S"
+
+          - name: /var/vcap/sys/log/uaa/uaa_events.log
+            file: /var/vcap/sys/log/uaa/uaa_events.log
+            log_group_name: bosh_d_uaa_events_((deploy_env))
+            log_stream_name: "{{instance_id}}"
+            initial_position: start_of_file
+            datetime_format: "%Y-%m-%dT%H:%M:%S"
+
+          - name: /var/vcap/sys/log/director/audit.log
+            file: /var/vcap/sys/log/director/audit.log
+            log_group_name: bosh_d_audit_((deploy_env))
+            log_stream_name: "{{instance_id}}"
+            initial_position: start_of_file
+            datetime_format: "%Y-%m-%dT%H:%M:%S"
+
+          - name: /var/vcap/sys/log/director/audit_worker.log
+            file: /var/vcap/sys/log/director/audit_worker*.log
+            log_group_name: bosh_d_audit_worker_((deploy_env))
+            log_stream_name: "{{instance_id}}"
+            initial_position: start_of_file
+            datetime_format: "%Y-%m-%dT%H:%M:%S"
+
+          - name: /var/log/auth.log
+            file: /var/log/auth.log
+            log_group_name: bosh_d_auth_((deploy_env))
+            log_stream_name: "{{instance_id}}"
+            initial_position: start_of_file
+            datetime_format: "%Y-%m-%dT%H:%M:%S"
+
+          - name: /var/log/audit/audit.log
+            file: /var/log/audit/audit.log
+            log_group_name: bosh_d_kauditd_((deploy_env))
+            log_stream_name: "{{instance_id}}"
+            initial_position: start_of_file
+            datetime_format: "%Y-%m-%dT%H:%M:%S"

--- a/scripts/upload-cyber-tfvars.sh
+++ b/scripts/upload-cyber-tfvars.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+set -eu
+
+export PASSWORD_STORE_DIR=${CYBER_PASSWORD_STORE_DIR}
+
+cat << EOF | aws s3 cp - "s3://gds-paas-${DEPLOY_ENV}-state/bootstrap-cyber.tfvars"
+csls_kinesis_destination_arn = "$(pass "/cyber/${MAKEFILE_ENV_TARGET}/csls_kinesis_destination_arn")"
+EOF

--- a/terraform/bosh/cloudwatch_logs.tf
+++ b/terraform/bosh/cloudwatch_logs.tf
@@ -1,0 +1,9 @@
+locals {
+  log_groups = "${formatlist("%s_%s", var.log_groups_to_ship_to_csls, var.env)}"
+}
+
+resource "aws_cloudwatch_log_group" "bosh_director_vm" {
+  count             = "${length(local.log_groups)}"
+  name              = "${element(local.log_groups, count.index)}"
+  retention_in_days = "${var.cloudwatch_log_retention_period}"
+}

--- a/terraform/bosh/variables.tf
+++ b/terraform/bosh/variables.tf
@@ -40,3 +40,13 @@ variable "bosh_fqdn" {
 variable "bosh_fqdn_external" {
   description = "DNS record pointing to BOSH external IP"
 }
+
+variable "bosh_rds_storage_gb" {
+  description = "Storage in GB allocated to BOSH RDS"
+  default     = 25
+}
+
+variable cloudwatch_log_retention_period {
+  description = "how long cloudwatch logs should be retained for (in days). Default 18 months"
+  default     = 545
+}

--- a/terraform/cyber/cloudwatch_logs.tf
+++ b/terraform/cyber/cloudwatch_logs.tf
@@ -1,0 +1,13 @@
+locals {
+  destination_arn = "${replace(var.csls_kinesis_destination_arn, "REGION", var.region)}"
+  log_groups      = "${formatlist("%s_%s", var.log_groups_to_ship_to_csls, var.env)}"
+}
+
+resource "aws_cloudwatch_log_subscription_filter" "ship_logs_to_cyber" {
+  count           = "${length(local.log_groups)}"
+  name            = "${element(local.log_groups, count.index)}"
+  log_group_name  = "${element(local.log_groups, count.index)}"
+  destination_arn = "${local.destination_arn}"
+  filter_pattern  = ""                                          # Matches all events
+  distribution    = "Random"
+}

--- a/terraform/cyber/globals.tf
+++ b/terraform/cyber/globals.tf
@@ -1,0 +1,1 @@
+../globals.tf

--- a/terraform/cyber/variables.tf
+++ b/terraform/cyber/variables.tf
@@ -1,0 +1,4 @@
+variable "csls_kinesis_destination_arn" {
+  description = "The destination arn for Cyber Security's CSLS"
+  type        = "string"
+}

--- a/terraform/globals.tf
+++ b/terraform/globals.tf
@@ -104,3 +104,17 @@ variable "assets_prefix" {
   description = "Prefix for global assests like S3 buckets"
   default     = "gds-paas"
 }
+
+variable "log_groups_to_ship_to_csls" {
+  description = "The names of the log groups to ship to CSLS, without the _env suffix"
+  type        = "list"
+
+  default = [
+    "bosh_d_audit",
+    "bosh_d_audit_worker",
+    "bosh_d_auth",
+    "bosh_d_credhub_security_events",
+    "bosh_d_kauditd",
+    "bosh_d_uaa_events",
+  ]
+}


### PR DESCRIPTION
[Story](https://www.pivotaltracker.com/n/projects/1275640/stories/167894707)

What
----

- We need to create some log groups for our audit logs
- We need to retain the data for sometime
- We need to pull in the awslogs release
- We need to configure the awslogs jobs on the BOSH director to ship logs

See https://github.com/alphagov/paas-aws-account-wide-terraform/pull/188

How to review
-------------

Code review

`make dev upload-cyber-tfvars`

Deploy it to your dev env

Check that the log groups exist and are subscribed to the destination

I've tested that bootstrap works

Who can review
--------------

Describe who can review the changes. Or more importantly, list the people
that can't review, because they worked on it.
