### PR TITLE
Bump stemcell to 621.29

### DIFF
--- a/manifests/bosh-manifest/operations.d/030-set-stemcell.yml
+++ b/manifests/bosh-manifest/operations.d/030-set-stemcell.yml
@@ -2,5 +2,5 @@
 - type: replace
   path: /resource_pools/name=vms/stemcell
   value:
-    url: https://bosh.io/d/stemcells/bosh-aws-xen-hvm-ubuntu-xenial-go_agent?v=621.23
-    sha1: fee86241cf8bd471bd69be0d8a436f8b71086392
+    url: https://bosh.io/d/stemcells/bosh-aws-xen-hvm-ubuntu-xenial-go_agent?v=621.29
+    sha1: ed4f68426705a8f1c84fd824f0ed1e1e3761bbbc

--- a/manifests/concourse-manifest/concourse-base.yml
+++ b/manifests/concourse-manifest/concourse-base.yml
@@ -2,7 +2,7 @@
 meta:
   stemcell:
     name: bosh-aws-xen-hvm-ubuntu-xenial-go_agent
-    version: "621.23"
+    version: "621.29"
 
 name: concourse
 


### PR DESCRIPTION
What
----

In https://github.com/alphagov/paas-cf/pull/2197 we upgraded the stemcells to 621.23 but did not make the change in paas-bootstrap. We should keep stemcells in sync.

We were checking for the stemcell sha when raising this PR, and discovered that there were some CVE fixes in 621.29:

- USN-4211-1
- USN-4205-1
- USN-4203-1
- USN-4213-1
- USN-4210-1
- USN-4204-1

How to review
-------------

Code review

Check the pivotal network: https://docs.pivotal.io/platform/stemcells/stemcells.html

Who can review
--------------

Done as pair with @schmie 
