### PR TITLE
Use default SSH key when SSHing to BOSH

### DIFF
--- a/scripts/ssh_bosh.sh
+++ b/scripts/ssh_bosh.sh
@@ -1,16 +1,9 @@
 #!/bin/bash
 set -euo pipefail
 
-SSH_PATH=${SSH_PATH:-"/Users/${USER}/.ssh/id_rsa"}
-
-BOSH_KEY=/tmp/id_rsa.$RANDOM
 BOSH_IP=$(aws ec2 describe-instances \
     --filters "Name=tag:deploy_env,Values=${DEPLOY_ENV}" 'Name=tag:instance_group,Values=bosh' \
     --query 'Reservations[].Instances[].PublicIpAddress' --output text)
-
-trap 'rm -f ${BOSH_KEY}' EXIT
-
-aws s3 cp "s3://gds-paas-${DEPLOY_ENV}-state/id_rsa" ${BOSH_KEY} && chmod 400 ${BOSH_KEY}
 
 aws s3 cp "s3://gds-paas-${DEPLOY_ENV}-state/bosh-secrets.yml" - | \
   ruby -ryaml -e 'puts "Sudo password is " + YAML.load(STDIN)["secrets"]["vcap_password_orig"]'
@@ -18,8 +11,6 @@ echo
 
 # shellcheck disable=SC2029
 ssh \
-    -i "$SSH_PATH" \
-    -o IdentitiesOnly=yes \
     -o ServerAliveInterval=60 \
     -o StrictHostKeyChecking=no \
     -o UserKnownHostsFile=/dev/null \


### PR DESCRIPTION
What
----

Some of the team use SSH keys on disk to access BOSH, but others use keys on a Yubikey. The existing script didn't support using a Yubikey.

This commit removes all specifying of the SSH key, relying on the default. It also removes `-o IdentitiesOnly=yes` which was obstructing Yubikey use.

How to review
-------------

Someone who uses a key on disk should review this. You may as well do it alongside #337 which is the Concourse version of this PR.

Who can review
--------------

Not @46bit 