### PR TITLE
Upgrade concourse to 6.2

### DIFF
--- a/manifests/concourse-manifest/concourse-base.yml
+++ b/manifests/concourse-manifest/concourse-base.yml
@@ -16,9 +16,9 @@ stemcells:
 # relevant tag of https://github.com/concourse/concourse-bosh-deployment
 releases:
   - name: "concourse"
-    version: "6.1.0"
-    url: "https://bosh.io/d/github.com/concourse/concourse-bosh-release?v=6.1.0"
-    sha1: "8b30905b6295a94c2a8e85fea18d708edb38d3bc"
+    version: "6.2.0"
+    url: "https://bosh.io/d/github.com/concourse/concourse-bosh-release?v=6.2.0"
+    sha1: "3c59cac5d5faae5f058fafaa1b501c34b084adba"
   - name: "bpm"
     version: "1.1.8"
     url: "https://bosh.io/d/github.com/cloudfoundry/bpm-release?v=1.1.8"


### PR DESCRIPTION
What
----

Bump to 6.2

Fixes https://github.com/concourse/concourse/releases/tag/v6.2.0#5485

How to review
-------------

Check [my pipeline has run with 6.2](https://deployer.tlwr.dev.cloudpipeline.digital/teams/main/pipelines/create-bosh-concourse/jobs/expunge-concourse/builds/14)

Check [the release notes](https://github.com/concourse/concourse/releases/tag/v6.2.0)

Who can review
--------------

Not @tlwr
