### PR TITLE
CredHub uses default_ca

### DIFF
--- a/concourse/pipelines/create-bosh-concourse.yml
+++ b/concourse/pipelines/create-bosh-concourse.yml
@@ -1537,11 +1537,9 @@ jobs:
               export BOSH_CLIENT
               export BOSH_CLIENT_SECRET
 
-              $VAL_FROM_YAML credhub_ca.certificate bosh-vars-store/bosh-vars-store.yml > credhub-ca-cert.yml
-
               bosh deploy concourse-manifest/concourse-manifest.yml \
                    -v "concourse_worker_instances=$CONCOURSE_WORKER_INSTANCES" \
-                   --var-file=credhub_ca_cert=credhub-ca-cert.yml
+                   --var-file=credhub_ca_cert=bosh-CA-crt/bosh-CA.crt
 
   - name: post-deploy
     serial: true
@@ -1599,7 +1597,7 @@ jobs:
                 CREDHUB_CLIENT_SECRET=$($VAL_FROM_YAML secrets.bosh_credhub_admin_client_password bosh-secrets/bosh-secrets.yml)
 
                 CREDHUB_CA_CERT="$(cat <<EOCERT
-                $($VAL_FROM_YAML credhub_ca.ca bosh-vars-store/bosh-vars-store.yml)
+                $($VAL_FROM_YAML credhub_tls.ca bosh-vars-store/bosh-vars-store.yml)
                 $($VAL_FROM_YAML uaa_ssl.ca bosh-vars-store/bosh-vars-store.yml)
                 EOCERT
                 )"
@@ -1693,7 +1691,7 @@ jobs:
               VCAP_PASSWORD=$($VAL_FROM_YAML secrets.vcap_password bosh-secrets/bosh-secrets.yml)
 
               CREDHUB_CA_CERT="$(cat <<EOCERT
-              $($VAL_FROM_YAML credhub_ca.ca bosh-vars-store/bosh-vars-store.yml)
+              $($VAL_FROM_YAML credhub_tls.ca bosh-vars-store/bosh-vars-store.yml)
               $($VAL_FROM_YAML uaa_ssl.ca bosh-vars-store/bosh-vars-store.yml)
               EOCERT
               )"

--- a/manifests/bosh-manifest/scripts/cleanup-bosh-vars-store.rb
+++ b/manifests/bosh-manifest/scripts/cleanup-bosh-vars-store.rb
@@ -90,6 +90,9 @@ end
 contents.delete("blobstore_ca") if contents.key? "blobstore_ca"
 contents.delete("blobstore_server_tls") if contents.key? "blobstore_server_tls"
 
+contents.delete("credhub_ca") if contents.key? "credhub_ca"
+contents.delete("credhub_tls") if contents.key? "credhub_tls"
+
 puts "New variable names: #{contents.keys}"
 
 puts "Writing file #{filename}"

--- a/manifests/bosh-manifest/scripts/generate-manifest.sh
+++ b/manifests/bosh-manifest/scripts/generate-manifest.sh
@@ -96,6 +96,11 @@ nats_ca:
   certificate: ((default_ca.certificate))
   private_key: ((default_ca.private_key))
 
+credhub_ca:
+  ca: ((default_ca.certificate))
+  certificate: ((default_ca.certificate))
+  private_key: ((default_ca.private_key))
+
 vcap_password: ((secrets.vcap_password))
 bosh_credhub_admin_client_password: ((secrets.bosh_credhub_admin_client_password))
 

--- a/manifests/bosh-manifest/spec/variables_spec.rb
+++ b/manifests/bosh-manifest/spec/variables_spec.rb
@@ -1,0 +1,9 @@
+RSpec.describe "variables validations" do
+  let(:manifest) { manifest_with_defaults }
+  let(:vars) { manifest["variables"] }
+  let(:certs) { vars.select { |v| v["type"] == "certificate" } }
+
+  it "generates no certificates" do
+    expect(certs).to be_empty
+  end
+end


### PR DESCRIPTION
What
----

We have a certificate rotation process for BOSH which relies on how we use `bosh-vars-store.yml`.
We have a convention that mbus/bosh/uaa use `default_ca` which is generated inside the Concourse pipeline.

This PR:
- makes Credhub follow the convention of using `default_ca` (so our certificate rotation still works)
- adds a test so that this mistake does not happen in future

When deploying this PR, it will prevent Concourse from talking to CredHub until Concourse gets redeployed (via the pipeline), which means smoke tests will not run for the duration of `deploy-bosh` and `deploy-concourse`.

How to review
-------------

Code review

Deploy to your dev env

Who can review
--------------

Not @tlwr
