### PR TITLE
[#170750179] Update concourse to v5.8.0

### DIFF
--- a/manifests/concourse-manifest/concourse-base.yml
+++ b/manifests/concourse-manifest/concourse-base.yml
@@ -16,9 +16,9 @@ stemcells:
 # relevant tag of https://github.com/concourse/concourse-bosh-deployment
 releases:
   - name: "concourse"
-    version: "5.7.1"
-    url: "https://bosh.io/d/github.com/concourse/concourse-bosh-release?v=5.7.1"
-    sha1: "0e183503af84afbbf228cfc30b584b120080b975"
+    version: "5.8.0"
+    url: "https://bosh.io/d/github.com/concourse/concourse-bosh-release?v=5.8.0"
+    sha1: "66b8a0d51b0436bd615eb9b99fc5d3963dd87efa"
   - name: "bpm"
     version: "1.1.5"
     url: "https://bosh.io/d/github.com/cloudfoundry/bpm-release?v=1.1.5"

--- a/vagrant/docker-compose.yml
+++ b/vagrant/docker-compose.yml
@@ -10,7 +10,7 @@ services:
     - PGDATA=/database
 
   concourse-web:
-    image: concourse/concourse:5.7.0
+    image: concourse/concourse:5.8.0
     command: web
     privileged: true
     depends_on: [concourse-db]
@@ -32,7 +32,7 @@ services:
     - CONCOURSE_SESSION_SIGNING_KEY=/keys/session_signing_key
 
   concourse-worker-colocated:
-    image: concourse/concourse:5.7.0
+    image: concourse/concourse:5.8.0
     command: worker
     privileged: true
     depends_on: [concourse-db, concourse-web]
@@ -50,7 +50,7 @@ services:
     - CONCOURSE_GARDEN_DNS_SERVER=169.254.169.253
 
   concourse-worker-normal:
-    image: concourse/concourse:5.7.0
+    image: concourse/concourse:5.8.0
     command: worker
     privileged: true
     depends_on: [concourse-db, concourse-web]


### PR DESCRIPTION
[Story](https://www.pivotaltracker.com/story/show/170750179)

What
----

Version bump

How to review
-------------

See the release notes https://github.com/concourse/concourse/releases/tag/v5.8.0

Try upgrading your dev concourse

Who can review
--------------

Not @tlwr

---

Once approved, I'm happy to shepherd this to production