### PR TITLE
[#175041036] Vertically scale non-dev BOSH directors

### DIFF
--- a/manifests/bosh-manifest/operations/scale-down-dev.yml
+++ b/manifests/bosh-manifest/operations/scale-down-dev.yml
@@ -1,4 +1,3 @@
----
 - type: replace
   path: /resource_pools/name=vms/cloud_properties/instance_type
-  value: m5.large
+  value: t3.medium

--- a/manifests/bosh-manifest/scripts/generate-manifest.sh
+++ b/manifests/bosh-manifest/scripts/generate-manifest.sh
@@ -11,6 +11,10 @@ for i in "${PAAS_BOOTSTRAP_DIR}"/manifests/bosh-manifest/operations.d/*.yml; do
   opsfile_args+="-o $i "
 done
 
+if [ "${AWS_ACCOUNT}" == "dev" ]; then
+  opsfile_args+="-o ${PAAS_BOOTSTRAP_DIR}/manifests/bosh-manifest/operations/scale-down-dev.yml "
+fi
+
 uaa_users_ops_file="${WORKDIR}/uaa-users-ops-file/uaa-users-ops-file.yml"
 if [ -f "$uaa_users_ops_file" ]; then
   opsfile_args+="-o $uaa_users_ops_file "

--- a/manifests/bosh-manifest/spec/manifest_validation_spec.rb
+++ b/manifests/bosh-manifest/spec/manifest_validation_spec.rb
@@ -139,4 +139,25 @@ RSpec.describe "generic manifest validations" do
       end
     end
   end
+
+  describe "resource_pools" do
+    let(:resource_pools) { manifest["resource_pools"] }
+    let(:resource_pool) { resource_pools.first }
+
+    describe "instance type" do
+      let(:instance_type) { resource_pool.dig("cloud_properties", "instance_type") }
+
+      it "is t3.medium" do
+        expect(instance_type).to eq("t3.medium")
+      end
+
+      context "when not in development" do
+        let(:manifest) { manifest_for_account("prod") }
+
+        it "is m5.large" do
+          expect(instance_type).to eq("m5.large")
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
[Story](https://www.pivotaltracker.com/story/show/175041036)

What
----

[BOSH.io](https://bosh.io/docs/quick-start/) suggests that Directors should have at least 8gb of RAM, which I agree with, especially in London where it has to monitor lots of VMs and run more tasks

`t3.medium` -> `m5.large` increases the amount of network bandwith, memory, and CPU available to BOSH which should help high memory jobs like `bosh clean-up` and `bosh cck`

How to review
----

Code review

CI