### PR TITLE
Use the correct encoding for pipeline pool SSH key

### DIFF
--- a/terraform/concourse/codecommit.tf
+++ b/terraform/concourse/codecommit.tf
@@ -16,6 +16,6 @@ resource "aws_iam_user_group_membership" "git_concourse_pool" {
 
 resource "aws_iam_user_ssh_key" "git" {
   username   = "${aws_iam_user.git.name}"
-  encoding   = "PEM"
+  encoding   = "SSH"
   public_key = "${var.git_rsa_id_pub}"
 }


### PR DESCRIPTION
What
----

This was incorrectly being set as PEM, which it is not as you can see from the redacted apply output, [check the real output here](https://deployer.london.cloud.service.gov.uk/teams/main/pipelines/create-bosh-concourse/jobs/concourse-terraform/builds/13)

```
aws_iam_user_ssh_key.git: Creating...
  encoding:          "" => "PEM"
  fingerprint:       "" => "<computed>"
  public_key:        "" => "ssh-rsa 0000000000000000000000000000000000000000000000000000000/0000000000000000000000000000000000000000000000000000000000000000000000000000000/000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000/00/000000000000000000000000000000000000000000000000000000000000000000000000000000000/000/00000000000000000/00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000== 0000@000000000000000000000000000000000000"
  ssh_public_key_id: "" => "<computed>"
  status:            "" => "<computed>"
  username:          "" => "git-prod-lon"
aws_iam_user_ssh_key.git: Creation complete after 1s (ID: 00000000000000000000)
```

Setting it to SSH will stop the key getting recreated because the encoding is magically reset by AWS

How to review
-------------

Do code review

Check that two consecutive runs of the `create-bosh-concourse` pipeline do not recreate the key:
- [first](https://deployer.london.cloud.service.gov.uk/teams/main/pipelines/create-bosh-concourse/jobs/concourse-terraform/builds/12)
- [second](https://deployer.london.cloud.service.gov.uk/teams/main/pipelines/create-bosh-concourse/jobs/concourse-terraform/builds/13)

Who can review
--------------

Not @tlwr