### PR TITLE
Try to fix Cyber CSLS Kinesis Destination ARN

### DIFF
--- a/manifests/bosh-manifest/scripts/generate-manifest.sh
+++ b/manifests/bosh-manifest/scripts/generate-manifest.sh
@@ -103,6 +103,7 @@ admin_google_oauth_client_id: ((admin_google_oauth_client_id))
 admin_google_oauth_client_secret: ((admin_google_oauth_client_secret))
 
 bosh_auditor_splunk_hec_token: ((bosh_auditor_splunk_hec_token))
+csls_kinesis_destination_arn: ((csls_kinesis_destination_arn))
 EOF
 
 

--- a/manifests/bosh-manifest/spec/support/manifest_helpers.rb
+++ b/manifests/bosh-manifest/spec/support/manifest_helpers.rb
@@ -66,6 +66,7 @@ private
     generate_cyber_secrets_fixture(
       "#{workdir}/bosh-cyber-secrets",
       "aaaa-splunk-hec-token",
+      "aaa-csls-kinesis-destination-arn",
     )
     generate_uaa_users_fixture("#{workdir}/uaa-users-ops-file")
     generate_unix_users_fixture("#{workdir}/unix-users-ops-file")

--- a/manifests/shared/spec/support/fixture_helpers.rb
+++ b/manifests/shared/spec/support/fixture_helpers.rb
@@ -36,11 +36,12 @@ module FixtureHelpers
     end
   end
 
-  def generate_cyber_secrets_fixture(target_dir, bosh_auditor_splunk_hec_token)
+  def generate_cyber_secrets_fixture(target_dir, bosh_auditor_splunk_hec_token, csls_kinesis_destination_arn)
     FileUtils.mkdir(target_dir) unless Dir.exist?(target_dir)
     File.open("#{target_dir}/bosh-cyber-secrets.yml", "w") do |file|
       file.write({
         "bosh_auditor_splunk_hec_token" => bosh_auditor_splunk_hec_token,
+        "csls_kinesis_destination_arn" => csls_kinesis_destination_arn,
       }.to_yaml)
     end
   end

--- a/scripts/upload-secrets/upload-cyber-secrets.sh
+++ b/scripts/upload-secrets/upload-cyber-secrets.sh
@@ -7,5 +7,5 @@ export PASSWORD_STORE_DIR=${CYBER_PASSWORD_STORE_DIR}
 cat <<EOF | aws s3 cp - "s3://gds-paas-${DEPLOY_ENV}-state/bosh-cyber-secrets.yml"
 ---
 bosh_auditor_splunk_hec_token: "${BOSH_AUDITOR_SPLUNK_HEC_TOKEN:-"$(pass "splunk/${MAKEFILE_ENV_TARGET}/hec_token")"}"
+csls_kinesis_destination_arn: "${CSLS_KINESIS_DESTINATION_ARN:-"$(pass "cyber/${MAKEFILE_ENV_TARGET}/csls_kinesis_destination_arn")"}"
 EOF
-


### PR DESCRIPTION
What
----

I'm trying to reset (destroy + recreate) my dev env. Running Terraform from the bootstrap Concourse is failing with:

```
Error: Required variable not set: csls_kinesis_destination_arn
```

That `csls_kinesis_destination_arn` secret was not being uploaded anywhere in `paas-bootstrap`. Meanwhile, `paas-cf` only uploads it to Credhub, which doesn't exist at bootstrap time.

This commit gets `paas-bootstrap` to upload `csls_kinesis_destination_arn` to S3 to fix the problem.

How to review
-------------

Code review. Sanity check we're OK putting this in S3.

Who can review
--------------

Not @46bit.