### PR TITLE
Give operators credhub.read/write and uaa.admin

### DIFF
--- a/manifests/bosh-manifest/scripts/generate-uaa-users-ops-file.rb
+++ b/manifests/bosh-manifest/scripts/generate-uaa-users-ops-file.rb
@@ -1,16 +1,23 @@
 #!/usr/bin/env ruby
 
+require 'English'
 require 'yaml'
 
 def generate_uaa_users_ops_file(config_file, aws_account)
   named_roles_to_groups = {
-    'bosh-admin' => ['bosh.admin'],
+    'bosh-admin' => [
+      'bosh.admin',
+      'credhub.read', 'credhub.write',
+      'uaa.admin'
+    ]
   }
+
   ops_file = [{
     'type' => 'replace',
     'path' => '/instance_groups/name=bosh/jobs/name=uaa/properties/uaa/scim/users',
-    'value' => [],
+    'value' => []
   }]
+
   if File.file? config_file
     users_config = YAML.load_file config_file
     users_and_groups = users_config
@@ -28,7 +35,7 @@ def generate_uaa_users_ops_file(config_file, aws_account)
           'email' => email,
           'name' => email,
           'origin' => 'admin-google',
-          'groups' => groups,
+          'groups' => groups.uniq,
         }
       end
 
@@ -36,7 +43,7 @@ def generate_uaa_users_ops_file(config_file, aws_account)
   end
 end
 
-if $0 == __FILE__
+if $PROGRAM_NAME == __FILE__
   config_file = ARGV[0]
   aws_account = ARGV[1]
 

--- a/manifests/bosh-manifest/spec/generate-uaa-users-ops-file_spec.rb
+++ b/manifests/bosh-manifest/spec/generate-uaa-users-ops-file_spec.rb
@@ -59,7 +59,11 @@ RSpec.describe 'Generating UAA users ops file' do
           'email' => 'some-admin-email@digital.cabinet-office.gov.uk',
           'name' => 'some-admin-email@digital.cabinet-office.gov.uk',
           'origin' => 'admin-google',
-          'groups' => ['bosh.admin'],
+          'groups' => [
+            'bosh.admin',
+            'credhub.read', 'credhub.write',
+            'uaa.admin',
+          ],
         }],
       }])
     end


### PR DESCRIPTION
What
----

We are now using individual user identities for BOSH and Credhub access

To avoid using shared credentials, individual operators should have the power they need to administer BOSH/UAA/Credhub with identity based credentials

How to review
-------------

Code review

Who can review
--------------

@LeePorte 