### PR TITLE
on-board autom8 members

### DIFF
--- a/manifests/concourse-manifest/github_auth/dev_ci_additional_users.yml
+++ b/manifests/concourse-manifest/github_auth/dev_ci_additional_users.yml
@@ -14,3 +14,9 @@ instance_groups:
                   - kr8n3r
                   - poveyd
                   - barsutka
+                  - szd55gds
+                  - philandstuff
+                  - adityapahuja
+                  - Krenair
+                  - chrisfarms
+                  - blairboy362


### PR DESCRIPTION
What
----

allow autom8 members access to login to concourse with github

How to review
-------------

Verify that it's ok for these people to login to concourse

Who can review
--------------

Not @chrisfarms (nor probably any of the users listed)
