### PR TITLE
[SUPPORT] Modify vagrant deploy to work with linux

### DIFF
--- a/vagrant/deploy.sh
+++ b/vagrant/deploy.sh
@@ -39,13 +39,9 @@ fi
 
 vagrant up
 
-# Try to start a SSH tunnel to localhost
 echo "Setting up SSH tunnel to concourse..."
-if ! ( [ -a .vagrant/tunnel-ctrl-socket ] && \
-  vagrant ssh -- -S .vagrant/tunnel-ctrl-socket -O check ); then
-  vagrant ssh -- -L 8080:127.0.0.1:8080 -fN \
-    -M -S .vagrant/tunnel-ctrl-socket -o "ExitOnForwardFailure yes"
-fi
+
+vagrant ssh -- -L 8080:127.0.0.1:8080 -fN
 
 timeout=180
 deadline=$(($(date +%s) + timeout))


### PR DESCRIPTION
What
----

We have been using connection sharing options on the vagrant ssh command
that make no real sense in the usage context of the bootstrap. So in
order to make things work for both linux and darwin let's get rid of
them.

How to review
-------------

Code review and spin up a bootstrap to check if it works

Who can review
--------------

@tlwr has already tested
