### PR TITLE
Update concourse 6.6.0

### DIFF
--- a/concourse/pipelines/concourse-lite-self-terminate.yml
+++ b/concourse/pipelines/concourse-lite-self-terminate.yml
@@ -1,3 +1,7 @@
+---
+display:
+  background_image: ((background_image_url))
+
 meta:
   containers:
     awscli: &awscli-image-resource

--- a/concourse/pipelines/create-bosh-concourse.yml
+++ b/concourse/pipelines/create-bosh-concourse.yml
@@ -1,4 +1,7 @@
 ---
+display:
+  background_image: ((background_image_url))
+
 meta:
   containers:
     awscli: &awscli-image-resource

--- a/concourse/pipelines/destroy-bosh-concourse.yml
+++ b/concourse/pipelines/destroy-bosh-concourse.yml
@@ -1,4 +1,7 @@
 ---
+display:
+  background_image: ((background_image_url))
+
 meta:
   containers:
     awscli: &awscli-image-resource

--- a/concourse/scripts/pipelines.sh
+++ b/concourse/scripts/pipelines.sh
@@ -7,6 +7,26 @@ SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)
 
 state_bucket=gds-paas-${DEPLOY_ENV}-state
 
+case $AWS_ACCOUNT in
+prod-lon)
+  # Flag of Greater London
+  BACKGROUND_IMAGE_URL="https://upload.wikimedia.org/wikipedia/commons/2/25/Flag_of_Greater_London.svg"
+  ;;
+prod)
+  # Flag of the City of Dublin
+  BACKGROUND_IMAGE_URL="https://upload.wikimedia.org/wikipedia/commons/thumb/8/8f/IRL_Dublin_flag.svg/1500px-IRL_Dublin_flag.svg.png"
+  ;;
+stg-lon)
+  # The Minack Theatre in Cornwall
+  BACKGROUND_IMAGE_URL="https://upload.wikimedia.org/wikipedia/commons/1/16/Minack_Theatre.jpg"
+  ;;
+*)
+  # A large inflatable duck
+  BACKGROUND_IMAGE_URL="https://si.wsj.net/public/resources/images/BN-EX226_duck_G_20141008024653.jpg"
+  ;;
+esac
+
+
 generate_vars_file() {
    cat <<EOF
 ---
@@ -38,6 +58,7 @@ enable_github: ${ENABLE_GITHUB}
 github_client_id: ${GITHUB_CLIENT_ID:-}
 github_client_secret: ${GITHUB_CLIENT_SECRET:-}
 concourse_auth_duration: ${CONCOURSE_AUTH_DURATION:-5m}
+background_image_url: ${BACKGROUND_IMAGE_URL}
 EOF
 }
 

--- a/manifests/concourse-manifest/concourse-base.yml
+++ b/manifests/concourse-manifest/concourse-base.yml
@@ -16,13 +16,13 @@ stemcells:
 # relevant tag of https://github.com/concourse/concourse-bosh-deployment
 releases:
   - name: "concourse"
-    version: "6.5.1"
-    url: "https://bosh.io/d/github.com/concourse/concourse-bosh-release?v=6.5.1"
-    sha1: "ffda854bcb84a3a36d83348bf4ab6d481e721ab5"
+    version: "6.6.0"
+    url: "https://bosh.io/d/github.com/concourse/concourse-bosh-release?v=6.6.0"
+    sha1: "4cac2f29591ae88fbd97539e3020ecd06a6fe4c1"
   - name: "bpm"
-    version: "1.1.8"
-    url: "https://bosh.io/d/github.com/cloudfoundry/bpm-release?v=1.1.8"
-    sha1: "c956394fce7e74f741e4ae8c256b480904ad5942"
+    version: "1.1.9"
+    url: "https://bosh.io/d/github.com/cloudfoundry/bpm-release?v=1.1.9"
+    sha1: "dcf0582d838a73de29da273552ae79ac3098ee8b"
   - name: awslogs
     version: 0.1.1
     url: https://s3-eu-west-1.amazonaws.com/gds-paas-build-releases/awslogs-0.1.1.tgz

--- a/vagrant/docker-compose.yml
+++ b/vagrant/docker-compose.yml
@@ -10,7 +10,7 @@ services:
     - PGDATA=/database
 
   concourse-web:
-    image: concourse/concourse:6.4.0
+    image: concourse/concourse:6.6.0
     command: web
     privileged: true
     depends_on: [concourse-db]
@@ -32,7 +32,7 @@ services:
     - CONCOURSE_SESSION_SIGNING_KEY=/keys/session_signing_key
 
   concourse-worker-colocated:
-    image: concourse/concourse:6.4.0
+    image: concourse/concourse:6.6.0
     command: worker
     privileged: true
     depends_on: [concourse-db, concourse-web]


### PR DESCRIPTION
What
----

Upgrades Concourse to 6.6.0
Updates BPM to 1.1.9 to ensure Concourse works with 6.6.0

Adds pictures to paas-bootstrap pipelines, to distinguish between environments

How to review
-------------

Review [tlwr](https://deployer.tlwr.dev.cloudpipeline.digital/teams/main/pipelines/create-bosh-concourse)

Review the following screenshots:

***Dev***
![dev](https://user-images.githubusercontent.com/1482692/95092219-4cdf1100-071f-11eb-91b4-5d4a86e5cd0c.png)

***Staging***
![staging](https://user-images.githubusercontent.com/1482692/95092320-697b4900-071f-11eb-9b1c-ebd79819e63e.png)

***Ireland***
![ireland](https://user-images.githubusercontent.com/1482692/95092432-86178100-071f-11eb-8591-1333b546d254.png)

***London***
![image](https://user-images.githubusercontent.com/1482692/95092502-a0515f00-071f-11eb-8da7-e32f679c3602.png)
