### PR TITLE
[#171787442] Bosh access UAA via ALB

### DIFF
--- a/concourse/pipelines/destroy-bosh-concourse.yml
+++ b/concourse/pipelines/destroy-bosh-concourse.yml
@@ -76,6 +76,37 @@ resources:
       region_name: ((aws_region))
       versioned_file: bosh.tfstate
 
+  - name: bootstrap-cyber-tfvars
+    type: s3-iam
+    source:
+      bucket: ((state_bucket))
+      region_name: ((aws_region))
+      versioned_file: bootstrap-cyber.tfvars
+      initial_version: "-"
+      initial_content_text: ""
+
+  - name: bootstrap-cyber-tfstate
+    type: s3-iam
+    source:
+      bucket: ((state_bucket))
+      versioned_file: bootstrap-cyber.tfstate
+      region_name: ((aws_region))
+      initial_version: "-"
+      initial_content_text: |
+        {
+            "version": 1,
+            "serial": 0,
+            "modules": [
+                {
+                    "path": [
+                        "root"
+                    ],
+                    "outputs": {},
+                    "resources": {}
+                }
+            ]
+        }
+
   - name: bosh-secrets
     type: s3-iam
     source:
@@ -161,6 +192,7 @@ jobs:
         - get: paas-bootstrap
         - get: vpc-tfstate
         - get: bosh-tfstate
+        - get: bootstrap-cyber-tfvars
 
       - task: vpc-terraform-outputs-to-sh
         config:
@@ -190,6 +222,7 @@ jobs:
             - name: paas-bootstrap
             - name: vpc-terraform-outputs
             - name: bosh-tfstate
+            - name: bootstrap-cyber-tfvars
           outputs:
             - name: updated-bosh-tfstate
           params:
@@ -219,6 +252,7 @@ jobs:
                 -state=updated-bosh-tfstate/bosh.tfstate \
                 -var-file="paas-bootstrap/terraform/((aws_account)).tfvars" \
                 -var-file="paas-bootstrap/terraform/((aws_region)).tfvars" \
+                -var-file="bootstrap-cyber-tfvars/bootstrap-cyber.tfvars" \
                 paas-bootstrap/terraform/bosh
         ensure:
           put: bosh-tfstate
@@ -353,6 +387,7 @@ jobs:
         - get: bosh-manifest
         - get: vpc-tfstate
         - get: bosh-tfstate
+        - get: bootstrap-cyber-tfvars
         - get: bosh-CA-crt
         - get: ssh-private-key
 
@@ -496,6 +531,7 @@ jobs:
             - name: paas-bootstrap
             - name: terraform-variables
             - name: bosh-tfstate
+            - name: bootstrap-cyber-tfvars
           outputs:
             - name: updated-bosh-tfstate
           params:
@@ -525,6 +561,7 @@ jobs:
                   -var env="((deploy_env))" \
                   -var-file="paas-bootstrap/terraform/((aws_account)).tfvars" \
                   -var-file="paas-bootstrap/terraform/((aws_region)).tfvars" \
+                  -var-file="bootstrap-cyber-tfvars/bootstrap-cyber.tfvars" \
                   -state=updated-bosh-tfstate/bosh.tfstate \
                   paas-bootstrap/terraform/bosh
         ensure:
@@ -573,16 +610,61 @@ jobs:
           params:
             file: updated-vpc-tfstate/vpc.tfstate
 
+  - name: destroy-cyber
+    serial: true
+    plan:
+      - in_parallel:
+        - get: paas-bootstrap
+          passed: ['destroy-bosh']
+        - get: bootstrap-cyber-tfstate
+        - get: bootstrap-cyber-tfvars
+        - get: pipeline-trigger
+          trigger: true
+          passed: ['destroy-bosh']
+
+      - task: tf-destroy-cyber
+        config:
+          platform: linux
+          image_resource: *terraform-image-resource
+          params:
+              TF_VAR_env: ((deploy_env))
+              AWS_DEFAULT_REGION: ((aws_region))
+          inputs:
+            - name: paas-bootstrap
+            - name: bootstrap-cyber-tfstate
+            - name: bootstrap-cyber-tfvars
+          outputs:
+            - name: updated-bootstrap-cyber-tfstate
+          run:
+            path: sh
+            args:
+            - -e
+            - -c
+            - |
+              cp bootstrap-cyber-tfstate/bootstrap-cyber.tfstate updated-bootstrap-cyber-tfstate/bootstrap-cyber.tfstate
+              terraform init paas-bootstrap/terraform/cyber
+              terraform destroy -force \
+                -var-file="paas-bootstrap/terraform/((aws_account)).tfvars" \
+                -var-file="paas-bootstrap/terraform/((aws_region)).tfvars" \
+                -var-file="bootstrap-cyber-tfvars/bootstrap-cyber.tfvars" \
+                -state=updated-bootstrap-cyber-tfstate/bootstrap-cyber.tfstate \
+                paas-bootstrap/terraform/cyber
+        ensure:
+          put: bootstrap-cyber-tfstate
+          params:
+            file: updated-bootstrap-cyber-tfstate/bootstrap-cyber.tfstate
+
+
   - name: destroy-init-bucket
     serial: true
     plan:
       - in_parallel:
         - get: paas-bootstrap
-          passed: ['destroy-vpc']
+          passed: ['destroy-vpc', 'destroy-cyber']
         - get: bucket-terraform-state
         - get: pipeline-trigger
           trigger: true
-          passed: ['destroy-vpc']
+          passed: ['destroy-vpc', 'destroy-cyber']
 
       - task: tf-destroy-init-bucket
         config:

--- a/manifests/bosh-manifest/operations.d/201-uaa.yml
+++ b/manifests/bosh-manifest/operations.d/201-uaa.yml
@@ -6,6 +6,7 @@
   value:
     - "https://((bosh_fqdn)):8443"
     - "https://((bosh_fqdn_external)):8443"
+    - "https://((bosh_uaa_fqdn_external))"
 
 - type: replace
   path: /instance_groups/name=bosh/jobs/name=uaa/properties/uaa/url
@@ -20,8 +21,12 @@
   value: ((bosh_fqdn_external))
 
 - type: replace
+  path: /instance_groups/name=bosh/jobs/name=uaa/properties/uaa/zones/internal/hostnames/-
+  value: ((bosh_uaa_fqdn_external))
+
+- type: replace
   path: /instance_groups/name=bosh/jobs/name=uaa/properties/login/links?/homeRedirect
-  value: "https://((bosh_fqdn_external)):8443/passcode"
+  value: "https://((bosh_uaa_fqdn_external))/passcode"
 
 - type: replace
   path: /instance_groups/name=bosh/jobs/name=uaa/properties/uaadb
@@ -65,7 +70,7 @@
     tokenUrl: https://www.googleapis.com/oauth2/v4/token
     tokenKeyUrl: https://www.googleapis.com/oauth2/v3/certs
     issuer: https://accounts.google.com
-    redirectUrl: https://((bosh_fqdn_external)):8443
+    redirectUrl: https://((bosh_uaa_fqdn_external))
     scopes:
       - openid
       - profile

--- a/manifests/bosh-manifest/scripts/generate-manifest.sh
+++ b/manifests/bosh-manifest/scripts/generate-manifest.sh
@@ -43,8 +43,9 @@ director_name: ${DEPLOY_ENV}
 deploy_env: ${DEPLOY_ENV}
 system_domain: ${SYSTEM_DNS_ZONE_NAME}
 aws_account: ${AWS_ACCOUNT}
-bosh_fqdn: ${BOSH_FQDN}
-bosh_fqdn_external: ${BOSH_FQDN_EXTERNAL}
+bosh_fqdn: bosh.${SYSTEM_DNS_ZONE_NAME}
+bosh_fqdn_external: bosh-external.${SYSTEM_DNS_ZONE_NAME}
+bosh_uaa_fqdn_external: bosh-uaa-external.${SYSTEM_DNS_ZONE_NAME}
 
 iam_instance_profile: ${BOSH_INSTANCE_PROFILE}
 

--- a/scripts/bosh-cli.sh
+++ b/scripts/bosh-cli.sh
@@ -41,7 +41,7 @@ echo "
    '---'  '---' '----' '--' '--'
   1. Run 'bosh login'
   2. Skip entering a username and password
-  3. Enter the passcode from https://bosh-external.${SYSTEM_DNS_ZONE_NAME}:8443/passcode
+  3. Enter the passcode from https://bosh-uaa-external.${SYSTEM_DNS_ZONE_NAME}/passcode
 "
 
 PS1="BOSH ($DEPLOY_ENV) $ " bash --login --norc --noprofile

--- a/terraform/bosh/acm.tf
+++ b/terraform/bosh/acm.tf
@@ -1,0 +1,39 @@
+resource "aws_acm_certificate" "bosh" {
+  domain_name = "bosh-external.${var.system_dns_zone_name}"
+
+  subject_alternative_names = [
+    "uaa-external.${var.system_dns_zone_name}",
+  ]
+
+  validation_method = "DNS"
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+resource "aws_route53_record" "bosh_cert_validation" {
+  count   = "${length(aws_acm_certificate.bosh.domain_validation_options)}"
+  zone_id = "${var.system_dns_zone_id}"
+  ttl     = 60
+
+  name = "${lookup(
+    aws_acm_certificate.bosh.domain_validation_options[count.index],
+    "resource_record_name"
+  )}"
+
+  type = "${lookup(
+    aws_acm_certificate.bosh.domain_validation_options[count.index],
+    "resource_record_type"
+  )}"
+
+  records = ["${lookup(
+    aws_acm_certificate.bosh.domain_validation_options[count.index],
+    "resource_record_value"
+  )}"]
+}
+
+resource "aws_acm_certificate_validation" "bosh" {
+  certificate_arn         = "${aws_acm_certificate.bosh.arn}"
+  validation_record_fqdns = ["${aws_route53_record.bosh_cert_validation.*.fqdn}"]
+}

--- a/terraform/bosh/acm.tf
+++ b/terraform/bosh/acm.tf
@@ -1,9 +1,18 @@
+locals {
+  bosh_lb_domains = [
+    "bosh-external.${var.system_dns_zone_name}",
+    "bosh-uaa-external.${var.system_dns_zone_name}",
+  ]
+
+  bosh_lb_domain_name = "${element(local.bosh_lb_domains, 0)}"
+
+  bosh_lb_sans = ["${slice(local.bosh_lb_domains, 1, length(local.bosh_lb_domains))}"]
+}
+
 resource "aws_acm_certificate" "bosh" {
   domain_name = "bosh-external.${var.system_dns_zone_name}"
 
-  subject_alternative_names = [
-    "uaa-external.${var.system_dns_zone_name}",
-  ]
+  subject_alternative_names = ["${local.bosh_lb_sans}"]
 
   validation_method = "DNS"
 
@@ -13,7 +22,7 @@ resource "aws_acm_certificate" "bosh" {
 }
 
 resource "aws_route53_record" "bosh_cert_validation" {
-  count   = "${length(aws_acm_certificate.bosh.domain_validation_options)}"
+  count   = "${length(local.bosh_lb_domains)}"
   zone_id = "${var.system_dns_zone_id}"
   ttl     = 60
 
@@ -31,6 +40,8 @@ resource "aws_route53_record" "bosh_cert_validation" {
     aws_acm_certificate.bosh.domain_validation_options[count.index],
     "resource_record_value"
   )}"]
+
+  depends_on = ["aws_acm_certificate.bosh"]
 }
 
 resource "aws_acm_certificate_validation" "bosh" {

--- a/terraform/bosh/lb.tf
+++ b/terraform/bosh/lb.tf
@@ -1,0 +1,98 @@
+resource "aws_security_group" "bosh_lb" {
+  name        = "${var.env}-bosh-lb"
+  description = "BOSH LB security group"
+  vpc_id      = "${var.vpc_id}"
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  ingress {
+    from_port   = 443
+    to_port     = 443
+    protocol    = "tcp"
+    cidr_blocks = ["${var.admin_cidrs}"]
+  }
+
+  tags {
+    Name = "${var.env}-bosh-lb"
+  }
+}
+
+resource "aws_lb" "bosh" {
+  name               = "${var.env}-bosh"
+  idle_timeout       = 600
+  load_balancer_type = "application"
+
+  subnets = ["${split(",", var.infra_subnet_ids)}"]
+
+  security_groups = [
+    "${aws_security_group.bosh_api_client.id}",
+    "${aws_security_group.bosh_lb.id}",
+  ]
+
+  tags {
+    Name = "${var.env}-bosh-lb"
+  }
+}
+
+resource "aws_lb_listener" "bosh_tls" {
+  load_balancer_arn = "${aws_lb.bosh.arn}"
+  port              = "443"
+  protocol          = "HTTPS"
+  ssl_policy        = "ELBSecurityPolicy-TLS-1-2-2017-01"
+  certificate_arn   = "${aws_acm_certificate.bosh.arn}"
+
+  default_action {
+    type = "fixed-response"
+
+    fixed_response {
+      content_type = "text/plain"
+      message_body = "Target not found"
+      status_code  = "404"
+    }
+  }
+}
+
+resource "aws_lb_target_group" "bosh_uaa" {
+  name        = "${var.env}-bosh-uaa"
+  port        = 8443
+  protocol    = "HTTPS"
+  target_type = "ip"
+  vpc_id      = "${var.vpc_id}"
+}
+
+resource "aws_lb_target_group_attachment" "bosh_uaa_bosh_static" {
+  target_group_arn = "${aws_lb_target_group.bosh_uaa.arn}"
+  target_id        = "${var.microbosh_static_private_ip}"
+}
+
+resource "aws_lb_listener_rule" "bosh_uaa" {
+  listener_arn = "${aws_lb_listener.bosh_tls.arn}"
+  priority     = 100
+
+  action {
+    type             = "forward"
+    target_group_arn = "${aws_lb_target_group.bosh_uaa.arn}"
+  }
+
+  condition {
+    field  = "host-header"
+    values = ["bosh-uaa-external.${var.system_dns_zone_name}"]
+  }
+}
+
+resource "aws_route53_record" "bosh_uaa_external" {
+  zone_id = "${var.system_dns_zone_id}"
+  name    = "bosh-uaa-external.${var.system_dns_zone_name}"
+  type    = "A"
+
+  alias {
+    name                   = "${aws_lb.bosh.dns_name}"
+    zone_id                = "${aws_lb.bosh.zone_id}"
+    evaluate_target_health = false
+  }
+}


### PR DESCRIPTION
[Story](https://www.pivotaltracker.com/n/projects/1275640/stories/171787442)

What
----

Adds an ALB in front of UAA running on the BOSH director so we can access UAA using a publicly valid certificate

ALB is admin CIDR restricted

UAA is addressable on `bosh-uaa-external.((system_domain))` so it is obvious that it is external, and related to BOSH.

Fixup the `destroy-bosh-cloudfoundry` pipeline to include cyber terraform, so that it works.

Gotchas
----

- [this issue about terraform AWS](https://github.com/terraform-providers/terraform-provider-aws/issues/7617) is mentioned in the story that allegedly prevents the attachment of an IP to a target group, I did not encounter this when testing
- In the UAA section of the BOSH manifest, UAA needs to know its external URL. The director SHOULD NOT know about UAA's external URL

How to review
-------------

Code review

`make dev bosh-cli DEPLOY_ENV=tlwr`

`echo | openssl s_client -connect deployer.tlwr.dev.cloudpipeline.digital:443 | openssl x509 -issuer -noout` should only list AWS related certs

`make dev bosh-cli` should print the correct URL in the prelude

Try it in your dev env

Who can review
--------------

Not @tlwr