### PR TITLE
Pipeline set first in try block

### DIFF
--- a/concourse/pipelines/create-bosh-concourse.yml
+++ b/concourse/pipelines/create-bosh-concourse.yml
@@ -358,29 +358,6 @@ jobs:
       - in_parallel:
         - get: paas-bootstrap
 
-      - task: self-update-pipelines
-        tags: [colocated-with-web]
-        config:
-          platform: linux
-          image_resource: *self-update-pipelines-image-resource
-          inputs:
-            - name: paas-bootstrap
-          params:
-            DEPLOY_ENV: ((deploy_env))
-            BRANCH: ((branch_name))
-            MAKEFILE_ENV_TARGET: ((makefile_env_target))
-            AWS_DEFAULT_REGION: ((aws_region))
-            SKIP_COMMIT_VERIFICATION: ((skip_commit_verification))
-            SELF_UPDATE_PIPELINE: ((self_update_pipeline))
-            TARGET_CONCOURSE: ((target_concourse))
-            CONCOURSE_TYPE: ((concourse_type))
-            ENABLE_GITHUB: ((enable_github))
-
-            CONCOURSE_WEB_USER: admin
-            CONCOURSE_WEB_PASSWORD: ((concourse_web_password))
-          run:
-            path: ./paas-bootstrap/concourse/scripts/self-update-pipeline.sh
-
       - task: try-fetch-bucket-state
         config:
           platform: linux
@@ -484,6 +461,29 @@ jobs:
                       # If self-update-pipelines does not succeed then fail
                       # We initially always mark as failed by default
                       echo fail > self-update-pipeline-status/state.txt
+
+            - task: self-update-pipelines
+              tags: [colocated-with-web]
+              config:
+                platform: linux
+                image_resource: *self-update-pipelines-image-resource
+                inputs:
+                  - name: paas-bootstrap
+                params:
+                  DEPLOY_ENV: ((deploy_env))
+                  BRANCH: ((branch_name))
+                  MAKEFILE_ENV_TARGET: ((makefile_env_target))
+                  AWS_DEFAULT_REGION: ((aws_region))
+                  SKIP_COMMIT_VERIFICATION: ((skip_commit_verification))
+                  SELF_UPDATE_PIPELINE: ((self_update_pipeline))
+                  TARGET_CONCOURSE: ((target_concourse))
+                  CONCOURSE_TYPE: ((concourse_type))
+                  ENABLE_GITHUB: ((enable_github))
+
+                  CONCOURSE_WEB_USER: admin
+                  CONCOURSE_WEB_PASSWORD: ((concourse_web_password))
+                run:
+                  path: ./paas-bootstrap/concourse/scripts/self-update-pipeline.sh
 
             - task: mark-as-passed
               config:

--- a/concourse/pipelines/create-bosh-concourse.yml
+++ b/concourse/pipelines/create-bosh-concourse.yml
@@ -355,61 +355,7 @@ jobs:
   - name: init-bucket
     serial: true
     plan:
-      - in_parallel:
-        - get: paas-bootstrap
-
-      - task: try-fetch-bucket-state
-        config:
-          platform: linux
-          image_resource: *awscli-image-resource
-          params:
-            AWS_DEFAULT_REGION: ((aws_region))
-          inputs:
-            - name: paas-bootstrap
-          outputs:
-            - name: bucket-state
-          run:
-            path: sh
-            args:
-            - -e
-            - -u
-            - -c
-            - |
-              cd bucket-state
-              aws s3 cp "s3://((state_bucket))/bucket.tfstate" . || true
-              ls -l
-
-      - task: create-init-bucket
-        config:
-          platform: linux
-          image_resource: *terraform-image-resource
-          params:
-            TF_VAR_env: ((deploy_env))
-            TF_VAR_state_bucket: ((state_bucket))
-            AWS_DEFAULT_REGION: ((aws_region))
-          inputs:
-            - name: paas-bootstrap
-            - name: bucket-state
-          outputs:
-            - name: updated-bucket-state
-          run:
-            path: sh
-            args:
-            - -c
-            - -e
-            - |
-              [ -f bucket-state/bucket.tfstate ] && cp bucket-state/bucket.tfstate updated-bucket-state/bucket.tfstate
-              terraform init paas-bootstrap/terraform/bucket
-              terraform apply \
-                -auto-approve=true \
-                -var-file="paas-bootstrap/terraform/((aws_account)).tfvars" \
-                -var-file="paas-bootstrap/terraform/((aws_region)).tfvars" \
-                -state=updated-bucket-state/bucket.tfstate \
-                paas-bootstrap/terraform/bucket
-        on_success:
-          put: bucket-terraform-state
-          params:
-            file: updated-bucket-state/bucket.tfstate
+      - get: paas-bootstrap
 
       - try:
           on_error:
@@ -534,6 +480,59 @@ jobs:
 
                 echo 'self-update-pipeline failed'
                 exit 1
+
+      - task: try-fetch-bucket-state
+        config:
+          platform: linux
+          image_resource: *awscli-image-resource
+          params:
+            AWS_DEFAULT_REGION: ((aws_region))
+          inputs:
+            - name: paas-bootstrap
+          outputs:
+            - name: bucket-state
+          run:
+            path: sh
+            args:
+            - -e
+            - -u
+            - -c
+            - |
+              cd bucket-state
+              aws s3 cp "s3://((state_bucket))/bucket.tfstate" . || true
+              ls -l
+
+      - task: create-init-bucket
+        config:
+          platform: linux
+          image_resource: *terraform-image-resource
+          params:
+            TF_VAR_env: ((deploy_env))
+            TF_VAR_state_bucket: ((state_bucket))
+            AWS_DEFAULT_REGION: ((aws_region))
+          inputs:
+            - name: paas-bootstrap
+            - name: bucket-state
+          outputs:
+            - name: updated-bucket-state
+          run:
+            path: sh
+            args:
+            - -c
+            - -e
+            - |
+              [ -f bucket-state/bucket.tfstate ] && cp bucket-state/bucket.tfstate updated-bucket-state/bucket.tfstate
+              terraform init paas-bootstrap/terraform/bucket
+              terraform apply \
+                -auto-approve=true \
+                -var-file="paas-bootstrap/terraform/((aws_account)).tfvars" \
+                -var-file="paas-bootstrap/terraform/((aws_region)).tfvars" \
+                -state=updated-bucket-state/bucket.tfstate \
+                paas-bootstrap/terraform/bucket
+        on_success:
+          put: bucket-terraform-state
+          params:
+            file: updated-bucket-state/bucket.tfstate
 
       - put: pipeline-trigger
         params: {bump: patch}


### PR DESCRIPTION
What
----

In 2955f07 we wanted to make `set-pipeline` be the first thing that happened.

Set pipeline happens in a try block so it works in both bootstrap and regular operations

Revert 2955f07 and then move the entire try block to the start.

How to review
-------------

Bootstrap a new Concourse

Who can review
--------------

@LeePorte 