### PR TITLE
Grant GH user `poveyd` dev Concourse access

### DIFF
--- a/manifests/concourse-manifest/github_auth/dev_ci_additional_users.yml
+++ b/manifests/concourse-manifest/github_auth/dev_ci_additional_users.yml
@@ -13,3 +13,4 @@ instance_groups:
                   - (( append ))
                   - schmie
                   - venusbb
+                  - poveyd


### PR DESCRIPTION
What
----
Dave Povey has joined the PaaS team, and his GH username is `poveyd`. He needs
dev Concourse access.

How to review
-------------
1. Code review

Who can review
--------------
Anyone. It's a small commit though, so I'll merge it myself.
