### PR TITLE
tf: bosh and concourse are RDS postgres 11.8

### DIFF
--- a/terraform/bosh/rds.tf
+++ b/terraform/bosh/rds.tf
@@ -46,7 +46,7 @@ resource "aws_db_instance" "bosh" {
   allocated_storage          = 100
   storage_type               = "gp2"
   engine                     = "postgres"
-  engine_version             = "11.5"
+  engine_version             = "11.8"
   instance_class             = "db.t3.small"
   username                   = "dbadmin"
   password                   = var.secrets_bosh_postgres_password

--- a/terraform/concourse/rds.tf
+++ b/terraform/concourse/rds.tf
@@ -45,7 +45,7 @@ resource "aws_db_instance" "concourse" {
   allocated_storage          = 25
   storage_type               = "gp2"
   engine                     = "postgres"
-  engine_version             = "11.5"
+  engine_version             = "11.8"
   instance_class             = "db.t3.small"
   username                   = "concourse"
   password                   = random_password.concourse_rds_password.result


### PR DESCRIPTION
What
----

We are in the middle of an automatic upgrade from 11.5 to 11.8 during our maintenance windows.

When our maintenance window is done, we should ensure we are specifying the same version as in production

How to review
-------------

Code review

Check that both production regions are using 11.8 for both Concourse and BOSH RDS databases