### PR TITLE
terraform: no longer attempt to migrate provider

### DIFF
--- a/concourse/pipelines/create-bosh-concourse.yml
+++ b/concourse/pipelines/create-bosh-concourse.yml
@@ -524,8 +524,6 @@ jobs:
               [ -f bucket-state/bucket.tfstate ] && cp bucket-state/bucket.tfstate updated-bucket-state/bucket.tfstate
               terraform init paas-bootstrap/terraform/bucket
 
-              sh paas-bootstrap/terraform/./update-terraform-providers.sh updated-bucket-state/bucket.tfstate
-
               terraform apply \
                 -auto-approve=true \
                 -var-file="paas-bootstrap/terraform/((aws_account)).tfvars" \
@@ -612,8 +610,6 @@ jobs:
               cp vpc-tfstate/vpc.tfstate updated-vpc-tfstate/vpc.tfstate
               terraform init paas-bootstrap/terraform/vpc
 
-              sh paas-bootstrap/terraform/./update-terraform-providers.sh updated-vpc-tfstate/vpc.tfstate
-
               terraform apply \
                 -auto-approve=true \
                 -var concourse_egress_cidr="${CONCOURSE_EGRESS_IP}/32" \
@@ -665,8 +661,6 @@ jobs:
                    updated-bootstrap-cyber-tfstate/bootstrap-cyber.tfstate
 
                 terraform init paas-bootstrap/terraform/cyber
-
-                sh paas-bootstrap/terraform/./update-terraform-providers.sh updated-bootstrap-cyber-tfstate/bootstrap-cyber.tfstate
 
                 terraform apply \
                   -auto-approve=true \
@@ -871,8 +865,6 @@ jobs:
 
                 cp bosh-tfstate/bosh.tfstate updated-bosh-tfstate/bosh.tfstate
                 terraform init paas-bootstrap/terraform/bosh
-
-                sh paas-bootstrap/terraform/./update-terraform-providers.sh updated-bosh-tfstate/bosh.tfstate
 
                 terraform apply \
                   -auto-approve=true \
@@ -1199,8 +1191,6 @@ jobs:
 
               cp concourse-tfstate/concourse.tfstate updated-concourse-tfstate/concourse.tfstate
               terraform init paas-bootstrap/terraform/concourse
-
-              sh paas-bootstrap/terraform/./update-terraform-providers.sh updated-concourse-tfstate/concourse.tfstate
 
               terraform apply \
                 -auto-approve=true \
@@ -1970,8 +1960,6 @@ jobs:
               cp vpc-tfstate/vpc.tfstate updated-vpc-tfstate/vpc.tfstate
               terraform init paas-bootstrap/terraform/vpc
 
-              sh paas-bootstrap/terraform/./update-terraform-providers.sh updated-vpc-tfstate/vpc.tfstate
-
               terraform apply \
                 -auto-approve=true \
                 -target=aws_security_group.office-access-ssh \
@@ -2016,8 +2004,6 @@ jobs:
               cp bosh-tfstate/bosh.tfstate updated-bosh-tfstate/bosh.tfstate
               terraform init paas-bootstrap/terraform/bosh
 
-              sh paas-bootstrap/terraform/./update-terraform-providers.sh updated-bosh-tfstate/bosh.tfstate
-
               terraform apply \
                 -auto-approve=true \
                 -target=aws_security_group.bosh \
@@ -2060,8 +2046,6 @@ jobs:
 
               cp concourse-tfstate/concourse.tfstate updated-concourse-tfstate/concourse.tfstate
               terraform init paas-bootstrap/terraform/concourse
-
-              sh paas-bootstrap/terraform/./update-terraform-providers.sh updated-concourse-tfstate/concourse.tfstate
 
               terraform apply \
                 -auto-approve=true \

--- a/terraform/update-terraform-providers.sh
+++ b/terraform/update-terraform-providers.sh
@@ -1,5 +1,0 @@
-#!/bin/sh
-
-terraform state replace-provider -state="$1" -auto-approve  registry.terraform.io/-/aws registry.terraform.io/hashicorp/aws
-terraform state replace-provider -state="$1" -auto-approve  registry.terraform.io/-/random registry.terraform.io/hashicorp/random
-terraform state replace-provider -state="$1" -auto-approve  registry.terraform.io/-/template registry.terraform.io/hashicorp/template


### PR DESCRIPTION
What
----

Migrating providers broke bootstrapping (initially there is no state to migrate), and now that we have migrated all the providers, we no longer need to attempt to do so:

***Before***
```
Terraform has been successfully initialized!

You may now begin working with Terraform. Try running "terraform plan" to see
any changes that are required for your infrastructure. All Terraform commands
should now work.

If you ever set or change modules or backend configuration for Terraform,
rerun this command to reinitialize your working directory. If you forget, other
commands will detect it and remind you to do so if necessary.
No state file was found!

State management commands require a state file. Run this command
in a directory where Terraform has been run or use the -state flag
to point the command to a specific state location.
No state file was found!

State management commands require a state file. Run this command
in a directory where Terraform has been run or use the -state flag
to point the command to a specific state location.
No state file was found!

State management commands require a state file. Run this command
in a directory where Terraform has been run or use the -state flag
to point the command to a specific state location.
```

_notice it never gets to an apply step_

***After***
```
Terraform has been successfully initialized!

You may now begin working with Terraform. Try running "terraform plan" to see
any changes that are required for your infrastructure. All Terraform commands
should now work.

If you ever set or change modules or backend configuration for Terraform,
rerun this command to reinitialize your working directory. If you forget, other
commands will detect it and remind you to do so if necessary.
aws_s3_bucket.terraform-state-s3: Creating...
aws_s3_bucket.terraform-state-s3: Creation complete after 1s [id=gds-paas-isoseg-state]

Warning: Value for undeclared variable

The root module does not declare a variable named
"concourse_db_maintenance_window" but a value was found in file
"paas-bootstrap/terraform/dev.tfvars". To use this value, add a "variable"
block to the configuration.

Using a variables file to set an undeclared variable is deprecated and will
become an error in a future release. If you wish to provide certain "global"
settings to all configurations in your organization, use TF_VAR_...
environment variables to set these instead.


Warning: Value for undeclared variable

The root module does not declare a variable named "bosh_db_maintenance_window"
but a value was found in file "paas-bootstrap/terraform/dev.tfvars". To use
this value, add a "variable" block to the configuration.

Using a variables file to set an undeclared variable is deprecated and will
become an error in a future release. If you wish to provide certain "global"
settings to all configurations in your organization, use TF_VAR_...
environment variables to set these instead.


Apply complete! Resources: 1 added, 0 changed, 0 destroyed.

Outputs:

bucket = gds-paas-isoseg-state
environment = isoseg
region = eu-west-2
```

How to review
-------------

Code review
