### PR TITLE
Upgrade concourse to 6.3

### DIFF
--- a/manifests/concourse-manifest/concourse-base.yml
+++ b/manifests/concourse-manifest/concourse-base.yml
@@ -16,9 +16,9 @@ stemcells:
 # relevant tag of https://github.com/concourse/concourse-bosh-deployment
 releases:
   - name: "concourse"
-    version: "6.2.0"
-    url: "https://bosh.io/d/github.com/concourse/concourse-bosh-release?v=6.2.0"
-    sha1: "3c59cac5d5faae5f058fafaa1b501c34b084adba"
+    version: "6.3.0"
+    url: "https://bosh.io/d/github.com/concourse/concourse-bosh-release?v=6.3.0"
+    sha1: "6a75118c6d295476f1619a7befa0d4ff0dc58602"
   - name: "bpm"
     version: "1.1.8"
     url: "https://bosh.io/d/github.com/cloudfoundry/bpm-release?v=1.1.8"

--- a/vagrant/docker-compose.yml
+++ b/vagrant/docker-compose.yml
@@ -10,7 +10,7 @@ services:
     - PGDATA=/database
 
   concourse-web:
-    image: concourse/concourse:6.1.0
+    image: concourse/concourse:6.3.0
     command: web
     privileged: true
     depends_on: [concourse-db]
@@ -32,7 +32,7 @@ services:
     - CONCOURSE_SESSION_SIGNING_KEY=/keys/session_signing_key
 
   concourse-worker-colocated:
-    image: concourse/concourse:6.1.0
+    image: concourse/concourse:6.3.0
     command: worker
     privileged: true
     depends_on: [concourse-db, concourse-web]


### PR DESCRIPTION
What
----

We should keep up to date with our tools.

Changes in this version;
* Rate limiting has been introduced on resourse checking.
* Error message is printed when starting a build with a version that
does not exist
* Bug fix on task cache being garbage collected on a set pipeline
* Job Scheduler checks if a version exists whist determining the next
job build imputs

How to review
-------------

Code review
Check https://deployer.leeporte.dev.cloudpipeline.digital/

Who can review
--------------

Anyone
