### PR TITLE
concourse: rds database has 100G storage

### DIFF
--- a/terraform/concourse/rds.tf
+++ b/terraform/concourse/rds.tf
@@ -42,7 +42,7 @@ resource "aws_db_parameter_group" "concourse_pg_11" {
 resource "aws_db_instance" "concourse" {
   identifier                 = "${var.env}-concourse"
   name                       = "concourse"
-  allocated_storage          = 25
+  allocated_storage          = 100
   storage_type               = "gp2"
   engine                     = "postgres"
   engine_version             = "11.5"


### PR DESCRIPTION
What
----

The AWS recommended minimum for storage is 100Gs

This is (I feel) partially because general purpose IOPS is proportional to allocated storage (3x)

eg  25G of storage =  75 IOPS
eg 100G of storage = 300 IOPS

When we upgraded ~strongcourse~ big concourse to 6.6 we saw disk usage increase, and so I am inclined to increase Concourse's allocated storage, so that it has more IOPS