### PR TITLE
Ignore RDS engine versions using lifecycle rule

### DIFF
--- a/terraform/bosh/rds.tf
+++ b/terraform/bosh/rds.tf
@@ -69,5 +69,16 @@ resource "aws_db_instance" "bosh" {
     Name       = "${var.env}-bosh"
     deploy_env = var.env
   }
+
+  lifecycle {
+    ignore_changes = [
+      # When you want to change a major version, then please remove this
+      # lifecycle rule
+      #
+      # This lifecycle rule is here to allow RDS to manage
+      # auto_minor_version_upgrades
+      engine_version,
+    ]
+  }
 }
 

--- a/terraform/concourse/rds.tf
+++ b/terraform/concourse/rds.tf
@@ -68,5 +68,16 @@ resource "aws_db_instance" "concourse" {
     Name       = "${var.env}-concourse"
     deploy_env = var.env
   }
+
+  lifecycle {
+    ignore_changes = [
+      # When you want to change a major version, then please remove this
+      # lifecycle rule
+      #
+      # This lifecycle rule is here to allow RDS to manage
+      # auto_minor_version_upgrades
+      engine_version,
+    ]
+  }
 }
 


### PR DESCRIPTION
What
----

We set `auto_minor_version_upgrade` on our RDS instances, which means that their minor versions get upgraded, this most recently happened from `11.5` to `11.8`.

However our maintenance windows are not synchronised, so there may be 24h or so when we have inconsistent versions.

We can ignore the engine version using a lifecycle rule, and let AWS manage the version. This lifecycle rule can be removed when we are explicitly upgrading the versions.


How to review
-------------

Code review
