### PR TITLE
Refactor concourse/scripts/ssh.sh

### DIFF
--- a/concourse/scripts/get_ip_address.sh
+++ b/concourse/scripts/get_ip_address.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+set -euo pipefail
+
+case ${1:-} in
+  concourse)
+    env > /tmp/debug.txt
+    aws ec2 describe-instances \
+      --filters "Name=tag:deploy_env,Values=${DEPLOY_ENV}" 'Name=tag:instance_group,Values=concourse' \
+      --query 'Reservations[].Instances[].PublicIpAddress' --output text
+    ;;
+  bootstrap)
+    aws ec2 describe-instances \
+      --filters 'Name=tag:Name,Values=*concourse' "Name=key-name,Values=${VAGRANT_SSH_KEY_NAME}" \
+      --query 'Reservations[].Instances[].PublicIpAddress' --output text
+    ;;
+  *)
+    usage "Unknown action '$1'"
+    exit 1
+    ;;
+esac


### PR DESCRIPTION
What
----

In #324 we stopped using a global SSH key and switched to user-specific SSH keys. But we didn't stop downloading the old global key from S3. This commit removes that old code.

How to review
-------------

* Code review;
* I've checked this still works but feel free to yourself.

Who can review
--------------

Not @46bit.