### PR TITLE
bosh: increase disk size

### DIFF
--- a/manifests/bosh-manifest/operations.d/030-increase-disk.yml
+++ b/manifests/bosh-manifest/operations.d/030-increase-disk.yml
@@ -1,0 +1,4 @@
+---
+- type: replace
+  path: /disk_pools/name=disks/disk_size
+  value: 131_072

--- a/manifests/bosh-manifest/spec/manifest_validation_spec.rb
+++ b/manifests/bosh-manifest/spec/manifest_validation_spec.rb
@@ -4,6 +4,18 @@ RSpec.describe "generic manifest validations" do
   let(:bosh_instance) { instance_groups.find { |ig| ig["name"] == "bosh" } }
   let(:bosh_jobs) { bosh_instance["jobs"] }
 
+  describe "instance" do
+    it "has a big disk" do
+      disk = bosh_instance["persistent_disk_pool"]
+
+      disk_pools = manifest["disk_pools"]
+      disk_pool = disk_pools.find { |p| p["name"] == disk }
+
+      disk_size = disk_pool["disk_size"]
+      expect(disk_size).to be >= 2.pow(17), "#{disk_pool} should be bigger"
+    end
+  end
+
   describe "name uniqueness" do
     %w[
       disk_pools


### PR DESCRIPTION
What
----

Disk has run out on our london director

How to review
-------------

Code review

Check [tlwr](https://deployer.tlwr.dev.cloudpipeline.digital/teams/main/pipelines/create-bosh-concourse/jobs/bosh-deploy/builds/37)

BOSH is the MVP:
```
  Attaching disk 'vol-0c558dbeca7145294' to VM 'i-07eda34ce5a92c640'... Finished (00:00:17)
  Creating disk... Finished (00:00:09)
  Attaching disk 'vol-0d759e3140f5730c5' to VM 'i-07eda34ce5a92c640'... Finished (00:00:15)
  Migrating disk content from 'vol-0c558dbeca7145294' to 'vol-0d759e3140f5730c5'... Finished (00:00:42)
  Detaching disk 'vol-0c558dbeca7145294'... Finished (00:00:10)
  Deleting disk 'vol-0c558dbeca7145294'... Finished (00:00:05)
  Rendering job templates... Finished (00:00:16)
```

```
ssh bosh-external.tlwr.dev.cloudpipeline.digital
cd /var/vcap/store/director/tasks
ls -larthi | grep 'Jun 29' | head
7864505 drwxr-xr-x     2 vcap vcap 4.0K Jun 29 00:00 153052
6684785 drwxr-xr-x     2 vcap vcap 4.0K Jun 29 00:00 153143
8258359 drwxr-xr-x     2 vcap vcap 4.0K Jun 29 00:00 153325
6947200 drwxr-xr-x     2 vcap vcap 4.0K Jun 29 00:00 153234
6030261 drwxr-xr-x     2 vcap vcap 4.0K Jun 29 00:00 153416
7865029 drwxr-xr-x     2 vcap vcap 4.0K Jun 29 00:00 153603
7078174 drwxr-xr-x     2 vcap vcap 4.0K Jun 29 00:00 153602
6816473 drwxr-xr-x     2 vcap vcap 4.0K Jun 29 00:00 153601
7340901 drwxr-xr-x     2 vcap vcap 4.0K Jun 29 00:00 153600
7995695 drwxr-xr-x     2 vcap vcap 4.0K Jun 29 00:00 153599
```

Who can review
--------------

@paroxp 