### PR TITLE
Replace deprecated characters in pipelines

### DIFF
--- a/concourse/pipelines/create-bosh-concourse.yml
+++ b/concourse/pipelines/create-bosh-concourse.yml
@@ -132,7 +132,7 @@ resources:
             ]
         }
 
-  - name: bosh-CA
+  - name: bosh-ca
     type: s3-iam
     source:
       bucket: ((state_bucket))
@@ -141,7 +141,7 @@ resources:
       initial_version: "-"
       initial_content_binary: "H4sICMtSp1YAA2NvbmNvdXJzZS1jZXJ0cy50YXIA7cEBDQAAAMKg909tDjegAAAAAAAAAAAAgDcDmt4dJwAoAAA="
 
-  - name: bosh-CA-crt
+  - name: bosh-ca-crt
     type: s3-iam
     source:
       bucket: ((state_bucket))
@@ -685,46 +685,46 @@ jobs:
         - get: pipeline-trigger
           passed: ['init-bucket']
           trigger: true
-        - get: bosh-CA
-        - get: bosh-CA-crt
+        - get: bosh-ca
+        - get: bosh-ca-crt
         - get: bosh-secrets
         - get: ssh-private-key
         - get: ssh-public-key
 
-      - task: generate-bosh-CA
+      - task: generate-bosh-ca
         config:
           platform: linux
           image_resource: *certstrap-image-resource
           inputs:
             - name: paas-bootstrap
-            - name: bosh-CA
-              path: existing-bosh-CA
+            - name: bosh-ca
+              path: existing-bosh-ca
           outputs:
-            - name: generated-bosh-CA
+            - name: generated-bosh-ca
           run:
             path: sh
             args:
               - -e
               - -c
               - |
-                if  [ -z "$(tar -tvzf existing-bosh-CA/bosh-CA.tar.gz)" ] ; then
+                if  [ -z "$(tar -tvzf existing-bosh-ca/bosh-CA.tar.gz)" ] ; then
                   certstrap init --years "10" --passphrase "" --common-name bosh-CA
-                  ( cd out && tar -cvzf ../generated-bosh-CA/bosh-CA.tar.gz bosh-CA.* )
+                  ( cd out && tar -cvzf ../generated-bosh-ca/bosh-CA.tar.gz bosh-CA.* )
                 else
                   echo "The CA cert already exists, skipping generation..."
-                  cp existing-bosh-CA/bosh-CA.tar.gz generated-bosh-CA/bosh-CA.tar.gz
+                  cp existing-bosh-ca/bosh-CA.tar.gz generated-bosh-ca/bosh-CA.tar.gz
                   mkdir out
-                  tar -xvzf generated-bosh-CA/bosh-CA.tar.gz -C out
+                  tar -xvzf generated-bosh-ca/bosh-CA.tar.gz -C out
                 fi
-                cp out/bosh-CA.crt generated-bosh-CA/bosh-CA.crt
+                cp out/bosh-CA.crt generated-bosh-ca/bosh-CA.crt
         on_success:
           in_parallel:
-            - put: bosh-CA
+            - put: bosh-ca
               params:
-                file: generated-bosh-CA/bosh-CA.tar.gz
-            - put: bosh-CA-crt
+                file: generated-bosh-ca/bosh-CA.tar.gz
+            - put: bosh-ca-crt
               params:
-                file: generated-bosh-CA/bosh-CA.crt
+                file: generated-bosh-ca/bosh-CA.crt
 
       - in_parallel:
         - task: generate-bosh-secrets
@@ -892,7 +892,7 @@ jobs:
           passed: ['bosh-terraform']
         - get: bosh-secrets
           passed: ['bosh-terraform']
-        - get: bosh-CA
+        - get: bosh-ca
         - get: bosh-vars-store
         - get: vpc-tfstate
           passed: ['bosh-terraform']
@@ -902,7 +902,7 @@ jobs:
         - get: bosh-cyber-secrets
         - get: paas-trusted-people
 
-      - task: extract_terraform_outputs
+      - task: extract-terraform-outputs
         config:
           platform: linux
           image_resource: *ruby-slim-image-resource
@@ -971,7 +971,7 @@ jobs:
             - name: paas-bootstrap
             - name: terraform-outputs
             - name: bosh-secrets
-            - name: bosh-CA
+            - name: bosh-ca
             - name: bosh-vars-store
             - name: bosh-uaa-google-oauth-secrets
             - name: bosh-cyber-secrets
@@ -996,7 +996,7 @@ jobs:
               - -c
               - |
                 mkdir -p certs
-                tar -xvzf bosh-CA/bosh-CA.tar.gz -C certs
+                tar -xvzf bosh-ca/bosh-CA.tar.gz -C certs
 
                 paas-bootstrap/manifests/bosh-manifest/scripts/generate-manifest.sh \
                   > bosh-manifest-pre-vars/bosh-manifest-pre-vars.yml
@@ -1036,7 +1036,7 @@ jobs:
           passed: ['generate-bosh-config']
         - get: paas-trusted-people
           passed: ['generate-bosh-config']
-        - get: bosh-CA-crt
+        - get: bosh-ca-crt
           passed: ['generate-secrets']
         - get: bosh-init-state
         - get: ssh-private-key
@@ -1079,11 +1079,11 @@ jobs:
             - name: bosh-vars-store
             - name: paas-bootstrap
             - name: paas-trusted-people
-            - name: bosh-CA-crt
+            - name: bosh-ca-crt
             - name: ssh-private-key
           params:
             BOSH_ENVIRONMENT: ((bosh_fqdn))
-            BOSH_CA_CERT: bosh-CA-crt/bosh-CA.crt
+            BOSH_CA_CERT: bosh-ca-crt/bosh-CA.crt
             BOSH_NON_INTERACTIVE: true
 
             BOSH_GW_HOST: ((bosh_login_host))
@@ -1370,7 +1370,7 @@ jobs:
         - get: bosh-vars-store
         - get: concourse-manifest
           passed: ['generate-concourse-config']
-        - get: bosh-CA-crt
+        - get: bosh-ca-crt
           passed: ['generate-secrets']
         - get: ssh-private-key
 
@@ -1382,11 +1382,11 @@ jobs:
             - name: cpi-config
             - name: bosh-vars-store
             - name: paas-bootstrap
-            - name: bosh-CA-crt
+            - name: bosh-ca-crt
             - name: ssh-private-key
           params:
             BOSH_ENVIRONMENT: ((bosh_fqdn))
-            BOSH_CA_CERT: bosh-CA-crt/bosh-CA.crt
+            BOSH_CA_CERT: bosh-ca-crt/bosh-CA.crt
             BOSH_DEPLOYMENT: concourse
             BOSH_NON_INTERACTIVE: true
 
@@ -1419,11 +1419,11 @@ jobs:
             - name: paas-bootstrap-cloud-config
             - name: bosh-vars-store
             - name: paas-bootstrap
-            - name: bosh-CA-crt
+            - name: bosh-ca-crt
             - name: ssh-private-key
           params:
             BOSH_ENVIRONMENT: ((bosh_fqdn))
-            BOSH_CA_CERT: bosh-CA-crt/bosh-CA.crt
+            BOSH_CA_CERT: bosh-ca-crt/bosh-CA.crt
             BOSH_DEPLOYMENT: concourse
             BOSH_NON_INTERACTIVE: true
 
@@ -1469,11 +1469,11 @@ jobs:
           inputs:
             - name: bosh-vars-store
             - name: paas-bootstrap
-            - name: bosh-CA-crt
+            - name: bosh-ca-crt
             - name: ssh-private-key
           params:
             BOSH_ENVIRONMENT: ((bosh_fqdn))
-            BOSH_CA_CERT: bosh-CA-crt/bosh-CA.crt
+            BOSH_CA_CERT: bosh-ca-crt/bosh-CA.crt
             BOSH_DEPLOYMENT: concourse
             BOSH_NON_INTERACTIVE: true
 
@@ -1511,11 +1511,11 @@ jobs:
           - name: concourse-manifest
           - name: bosh-vars-store
           - name: paas-bootstrap
-          - name: bosh-CA-crt
+          - name: bosh-ca-crt
           - name: ssh-private-key
           params:
             BOSH_ENVIRONMENT: ((bosh_fqdn))
-            BOSH_CA_CERT: bosh-CA-crt/bosh-CA.crt
+            BOSH_CA_CERT: bosh-ca-crt/bosh-CA.crt
             BOSH_DEPLOYMENT: concourse
             BOSH_NON_INTERACTIVE: true
 
@@ -1542,7 +1542,7 @@ jobs:
 
               bosh deploy concourse-manifest/concourse-manifest.yml \
                    -v "concourse_worker_instances=$CONCOURSE_WORKER_INSTANCES" \
-                   --var-file=credhub_ca_cert=bosh-CA-crt/bosh-CA.crt
+                   --var-file=credhub_ca_cert=bosh-ca-crt/bosh-CA.crt
 
   - name: post-deploy
     serial: true
@@ -1557,7 +1557,7 @@ jobs:
           passed: ['concourse-deploy']
         - get: bosh-secrets
           passed: ['generate-secrets']
-        - get: bosh-CA-crt
+        - get: bosh-ca-crt
           passed: ['generate-secrets']
         - get: ssh-private-key
 
@@ -1569,7 +1569,7 @@ jobs:
             - name: bosh-secrets
             - name: paas-bootstrap
             - name: bosh-vars-store
-            - name: bosh-CA-crt
+            - name: bosh-ca-crt
             - name: ssh-private-key
           outputs:
             - name: upload-pipeline-secrets
@@ -1629,11 +1629,11 @@ jobs:
           inputs:
           - name: paas-bootstrap
           - name: bosh-vars-store
-          - name: bosh-CA-crt
+          - name: bosh-ca-crt
           - name: ssh-private-key
           params:
             BOSH_ENVIRONMENT: ((bosh_fqdn))
-            BOSH_CA_CERT: bosh-CA-crt/bosh-CA.crt
+            BOSH_CA_CERT: bosh-ca-crt/bosh-CA.crt
             BOSH_DEPLOYMENT: concourse
             BOSH_NON_INTERACTIVE: true
 
@@ -1667,7 +1667,7 @@ jobs:
           - name: bosh-secrets
           - name: paas-bootstrap
           - name: bosh-vars-store
-          - name: bosh-CA-crt
+          - name: bosh-ca-crt
           - name: ssh-private-key
           params:
             BOSH_ENVIRONMENT: ((bosh_fqdn))
@@ -1699,7 +1699,7 @@ jobs:
               EOCERT
               )"
               export CREDHUB_CA_CERT
-              BOSH_CA_CERT="$(cat bosh-CA-crt/bosh-CA.crt)"
+              BOSH_CA_CERT="$(cat bosh-ca-crt/bosh-CA.crt)"
               BOSH_CLIENT_SECRET=$($VAL_FROM_YAML admin_password bosh-vars-store/bosh-vars-store.yml)
               BOSH_EXPORTER_PASSWORD=$($VAL_FROM_YAML bosh_exporter_password bosh-vars-store/bosh-vars-store.yml)
 
@@ -1939,7 +1939,7 @@ jobs:
               > bosh-terraform-outputs/tfvars.sh
               ls -l bosh-terraform-outputs/tfvars.sh
 
-      - task: remove-concourse-IP-from-ssh-SG
+      - task: remove-concourse-ip-from-ssh-sg
         config:
           platform: linux
           image_resource: *terraform-image-resource
@@ -1973,7 +1973,7 @@ jobs:
           params:
             file: updated-vpc-tfstate/vpc.tfstate
 
-      - task: remove-concourse-IP-from-BOSH-SG
+      - task: remove-concourse-ip-from-bosh-sg
         config:
           platform: linux
           image_resource: *terraform-image-resource
@@ -2017,7 +2017,7 @@ jobs:
           params:
             file: updated-bosh-tfstate/bosh.tfstate
 
-      - task: remove-concourse-IP-from-Concourse-SG
+      - task: remove-concourse-ip-from-concourse-sg
         config:
           platform: linux
           image_resource: *terraform-image-resource

--- a/concourse/pipelines/destroy-bosh-concourse.yml
+++ b/concourse/pipelines/destroy-bosh-concourse.yml
@@ -142,7 +142,7 @@ resources:
       versioned_file: concourse.tfstate
       region_name: ((aws_region))
 
-  - name: bosh-CA-crt
+  - name: bosh-ca-crt
     type: s3-iam
     source:
       bucket: ((state_bucket))
@@ -271,7 +271,7 @@ jobs:
         - get: bosh-vars-store
         - get: vpc-tfstate
         - get: concourse-tfstate
-        - get: bosh-CA-crt
+        - get: bosh-ca-crt
         - get: ssh-private-key
 
       - task: destroy-concourse
@@ -281,11 +281,11 @@ jobs:
           inputs:
           - name: paas-bootstrap
           - name: bosh-vars-store
-          - name: bosh-CA-crt
+          - name: bosh-ca-crt
           - name: ssh-private-key
           params:
             BOSH_ENVIRONMENT: ((bosh_fqdn))
-            BOSH_CA_CERT: bosh-CA-crt/bosh-CA.crt
+            BOSH_CA_CERT: bosh-ca-crt/bosh-CA.crt
             BOSH_DEPLOYMENT: concourse
             BOSH_NON_INTERACTIVE: true
 
@@ -388,7 +388,7 @@ jobs:
         - get: vpc-tfstate
         - get: bosh-tfstate
         - get: bootstrap-cyber-tfvars
-        - get: bosh-CA-crt
+        - get: bosh-ca-crt
         - get: ssh-private-key
 
       - task: check-existing-deployments
@@ -398,11 +398,11 @@ jobs:
           inputs:
             - name: paas-bootstrap
             - name: bosh-vars-store
-            - name: bosh-CA-crt
+            - name: bosh-ca-crt
             - name: ssh-private-key
           params:
             BOSH_ENVIRONMENT: ((bosh_fqdn))
-            BOSH_CA_CERT: bosh-CA-crt/bosh-CA.crt
+            BOSH_CA_CERT: bosh-ca-crt/bosh-CA.crt
             BOSH_DEPLOYMENT: concourse
             BOSH_NON_INTERACTIVE: true
 
@@ -438,11 +438,11 @@ jobs:
           inputs:
             - name: paas-bootstrap
             - name: bosh-vars-store
-            - name: bosh-CA-crt
+            - name: bosh-ca-crt
             - name: ssh-private-key
           params:
             BOSH_ENVIRONMENT: ((bosh_fqdn))
-            BOSH_CA_CERT: bosh-CA-crt/bosh-CA.crt
+            BOSH_CA_CERT: bosh-ca-crt/bosh-CA.crt
             BOSH_DEPLOYMENT: concourse
             BOSH_NON_INTERACTIVE: true
 


### PR DESCRIPTION
What
----

Since our latest concourse upgrade we were seeing a lot of illegal character errors, this PR corrects those without changing the underlying cert files 

```
DEPRECATION WARNING:
  - resources.bosh-CA: 'bosh-CA' is not a valid identifier: illegal character 'C'
  - resources.bosh-CA-crt: 'bosh-CA-crt' is not a valid identifier: illegal character 'C'
  - jobs.generate-secrets.plan.do[0].in_parallel.steps[2].get(bosh-CA): 'bosh-CA' is not a valid identifier: illegal character 'C'
  - jobs.generate-secrets.plan.do[0].in_parallel.steps[3].get(bosh-CA-crt): 'bosh-CA-crt' is not a valid identifier: illegal character 'C'
  - jobs.generate-secrets.plan.do[1].task(generate-bosh-CA): 'generate-bosh-CA' is not a valid identifier: illegal character 'C'
  - jobs.generate-secrets.plan.do[1].on_success.in_parallel.steps[0].put(bosh-CA): 'bosh-CA' is not a valid identifier: illegal character 'C'
  - jobs.generate-secrets.plan.do[1].on_success.in_parallel.steps[1].put(bosh-CA-crt): 'bosh-CA-crt' is not a valid identifier: illegal character 'C'
  - jobs.generate-bosh-config.plan.do[0].in_parallel.steps[3].get(bosh-CA): 'bosh-CA' is not a valid identifier: illegal character 'C'
  - jobs.generate-bosh-config.plan.do[1].task(extract_terraform_outputs): 'extract_terraform_outputs' is not a valid identifier: illegal character '_'
  - jobs.bosh-deploy.plan.do[0].in_parallel.steps[5].get(bosh-CA-crt): 'bosh-CA-crt' is not a valid identifier: illegal character 'C'
  - jobs.concourse-deploy.plan.do[0].in_parallel.steps[6].get(bosh-CA-crt): 'bosh-CA-crt' is not a valid identifier: illegal character 'C'
  - jobs.post-deploy.plan.do[0].in_parallel.steps[4].get(bosh-CA-crt): 'bosh-CA-crt' is not a valid identifier: illegal character 'C'
  - jobs.expunge-concourse.plan.do[2].task(remove-concourse-IP-from-ssh-SG): 'remove-concourse-IP-from-ssh-SG' is not a valid identifier: illegal character 'I'
  - jobs.expunge-concourse.plan.do[3].task(remove-concourse-IP-from-BOSH-SG): 'remove-concourse-IP-from-BOSH-SG' is not a valid identifier: illegal character 'I'
  - jobs.expunge-concourse.plan.do[4].task(remove-concourse-IP-from-Concourse-SG): 'remove-concourse-IP-from-Concourse-SG' is not a valid identifier: illegal character 'I'

identifier schema documentation: https://concourse-ci.org/config-basics.html#schema.identifier
```

How to review
-------------

Code review and deploy to your dev env

Who can review
--------------

Anyone
