### PR TITLE
[#169915408] Use Google SSO to authenticate to bosh's UAA

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,15 @@
-dist: trusty
+dist: bionic
 sudo: false
 rvm:
   - 2.5.3
 env:
   global:
-    - TF_VERSION="0.11.1"
-    - SPRUCE_VERSION="1.14.0"
-    - BOSH_CLI_VERSION="2.0.48"
-    - CERTSTRAP_VERSION="1.1.1"
+    - TF_VERSION="0.11.14"
+    - SPRUCE_VERSION="1.24.1"
+    - BOSH_CLI_VERSION="6.1.1"
+    - CERTSTRAP_VERSION="1.2.0"
+    - SHELLCHECK_VERSION="0.7.0"
+    - GO_VERSION="1.13"
 
 addons:
   apt:
@@ -16,6 +18,7 @@ addons:
     packages:
       - git
       - gnupg
+      - xz-utils
 
 before_install:
   - |
@@ -23,8 +26,8 @@ before_install:
     export PATH=~/bin:$PATH
   - |
     echo "Fetching shellcheck"
-    wget -O ~/bin/shellcheck https://github.com/alphagov/paas-cf/releases/download/shellcheck_binary_0.4.6/shellcheck_linux_amd64
-    chmod +x ~/bin/shellcheck
+    wget -qO- "https://storage.googleapis.com/shellcheck/shellcheck-v${SHELLCHECK_VERSION}.linux.x86_64.tar.xz" | tar -xJv
+    cp "shellcheck-v${SHELLCHECK_VERSION}/shellcheck" ~/bin
   - |
     echo "Fetching Terraform"
     set -e
@@ -39,16 +42,16 @@ before_install:
   - |
     echo "Fetching certstrap"
     set -e
-    wget https://github.com/square/certstrap/releases/download/v${CERTSTRAP_VERSION}/certstrap-v${CERTSTRAP_VERSION}-linux-amd64
-    mv certstrap-v${CERTSTRAP_VERSION}-linux-amd64 ~/bin/certstrap && chmod +x ~/bin/certstrap
+    wget https://github.com/square/certstrap/releases/download/v${CERTSTRAP_VERSION}/certstrap-${CERTSTRAP_VERSION}-linux-amd64
+    mv certstrap-${CERTSTRAP_VERSION}-linux-amd64 ~/bin/certstrap && chmod +x ~/bin/certstrap
   - |
-    echo "Fetching bosh cli v2"
+    echo "Fetching bosh cli"
     set -e
     wget https://s3.amazonaws.com/bosh-cli-artifacts/bosh-cli-${BOSH_CLI_VERSION}-linux-amd64
     mv bosh-cli-${BOSH_CLI_VERSION}-linux-amd64 ~/bin/bosh && chmod +x ~/bin/bosh
   - pip install --user yamllint
 
-  - eval "$(gimme 1.11)"
+  - 'eval "$(gimme "$GO_VERSION")"'
   - export GOPATH=$HOME/gopath
   - export PATH=$HOME/gopath/bin:$PATH
 

--- a/Makefile
+++ b/Makefile
@@ -222,7 +222,7 @@ stop-tunnel: check-env-vars ## Stop SSH tunnel
 	@./concourse/scripts/ssh.sh tunnel stop
 
 .PHONY: upload-all-secrets
-upload-all-secrets: upload-github-oauth upload-google-oauth upload-cyber-tfvars
+upload-all-secrets: upload-github-oauth upload-google-oauth upload-cyber-tfvars upload-paas-trusted-people
 
 .PHONY: upload-github-oauth
 upload-github-oauth: check-env-vars ## Decrypt and upload github OAuth credentials to S3
@@ -244,6 +244,10 @@ upload-cyber-tfvars: check-env-vars ## Decrypt and upload cyber tfvars to S3
 	$(if ${CYBER_PASSWORD_STORE_DIR},,$(error Must pass CYBER_PASSWORD_STORE_DIR=<path_to_password_store>))
 	$(if $(wildcard ${CYBER_PASSWORD_STORE_DIR}),,$(error Password store ${CYBER_PASSWORD_STORE_DIR} does not exist))
 	@scripts/upload-cyber-tfvars.sh
+
+.PHONY: upload-paas-trusted-people
+upload-paas-trusted-people: check-env-vars
+	@scripts/upload-paas-trusted-people.sh
 
 merge_pr: ## Merge a PR. Must specify number in a PR=<number> form.
 	$(if ${PR},,$(error Must pass PR=<number>))

--- a/Makefile
+++ b/Makefile
@@ -70,6 +70,7 @@ PASSWORD_STORE_DIR?=${HOME}/.paas-pass
 globals:
 	$(eval export PASSWORD_STORE_DIR=${PASSWORD_STORE_DIR})
 	$(eval export GITHUB_PASSWORD_STORE_DIR?=${HOME}/.paas-pass)
+	$(eval export GOOGLE_PASSWORD_STORE_DIR?=${HOME}/.paas-pass)
 	$(eval export CYBER_PASSWORD_STORE_DIR?=${HOME}/.paas-pass)
 	@true
 
@@ -221,7 +222,7 @@ stop-tunnel: check-env-vars ## Stop SSH tunnel
 	@./concourse/scripts/ssh.sh tunnel stop
 
 .PHONY: upload-all-secrets
-upload-all-secrets: upload-github-oauth upload-cyber-tfvars
+upload-all-secrets: upload-github-oauth upload-google-oauth upload-cyber-tfvars
 
 .PHONY: upload-github-oauth
 upload-github-oauth: check-env-vars ## Decrypt and upload github OAuth credentials to S3
@@ -229,6 +230,13 @@ upload-github-oauth: check-env-vars ## Decrypt and upload github OAuth credentia
 	$(if ${GITHUB_PASSWORD_STORE_DIR},,$(error Must pass GITHUB_PASSWORD_STORE_DIR=<path_to_password_store>))
 	$(if $(wildcard ${GITHUB_PASSWORD_STORE_DIR}),,$(error Password store ${GITHUB_PASSWORD_STORE_DIR} does not exist))
 	@scripts/manage-github-secrets.sh upload
+
+.PHONY: upload-google-oauth
+upload-google-oauth: check-env-vars ## Decrypt and upload google OAuth credentials to S3
+	$(if ${MAKEFILE_ENV_TARGET},,$(error Must set MAKEFILE_ENV_TARGET))
+	$(if ${GOOGLE_PASSWORD_STORE_DIR},,$(error Must pass GOOGLE_PASSWORD_STORE_DIR=<path_to_password_store>))
+	$(if $(wildcard ${GOOGLE_PASSWORD_STORE_DIR}),,$(error Password store ${GOOGLE_PASSWORD_STORE_DIR} does not exist))
+	@scripts/upload-google-oauth-secrets.sh
 
 .PHONY: upload-cyber-tfvars
 upload-cyber-tfvars: check-env-vars ## Decrypt and upload cyber tfvars to S3

--- a/concourse/pipelines/create-bosh-concourse.yml
+++ b/concourse/pipelines/create-bosh-concourse.yml
@@ -158,6 +158,15 @@ resources:
       initial_version: "-"
       initial_content_text: ""
 
+  - name: bosh-uaa-google-oauth-secrets
+    type: s3-iam
+    source:
+      bucket: ((state_bucket))
+      region_name: ((aws_region))
+      versioned_file: bosh-uaa-google-oauth-secrets.yml
+      initial_version: "-"
+      initial_content_text: ""
+
   - name: bootstrap-cyber-tfvars
     type: s3-iam
     source:
@@ -809,6 +818,7 @@ jobs:
           passed: ['bosh-terraform']
         - get: bosh-tfstate
           passed: ['bosh-terraform']
+        - get: bosh-uaa-google-oauth-secrets
 
       - task: extract_terraform_outputs
         config:
@@ -843,6 +853,7 @@ jobs:
             - name: bosh-secrets
             - name: bosh-CA
             - name: bosh-vars-store
+            - name: bosh-uaa-google-oauth-secrets
           outputs:
             - name: bosh-manifest
             - name: bosh-manifest-pre-vars

--- a/concourse/pipelines/create-bosh-concourse.yml
+++ b/concourse/pipelines/create-bosh-concourse.yml
@@ -953,14 +953,14 @@ jobs:
             BOSH_GW_USER: vcap
             BOSH_GW_PRIVATE_KEY: ssh-private-key/id_rsa
           run:
-            path: sh
+            path: bash
             args:
               - -e
               - -c
               - |
                 VAL_FROM_YAML=$(pwd)/paas-bootstrap/concourse/scripts/val_from_yaml.rb
                 . ./paas-bootstrap/concourse/scripts/bosh-tunnel.sh start
-                BOSH_CLIENT=admin
+                BOSH_CLIENT='admin'
                 BOSH_CLIENT_SECRET=$($VAL_FROM_YAML admin_password bosh-vars-store/bosh-vars-store.yml)
                 export BOSH_CLIENT
                 export BOSH_CLIENT_SECRET
@@ -1242,7 +1242,7 @@ jobs:
             BOSH_GW_USER: vcap
             BOSH_GW_PRIVATE_KEY: ssh-private-key/id_rsa
           run:
-            path: sh
+            path: bash
             args:
               - -e
               - -u
@@ -1251,7 +1251,7 @@ jobs:
                 . ./paas-bootstrap/concourse/scripts/bosh-tunnel.sh start
 
                 VAL_FROM_YAML=$(pwd)/paas-bootstrap/concourse/scripts/val_from_yaml.rb
-                BOSH_CLIENT=admin
+                BOSH_CLIENT='admin'
                 BOSH_CLIENT_SECRET=$($VAL_FROM_YAML admin_password bosh-vars-store/bosh-vars-store.yml)
                 export BOSH_CLIENT
                 export BOSH_CLIENT_SECRET
@@ -1278,7 +1278,7 @@ jobs:
             BOSH_GW_USER: vcap
             BOSH_GW_PRIVATE_KEY: ssh-private-key/id_rsa
           run:
-            path: sh
+            path: bash
             args:
               - -e
               - -u
@@ -1287,7 +1287,7 @@ jobs:
                 . ./paas-bootstrap/concourse/scripts/bosh-tunnel.sh start
 
                 VAL_FROM_YAML=$(pwd)/paas-bootstrap/concourse/scripts/val_from_yaml.rb
-                BOSH_CLIENT=admin
+                BOSH_CLIENT='admin'
                 BOSH_CLIENT_SECRET=$($VAL_FROM_YAML admin_password bosh-vars-store/bosh-vars-store.yml)
                 export BOSH_CLIENT
                 export BOSH_CLIENT_SECRET
@@ -1327,7 +1327,7 @@ jobs:
             BOSH_GW_USER: vcap
             BOSH_GW_PRIVATE_KEY: ssh-private-key/id_rsa
           run:
-            path: sh
+            path: bash
             args:
               - -e
               - -c
@@ -1341,7 +1341,7 @@ jobs:
 
                 . ./paas-bootstrap/concourse/scripts/bosh-tunnel.sh start
 
-                BOSH_CLIENT=admin
+                BOSH_CLIENT='admin'
                 BOSH_CLIENT_SECRET=$($VAL_FROM_YAML admin_password bosh-vars-store/bosh-vars-store.yml)
                 export BOSH_CLIENT
                 export BOSH_CLIENT_SECRET
@@ -1370,7 +1370,7 @@ jobs:
 
             CONCOURSE_WORKER_INSTANCES: ((concourse_worker_instances))
           run:
-            path: sh
+            path: bash
             args:
             - -e
             - -u
@@ -1379,7 +1379,7 @@ jobs:
               . ./paas-bootstrap/concourse/scripts/bosh-tunnel.sh start
 
               VAL_FROM_YAML=$(pwd)/paas-bootstrap/concourse/scripts/val_from_yaml.rb
-              BOSH_CLIENT=admin
+              BOSH_CLIENT='admin'
               BOSH_CLIENT_SECRET=$($VAL_FROM_YAML admin_password bosh-vars-store/bosh-vars-store.yml)
               export BOSH_CLIENT
               export BOSH_CLIENT_SECRET
@@ -1483,7 +1483,7 @@ jobs:
             TARGET_CONCOURSE: ((target_concourse))
             DEPLOY_ENV: ((deploy_env))
           run:
-            path: sh
+            path: bash
             args:
               - -e
               - -c
@@ -1540,7 +1540,7 @@ jobs:
             BOSH_GW_USER: vcap
             BOSH_GW_PRIVATE_KEY: ssh-private-key/id_rsa
           run:
-            path: sh
+            path: bash
             args:
             - -e
             - -c
@@ -1548,7 +1548,7 @@ jobs:
               . ./paas-bootstrap/concourse/scripts/bosh-tunnel.sh start
 
               VAL_FROM_YAML=$(pwd)/paas-bootstrap/concourse/scripts/val_from_yaml.rb
-              BOSH_CLIENT=admin
+              BOSH_CLIENT='admin'
               BOSH_CLIENT_SECRET=$($VAL_FROM_YAML admin_password bosh-vars-store/bosh-vars-store.yml)
               export BOSH_CLIENT
               export BOSH_CLIENT_SECRET
@@ -1574,7 +1574,7 @@ jobs:
             BOSH_GW_PRIVATE_KEY: ssh-private-key/id_rsa
             TARGET_CONCOURSE: ((target_concourse))
           run:
-            path: sh
+            path: bash
             args:
             - -e
             - -c
@@ -1704,7 +1704,7 @@ jobs:
               - -c
               - |
                 # We cannot use native credentials fetching here because bootstrap
-                CONCOURSE_WEB_USER=admin
+                CONCOURSE_WEB_USER='admin'
                 CONCOURSE_WEB_PASSWORD="$(cat upload-pipeline-secrets/concourse_web_password.txt)"
                 export CONCOURSE_WEB_USER CONCOURSE_WEB_PASSWORD
 

--- a/concourse/pipelines/create-bosh-concourse.yml
+++ b/concourse/pipelines/create-bosh-concourse.yml
@@ -86,6 +86,15 @@ resources:
       branch: ((branch_name))
       commit_verification_keys: ((gpg_public_keys))
 
+  - name: paas-trusted-people
+    type: s3-iam
+    source:
+      bucket: ((state_bucket))
+      region_name: ((aws_region))
+      versioned_file: paas-trusted-people/users.yml
+      initial_version: "-"
+      initial_content_text: ""
+
   - name: bucket-terraform-state
     type: s3-iam
     source:
@@ -819,6 +828,7 @@ jobs:
         - get: bosh-tfstate
           passed: ['bosh-terraform']
         - get: bosh-uaa-google-oauth-secrets
+        - get: paas-trusted-people
 
       - task: extract_terraform_outputs
         config:
@@ -843,6 +853,25 @@ jobs:
                   < bosh-tfstate/bosh.tfstate \
                   > terraform-outputs/bosh-terraform-outputs.yml
 
+      - task: generate-uaa-users
+        config:
+          platform: linux
+          image_resource: *ruby-slim-image-resource
+          inputs:
+            - name: paas-bootstrap
+            - name: paas-trusted-people
+          outputs:
+            - name: uaa-users-ops-file
+          run:
+            path: sh
+            args:
+              - -c
+              - -e
+              - |
+                paas-bootstrap/manifests/bosh-manifest/scripts/generate-uaa-users-ops-file.rb \
+                  paas-trusted-people/users.yml "((aws_account))" > uaa-users-ops-file/uaa-users-ops-file.yml
+                cat uaa-users-ops-file/uaa-users-ops-file.yml
+
       - task: render-bosh-manifest
         config:
           platform: linux
@@ -854,6 +883,7 @@ jobs:
             - name: bosh-CA
             - name: bosh-vars-store
             - name: bosh-uaa-google-oauth-secrets
+            - name: uaa-users-ops-file
           outputs:
             - name: bosh-manifest
             - name: bosh-manifest-pre-vars

--- a/concourse/pipelines/destroy-bosh-concourse.yml
+++ b/concourse/pipelines/destroy-bosh-concourse.yml
@@ -259,7 +259,7 @@ jobs:
             BOSH_GW_USER: vcap
             BOSH_GW_PRIVATE_KEY: ssh-private-key/id_rsa
           run:
-            path: sh
+            path: bash
             args:
             - -e
             - -c
@@ -267,7 +267,7 @@ jobs:
               . ./paas-bootstrap/concourse/scripts/bosh-tunnel.sh start
 
               VAL_FROM_YAML=$(pwd)/paas-bootstrap/concourse/scripts/val_from_yaml.rb
-              BOSH_CLIENT=admin
+              BOSH_CLIENT='admin'
               BOSH_CLIENT_SECRET=$($VAL_FROM_YAML admin_password bosh-vars-store/bosh-vars-store.yml)
               export BOSH_CLIENT
               export BOSH_CLIENT_SECRET
@@ -374,7 +374,7 @@ jobs:
             BOSH_GW_USER: vcap
             BOSH_GW_PRIVATE_KEY: ssh-private-key/id_rsa
           run:
-            path: sh
+            path: bash
             args:
               - -e
               - -c
@@ -382,7 +382,7 @@ jobs:
                 . ./paas-bootstrap/concourse/scripts/bosh-tunnel.sh start
 
                 VAL_FROM_YAML=$(pwd)/paas-bootstrap/concourse/scripts/val_from_yaml.rb
-                BOSH_CLIENT=admin
+                BOSH_CLIENT='admin'
                 BOSH_CLIENT_SECRET=$($VAL_FROM_YAML admin_password bosh-vars-store/bosh-vars-store.yml)
                 export BOSH_CLIENT
                 export BOSH_CLIENT_SECRET
@@ -413,7 +413,7 @@ jobs:
             BOSH_GW_USER: vcap
             BOSH_GW_PRIVATE_KEY: ssh-private-key/id_rsa
           run:
-            path: sh
+            path: bash
             args:
               - -e
               - -c
@@ -421,7 +421,7 @@ jobs:
                 . ./paas-bootstrap/concourse/scripts/bosh-tunnel.sh start
 
                 VAL_FROM_YAML=$(pwd)/paas-bootstrap/concourse/scripts/val_from_yaml.rb
-                BOSH_CLIENT=admin
+                BOSH_CLIENT='admin'
                 BOSH_CLIENT_SECRET=$($VAL_FROM_YAML admin_password bosh-vars-store/bosh-vars-store.yml)
                 export BOSH_CLIENT
                 export BOSH_CLIENT_SECRET

--- a/concourse/scripts/ssh.sh
+++ b/concourse/scripts/ssh.sh
@@ -11,7 +11,7 @@ SOCKET_DEF=%r@%h:%p
 SOCKET=$SOCKET_DIR/$SOCKET_DEF
 
 usage() {
-  if [ ! -z "${1:-}" ]; then
+  if [ -n "${1:-}" ]; then
     echo "$@"
     echo
   fi

--- a/manifests/bosh-manifest/operations.d/201-uaa.yml
+++ b/manifests/bosh-manifest/operations.d/201-uaa.yml
@@ -31,3 +31,26 @@
 - type: replace
   path: /instance_groups/name=bosh/jobs/name=uaa/properties/uaa/ca_certs?/-
   value: ((aws_rds_combined_ca_bundle))
+
+- type: replace
+  path: /instance_groups/name=bosh/jobs/name=uaa/properties/login/oauth?/providers/google
+  value:
+    type: oidc1.0
+    authUrl: https://accounts.google.com/o/oauth2/v2/auth
+    tokenUrl: https://www.googleapis.com/oauth2/v4/token
+    tokenKeyUrl: https://www.googleapis.com/oauth2/v3/certs
+    issuer: https://accounts.google.com
+    redirectUrl: https://((bosh_fqdn)):8443
+    scopes:
+      - openid
+      - profile
+      - email
+    linkText: Google
+    showLinkText: true
+    addShadowUserOnLogin: false
+    relyingPartyId: ((google_oauth_client_id))
+    relyingPartySecret: ((google_oauth_client_secret))
+    skipSslValidation: false
+    attributeMappings:
+      user_name: sub
+

--- a/manifests/bosh-manifest/operations.d/209-uaa-remove-unused-users-and-clients.yml
+++ b/manifests/bosh-manifest/operations.d/209-uaa-remove-unused-users-and-clients.yml
@@ -1,10 +1,4 @@
 ---
 - type: remove
-  path: /instance_groups/name=bosh/jobs/name=uaa/properties/uaa/clients/bosh_cli
-
-- type: remove
   path: /instance_groups/name=bosh/jobs/name=uaa/properties/uaa/clients/uaa_admin
 
-- type: replace
-  path: /instance_groups/name=bosh/jobs/name=uaa/properties/uaa/scim/users
-  value: []

--- a/manifests/bosh-manifest/scripts/generate-manifest.sh
+++ b/manifests/bosh-manifest/scripts/generate-manifest.sh
@@ -24,6 +24,7 @@ bosh interpolate - \
   --vars-file "${WORKDIR}/bosh-secrets/bosh-secrets.yml" \
   --vars-file "${WORKDIR}/terraform-outputs/bosh-terraform-outputs.yml" \
   --vars-file "${WORKDIR}/terraform-outputs/vpc-terraform-outputs.yml" \
+  --vars-file "${WORKDIR}/bosh-uaa-google-oauth-secrets/bosh-uaa-google-oauth-secrets.yml" \
   --var-file="default_ca.certificate=${WORKDIR}/certs/bosh-CA.crt" \
   --var-file="default_ca.private_key=${WORKDIR}/certs/bosh-CA.key" \
   > "${variables_file}" \
@@ -79,6 +80,9 @@ nats_ca:
 
 vcap_password: ((secrets.vcap_password))
 bosh_credhub_admin_client_password: ((secrets.bosh_credhub_admin_client_password))
+
+google_oauth_client_id: ((google_oauth_client_id))
+google_oauth_client_secret: ((google_oauth_client_secret))
 EOF
 
 

--- a/manifests/bosh-manifest/scripts/generate-manifest.sh
+++ b/manifests/bosh-manifest/scripts/generate-manifest.sh
@@ -11,6 +11,14 @@ for i in "${PAAS_BOOTSTRAP_DIR}"/manifests/bosh-manifest/operations.d/*.yml; do
   opsfile_args+="-o $i "
 done
 
+uaa_users_ops_file="${WORKDIR}/uaa-users-ops-file/uaa-users-ops-file.yml"
+if [ -f "$uaa_users_ops_file" ]; then
+  opsfile_args+="-o $uaa_users_ops_file "
+else
+  >&2 echo "Could not find $uaa_users_ops_file. Aborting."
+  exit 1
+fi
+
 vars_store_args=""
 if [ -n "${VARS_STORE:-}" ]; then
   vars_store_args=" --var-errs --vars-store ${VARS_STORE}"

--- a/manifests/bosh-manifest/scripts/generate-uaa-users-ops-file.rb
+++ b/manifests/bosh-manifest/scripts/generate-uaa-users-ops-file.rb
@@ -1,0 +1,44 @@
+#!/usr/bin/env ruby
+
+require 'yaml'
+
+def generate_uaa_users_ops_file(config_file, aws_account)
+  named_roles_to_groups = {
+    'bosh-admin' => ['bosh.admin'],
+  }
+  ops_file = [{
+    'type' => 'replace',
+    'path' => '/instance_groups/name=bosh/jobs/name=uaa/properties/uaa/scim/users',
+    'value' => [],
+  }]
+  if File.file? config_file
+    users_config = YAML.load_file config_file
+    users_and_groups = users_config
+      .fetch('users')
+      .map do |user|
+        groups = (user.dig('roles', aws_account) || []).flat_map { |entry| named_roles_to_groups.fetch(entry['role'], []) }
+        [user, groups]
+      end
+
+    ops_file[0]['value'] = users_and_groups
+      .reject { |_user, groups| groups.empty? }
+      .map do |user, groups|
+        email = user.fetch('email')
+        {
+          'email' => email,
+          'name' => email,
+          'origin' => 'google',
+          'groups' => groups,
+        }
+      end
+
+    ops_file.to_yaml
+  end
+end
+
+if $0 == __FILE__
+  config_file = ARGV[0]
+  aws_account = ARGV[1]
+
+  puts generate_uaa_users_ops_file(config_file, aws_account)
+end

--- a/manifests/bosh-manifest/spec/generate-uaa-users-ops-file_spec.rb
+++ b/manifests/bosh-manifest/spec/generate-uaa-users-ops-file_spec.rb
@@ -1,0 +1,67 @@
+require 'tempfile'
+require 'yaml'
+
+require_relative '../scripts/generate-uaa-users-ops-file'
+
+def with_temp_users_file(contents)
+  Tempfile.create('users.yml') do |f|
+    f.write contents
+    f.flush
+    yield f
+  end
+end
+
+RSpec.describe 'Generating UAA users ops file' do
+  it 'Generates an empty ops file if no users are present' do
+    with_temp_users_file 'users: []' do |f|
+      result_str = generate_uaa_users_ops_file(f.path, 'some-aws-env')
+      result_yaml = YAML.safe_load(result_str)
+      expect(result_yaml).to eql([{
+        'type' => 'replace',
+        'path' => '/instance_groups/name=bosh/jobs/name=uaa/properties/uaa/scim/users',
+        'value' => [],
+      }])
+    end
+  end
+
+  it 'Generates an ops file with bosh-admins for the current environment based on the config' do
+    users = {
+      'users' => [
+        {
+          'email' => 'some-admin-email@digital.cabinet-office.gov.uk',
+          'roles' => { 'prod' => [{ 'role' => 'bosh-admin' }] },
+        },
+        {
+          'email' => 'some-admin-for-a-different-env-email@digital.cabinet-office.gov.uk',
+          'roles' => { 'dev' => [{ 'role' => 'bosh-admin' }] },
+        },
+        {
+          'email' => 'some-unrelated-roles-email@digital.cabinet-office.gov.uk',
+          'roles' => { 'prod' => [{ 'role' => 'some-unrelated-role' }] },
+        },
+        {
+          'email' => 'some-no-roles-email@digital.cabinet-office.gov.uk',
+          'roles' => { 'prod' => [] },
+        },
+        {
+          'email' => 'some-empty-roles-email@digital.cabinet-office.gov.uk',
+          'roles' => {},
+        },
+      ],
+    }
+    with_temp_users_file users.to_yaml do |f|
+      result_str = generate_uaa_users_ops_file(f.path, 'prod')
+      result_yaml = YAML.safe_load(result_str)
+      expect(result_yaml).to eql([{
+        'type' => 'replace',
+        'path' => '/instance_groups/name=bosh/jobs/name=uaa/properties/uaa/scim/users',
+        'value' => [{
+          'email' => 'some-admin-email@digital.cabinet-office.gov.uk',
+          'name' => 'some-admin-email@digital.cabinet-office.gov.uk',
+          'origin' => 'google',
+          'groups' => ['bosh.admin'],
+        }],
+      }])
+    end
+  end
+end

--- a/manifests/bosh-manifest/spec/manifest_validation_spec.rb
+++ b/manifests/bosh-manifest/spec/manifest_validation_spec.rb
@@ -123,4 +123,21 @@ RSpec.describe "generic manifest validations" do
       end
     end
   end
+
+  describe "uaa" do
+    let(:uaa_props) { bosh_jobs.find { |j| j['name'] == 'uaa' }['properties'] }
+
+    context "login providers" do
+      let(:uaa_google_login_provider) { uaa_props.dig('login', 'oauth', 'providers', 'google') }
+
+      it 'should be configured to use google' do
+        expect(uaa_google_login_provider).to_not be_nil
+        expect(uaa_google_login_provider['issuer']).to eql 'https://accounts.google.com'
+        expect(uaa_google_login_provider['type']).to eql 'oidc1.0'
+        expect(uaa_google_login_provider['scopes']).to eql %w(openid profile email)
+        expect(uaa_google_login_provider['relyingPartyId']).to eql 'some-google-client-id'
+        expect(uaa_google_login_provider['relyingPartySecret']).to eql 'some-google-client-secret'
+      end
+    end
+  end
 end

--- a/manifests/bosh-manifest/spec/support/manifest_helpers.rb
+++ b/manifests/bosh-manifest/spec/support/manifest_helpers.rb
@@ -59,6 +59,11 @@ private
     env['WORKDIR'] = workdir.to_s
 
     generate_bosh_secrets_fixture("#{workdir}/bosh-secrets")
+    generate_google_oauth_secrets_fixture(
+      "#{workdir}/bosh-uaa-google-oauth-secrets",
+      'some-google-client-id',
+      'some-google-client-secret',
+    )
     generate_bosh_ca_certs(workdir)
     copy_terraform_fixtures("#{workdir}/terraform-outputs", %w(vpc bosh))
 

--- a/manifests/bosh-manifest/spec/support/manifest_helpers.rb
+++ b/manifests/bosh-manifest/spec/support/manifest_helpers.rb
@@ -64,6 +64,7 @@ private
       'some-google-client-id',
       'some-google-client-secret',
     )
+    generate_uaa_users_fixture("#{workdir}/uaa-users-ops-file")
     generate_bosh_ca_certs(workdir)
     copy_terraform_fixtures("#{workdir}/terraform-outputs", %w(vpc bosh))
 

--- a/manifests/shared/spec/support/fixture_helpers.rb
+++ b/manifests/shared/spec/support/fixture_helpers.rb
@@ -25,6 +25,16 @@ module FixtureHelpers
     end
   end
 
+  def generate_google_oauth_secrets_fixture(target_dir, google_oauth_client_id, google_oauth_client_secret)
+    FileUtils.mkdir(target_dir) unless Dir.exist?(target_dir)
+    File.open("#{target_dir}/bosh-uaa-google-oauth-secrets.yml", 'w') do |file|
+      file.write({
+        'google_oauth_client_id' => google_oauth_client_id,
+        'google_oauth_client_secret' => google_oauth_client_secret,
+      }.to_yaml)
+    end
+  end
+
 private
 
   def fixtures_dir

--- a/manifests/shared/spec/support/fixture_helpers.rb
+++ b/manifests/shared/spec/support/fixture_helpers.rb
@@ -35,6 +35,13 @@ module FixtureHelpers
     end
   end
 
+  def generate_uaa_users_fixture(target_dir)
+    FileUtils.mkdir(target_dir) unless Dir.exist?(target_dir)
+    File.open("#{target_dir}/uaa-users-ops-file.yml", 'w') do |file|
+      file.write '[]'
+    end
+  end
+
 private
 
   def fixtures_dir

--- a/proxy/pacserver.rb
+++ b/proxy/pacserver.rb
@@ -1,0 +1,15 @@
+require 'webrick'
+
+server = WEBrick::HTTPServer.new Port: 9191
+
+proxy = File.read(File.expand_path(File.join(__dir__, 'proxy.pac')))
+
+server.mount_proc '/' do |_req, res|
+  res.status = 200
+  res['Content-Type'] = 'application/x-ns-proxy-autoconfig'
+  res.body = proxy
+end
+
+trap 'INT' do server.shutdown end
+
+server.start

--- a/proxy/proxy.pac
+++ b/proxy/proxy.pac
@@ -1,0 +1,15 @@
+// Used by scripts/bosh-cli.sh to proxy requests to things running on the bosh
+// director using the SOCKS5 proxy set up by our SSH tunnel.
+
+function FindProxyForURL(url, host) {
+
+  if (shExpMatch(host, "bosh.*.dev.cloudpipeline.digital")          ||
+      shExpMatch(host, "bosh.build.ci.cloudpipeline.digital")       ||
+      shExpMatch(host, "bosh.london.staging.cloudpipeline.digital") ||
+      shExpMatch(host, "bosh.cloud.service.gov.uk")                 ||
+      shExpMatch(host, "bosh.london.cloud.service.gov.uk")) {
+    return "SOCKS localhost:25555; SOCKS5 localhost:25555";
+  }
+
+  return "DIRECT";
+}

--- a/scripts/upload-google-oauth-secrets.sh
+++ b/scripts/upload-google-oauth-secrets.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+set -eu
+
+export PASSWORD_STORE_DIR=${GOOGLE_PASSWORD_STORE_DIR}
+
+cat <<EOF | aws s3 cp - "s3://gds-paas-${DEPLOY_ENV}-state/bosh-uaa-google-oauth-secrets.yml"
+---
+google_oauth_client_id: "${GOOGLE_OAUTH_CLIENT_ID:-"$(pass "google/${MAKEFILE_ENV_TARGET}/oauth/client_id")"}"
+google_oauth_client_secret: "${GOOGLE_OAUTH_CLIENT_SECRET:-"$(pass "google/${MAKEFILE_ENV_TARGET}/oauth/client_secret")"}"
+EOF
+

--- a/scripts/upload-paas-trusted-people.sh
+++ b/scripts/upload-paas-trusted-people.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+cd "$(mktemp -d -t paas-trusted-people-XXXXX)"
+
+git clone --depth 1 --branch "${PAAS_TRUSTED_PEOPLE_BRANCH:-master}" git@github.com:alphagov/paas-trusted-people.git
+aws s3 cp ./paas-trusted-people/users.yml "s3://gds-paas-${DEPLOY_ENV}-state/paas-trusted-people/users.yml"
+


### PR DESCRIPTION
What
----

We don't want to be using shared credentials to access bosh, as this
makes auditing impossible. We also don't want to have to manage another
set of credentials, so it's best if we can use SSO.

This adds the bosh-admin users from [alphagov/paas-trusted-people](https://github.com/alphagov/paas-trusted-people/) to
bosh's UAA (via its config file), and updates the bosh-cli script to
allow people to log in using SSO.

I also did a bit of updating of things on Travis because I was annoyed
at them being much older versions than I had locally.

See the individual commits for more detail.

How to review
-------------

* Code review
* Run this branch down your dev env
* Check that you can authenticate to bosh in you dev env using `make dev bosh-cli` from this branch

Who can review
--------------

Not @richardtowers