### PR TITLE
AWS CPI supports spot with tags

### DIFF
--- a/manifests/bosh-manifest/operations.d/110-hm.yml
+++ b/manifests/bosh-manifest/operations.d/110-hm.yml
@@ -1,8 +1,0 @@
----
-- type: remove
-  path: /instance_groups/name=bosh/properties/hm/director_account/password
-- type: remove
-  path: /instance_groups/name=bosh/properties/hm/director_account/user
-- type: replace
-  path: /instance_groups/name=bosh/properties/hm/resurrector_enabled
-  value: false

--- a/manifests/bosh-manifest/operations.d/120-cpi.yml
+++ b/manifests/bosh-manifest/operations.d/120-cpi.yml
@@ -5,9 +5,7 @@
 - path: /releases/name=bosh-aws-cpi
   type: replace
   value:
-    # github.com/cloudfoundry/bosh-aws-cpi-release
-    # commit d6a07a46e3a0d1f4df673547cd4bb6e817512e3f
     name: bosh-aws-cpi
-    version: 0.1.6
-    url: https://s3-eu-west-1.amazonaws.com/gds-paas-build-releases/bosh-aws-cpi-0.1.6.tgz
-    sha1: 756cc1fea637d4401152b6c3df0ee912d0495b62
+    version: "83"
+    url: "https://bosh.io/d/github.com/cloudfoundry/bosh-aws-cpi-release?v=83"
+    sha1: "cabcdf15846adabe2000fe892314a3a2f72c9177"

--- a/manifests/bosh-manifest/operations.d/120-cpi.yml
+++ b/manifests/bosh-manifest/operations.d/120-cpi.yml
@@ -1,3 +1,13 @@
 - type: replace
   path: /instance_groups/name=bosh/properties/aws/max_retries?
   value: 16
+
+- path: /releases/name=bosh-aws-cpi
+  type: replace
+  value:
+    # github.com/cloudfoundry/bosh-aws-cpi-release
+    # commit d6a07a46e3a0d1f4df673547cd4bb6e817512e3f
+    name: bosh-aws-cpi
+    version: 0.1.6
+    url: https://s3-eu-west-1.amazonaws.com/gds-paas-build-releases/bosh-aws-cpi-0.1.6.tgz
+    sha1: 756cc1fea637d4401152b6c3df0ee912d0495b62

--- a/manifests/bosh-manifest/spec/properties_spec.rb
+++ b/manifests/bosh-manifest/spec/properties_spec.rb
@@ -3,8 +3,8 @@ RSpec.describe "manifest properties validations" do
   let(:bosh_instance_group) { manifest.fetch("instance_groups").select { |x| x["name"] == "bosh" }.first }
   let(:bosh_properties) { bosh_instance_group.fetch("properties") }
 
-  it "disables the health manager resurrector" do
-    expect(bosh_properties["hm"]["resurrector_enabled"]).to eq(false)
+  it "enables the health manager resurrector" do
+    expect(bosh_properties["hm"]["resurrector_enabled"]).to eq(true)
   end
 
   it "sets the bosh director name to the value of DEPLOY_ENV" do


### PR DESCRIPTION
What
----

Use AWS CPI release v82 with changes from https://github.com/cloudfoundry/bosh-aws-cpi-release/pull/105 (v83 does not exist yet). This is so we can continue to tag our instances

Enable (do not disable) the BOSH resurrector, so that if our spot instances go away, they will be resurrected

How to review
-------------

Deploy to your development environment

Who can review
--------------

Not @tlwr
