### PR TITLE
Shrink deployer-concourse to m5.large in dev

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -91,6 +91,7 @@ dev: globals check-env-vars ## Set Environment to DEV
 	$(eval export SKIP_COMMIT_VERIFICATION=true)
 	$(eval export AWS_DEFAULT_REGION ?= eu-west-1)
 	$(eval export CYBER_PASSWORD_STORE_DIR?=${HOME}/.paas-pass)
+	$(eval export CONCOURSE_INSTANCE_TYPE=m5.large)
 
 .PHONY: ci
 ci: globals check-env-vars ## Set Environment to CI
@@ -165,7 +166,7 @@ deployer-concourse: ## Setup profiles for deploying a paas-cf deployer concourse
 	$(eval export BOSH_INSTANCE_PROFILE=bosh-director-cf)
 	$(eval export CONCOURSE_TYPE=deployer-concourse)
 	$(eval export CONCOURSE_HOSTNAME=deployer)
-	$(eval export CONCOURSE_INSTANCE_TYPE=m5.xlarge)
+	$(eval export CONCOURSE_INSTANCE_TYPE ?= m5.xlarge)
 	$(eval export CONCOURSE_INSTANCE_PROFILE=deployer-concourse)
 	$(eval export CONCOURSE_WORKER_INSTANCES ?= 1)
 	@true


### PR DESCRIPTION
Each team member runs an always-on deployer concourse consisting of a
web node and a worker node, each of which is an m5.xlarge instance.
If each m5.xlarge costs $0.222/hour (current london price; ireland is
slightly cheaper), this corresponds to an on-demand cost of
$0.222×2×24×30 = $319.68 per 30-day month, per developer concourse.

By shrinking the instance size to m5.large we could save half of this
cost.

What
----

Describe what you have changed and why.

How to review
-------------

Describe the steps required to test the changes.

Who can review
--------------

Describe who can review the changes. Or more importantly, list the people
that can't review, because they worked on it.
