### PR TITLE
[#171404935] Bump Xenial stemcell version to 621.57

### DIFF
--- a/manifests/bosh-manifest/operations.d/030-set-stemcell.yml
+++ b/manifests/bosh-manifest/operations.d/030-set-stemcell.yml
@@ -2,5 +2,5 @@
 - type: replace
   path: /resource_pools/name=vms/stemcell
   value:
-    url: https://bosh.io/d/stemcells/bosh-aws-xen-hvm-ubuntu-xenial-go_agent?v=621.55
-    sha1: b699fdce479c823378053f05e3611c3c26b4e63e
+    url: https://bosh.io/d/stemcells/bosh-aws-xen-hvm-ubuntu-xenial-go_agent?v=621.57
+    sha1: 274da7463ed4784af230b8d3d534139125554cf8

--- a/manifests/concourse-manifest/concourse-base.yml
+++ b/manifests/concourse-manifest/concourse-base.yml
@@ -2,7 +2,7 @@
 meta:
   stemcell:
     name: bosh-aws-xen-hvm-ubuntu-xenial-go_agent
-    version: "621.55"
+    version: "621.57"
 
 name: concourse
 


### PR DESCRIPTION
What
----
Bumping to match the version bump that's happening as part of [upgrading from
cf-deployment v12.29.0 to v12.33.0](https://github.com/alphagov/paas-cf/pull/2264)

How to review
-------------
1. Code review
2. Check it ran down [my pipeline](https://deployer.andyhunt.dev.cloudpipeline.digital/teams/main/pipelines/create-bosh-concourse) OK

Who can review
--------------
Anyone