### PR TITLE
[#169397386] Add node exporter

### DIFF
--- a/manifests/bosh-manifest/operations.d/600-exporters.yml
+++ b/manifests/bosh-manifest/operations.d/600-exporters.yml
@@ -1,4 +1,5 @@
 ---
+# Add a UAA client so that the bosh prometheus exporter can scrape via bosh
 - type: replace
   path: /instance_groups/name=bosh/jobs/name=uaa/properties/uaa/clients/bosh_exporter?
   value:

--- a/manifests/bosh-manifest/operations.d/600-exporters.yml
+++ b/manifests/bosh-manifest/operations.d/600-exporters.yml
@@ -1,5 +1,6 @@
 ---
 # Add a UAA client so that the bosh prometheus exporter can scrape via bosh
+
 - type: replace
   path: /instance_groups/name=bosh/jobs/name=uaa/properties/uaa/clients/bosh_exporter?
   value:
@@ -14,3 +15,20 @@
   value:
     name: bosh_exporter_password
     type: password
+
+# Add the prometheus node exporter to the bosh director vm
+
+- type: replace
+  path: /releases/-
+  value:
+    name: "node-exporter"
+    version: "4.2.0"
+    url: "https://bosh.io/d/github.com/cloudfoundry-community/node-exporter-boshrelease?v=4.2.0"
+    sha1: "b4ffebacc55fbb9934425ac792bb7179eed7e61c"
+
+- type: replace
+  path: /instance_groups/name=bosh/jobs/-
+  value:
+    name: node_exporter
+    release: node-exporter
+    properties: {}

--- a/manifests/runtime-config/runtime-config.yml
+++ b/manifests/runtime-config/runtime-config.yml
@@ -54,12 +54,29 @@ addons:
     include:
       lifecycle: service
 
+  - name: node_exporter
+    jobs:
+      - name: node_exporter
+        release: node-exporter
+    include:
+      stemcell:
+        - os: ubuntu-trusty
+        - os: ubuntu-xenial
+
 releases:
   - name: os-conf
     version: 21.0.0
     url: https://bosh.io/d/github.com/cloudfoundry/os-conf-release?v=21.0.0
     sha1: 7579a96515b265c6d828924bf4f5fae115798199
+    properties: {}
+
   - name: awslogs
     version: 0.1.1
     url: https://s3-eu-west-1.amazonaws.com/gds-paas-build-releases/awslogs-0.1.1.tgz
     sha1: dd307700e55c6c45376a5d76583243601e7559e6
+    properties: {}
+
+  - name: node-exporter
+    version: "4.2.0"
+    url: "https://bosh.io/d/github.com/cloudfoundry-community/node-exporter-boshrelease?v=4.2.0"
+    sha1: "b4ffebacc55fbb9934425ac792bb7179eed7e61c"

--- a/terraform/bosh/security_groups.tf
+++ b/terraform/bosh/security_groups.tf
@@ -65,6 +65,16 @@ resource "aws_security_group" "bosh" {
   }
 
   ingress {
+    from_port = 9100
+    to_port   = 9100
+    protocol  = "tcp"
+
+    security_groups = [
+      "${aws_security_group.bosh_api_client.id}",
+    ]
+  }
+
+  ingress {
     from_port = 25555
     to_port   = 25555
     protocol  = "tcp"


### PR DESCRIPTION
[Story](https://www.pivotaltracker.com/story/show/169397386)

What
----

Deploys the [prometheus node exporter](https://github.com/prometheus/node_exporter) as a [bosh-addon](https://github.com/bosh-prometheus/node-exporter-boshrelease) via runtime-config

Deploys the prometheus node exporter to the BOSH director (because it does not get addons)

Allows bosh-clients (Prometheus) to connect to the node exporter port (9100) on the bosh director

Refactors the ops files a bit to be more generic (node exporter + bosh exporter in one ops file)

How to review
-------------

Deploy to your development environment

SSH onto the BOSH director and check that the node exporter is running using `monit summary`

Check that the node-exporter is running on Concourse via `bosh -d concourse instances --ps`

Run your CF pipeline and check that the node-exporter is running via `bosh instances --ps`

Who can review
--------------

Not @tlwr