### PR TITLE
Update bosh and aws cpi

### DIFF
--- a/manifests/bosh-manifest/operations.d/030-set-stemcell.yml
+++ b/manifests/bosh-manifest/operations.d/030-set-stemcell.yml
@@ -2,5 +2,5 @@
 - type: replace
   path: /resource_pools/name=vms/stemcell
   value:
-    url: https://bosh.io/d/stemcells/bosh-aws-xen-hvm-ubuntu-xenial-go_agent?v=456.51
-    sha1: 2110e8bcc84b669939bcc99638a114cb4ef3c595
+    url: https://bosh.io/d/stemcells/bosh-aws-xen-hvm-ubuntu-xenial-go_agent?v=621.23
+    sha1: fee86241cf8bd471bd69be0d8a436f8b71086392

--- a/manifests/bosh-manifest/operations.d/209-update-uaa-release.yml
+++ b/manifests/bosh-manifest/operations.d/209-update-uaa-release.yml
@@ -1,8 +1,0 @@
----
-- type: replace
-  path: /releases/name=uaa
-  value:
-    name: "uaa"
-    version: "74.7.0"
-    url: "https://bosh.io/d/github.com/cloudfoundry/uaa-release?v=74.7.0"
-    sha1: "b82c423cead3683e3ee13a1d9ee243085df1803a"

--- a/manifests/bosh-manifest/operations.d/301-credhub.yml
+++ b/manifests/bosh-manifest/operations.d/301-credhub.yml
@@ -1,12 +1,4 @@
 ---
-- path: /releases/name=credhub
-  type: replace
-  value:
-    name: credhub
-    sha1: "788c7da077480fc76a49a69095debbd887c9250e"
-    url: "https://bosh.io/d/github.com/pivotal-cf/credhub-release?v=2.5.6"
-    version: "2.5.6"
-
 - path: /instance_groups/name=bosh/jobs/name=credhub/properties/credhub/data_storage/host
   type: replace
   value: ((external_db_host))

--- a/manifests/concourse-manifest/concourse-base.yml
+++ b/manifests/concourse-manifest/concourse-base.yml
@@ -2,7 +2,7 @@
 meta:
   stemcell:
     name: bosh-aws-xen-hvm-ubuntu-xenial-go_agent
-    version: "456.51"
+    version: "621.23"
 
 name: concourse
 

--- a/manifests/concourse-manifest/concourse-base.yml
+++ b/manifests/concourse-manifest/concourse-base.yml
@@ -16,9 +16,9 @@ stemcells:
 # relevant tag of https://github.com/concourse/concourse-bosh-deployment
 releases:
   - name: "concourse"
-    version: "5.7.0"
-    url: "https://bosh.io/d/github.com/concourse/concourse-bosh-release?v=5.7.0"
-    sha1: "7fa513c5059c44eb5cc57c1fc5aaf9f845112bf3"
+    version: "5.7.1"
+    url: "https://bosh.io/d/github.com/concourse/concourse-bosh-release?v=5.7.1"
+    sha1: "0e183503af84afbbf228cfc30b584b120080b975"
   - name: "bpm"
     version: "1.1.5"
     url: "https://bosh.io/d/github.com/cloudfoundry/bpm-release?v=1.1.5"


### PR DESCRIPTION
What
----

- Updated BOSH to latest version: v270.9.0
  - which updated BOSH AWS CPI to latest version v79
    - which has support for latest stemcell series 621 (bosh-agent API v3)

- Stopped pinning UAA because BOSH has later version
- Stopped pinning Credhub because BOSH has later version
- Bumped Concourse to v5.7.1 to get latest point release
- Bumped stemcells to 621 because BOSH can use them now

Who can review
----

Done as pair with @mogds