### PR TITLE
bosh: ensure task cleanup runs every day

### DIFF
--- a/manifests/bosh-manifest/operations.d/109-director-misc-properties.yml
+++ b/manifests/bosh-manifest/operations.d/109-director-misc-properties.yml
@@ -8,3 +8,6 @@
 - type: replace
   path: /instance_groups/name=bosh/properties/director/disks?/max_orphaned_age_in_days
   value: 0
+- type: replace
+  path: /instance_groups/name=bosh/properties/director/tasks_cleanup_schedule?
+  value: 0 0 0 * * * UTC

--- a/manifests/bosh-manifest/spec/manifest_validation_spec.rb
+++ b/manifests/bosh-manifest/spec/manifest_validation_spec.rb
@@ -3,6 +3,7 @@ RSpec.describe "generic manifest validations" do
   let(:instance_groups) { manifest["instance_groups"] }
   let(:bosh_instance) { instance_groups.find { |ig| ig["name"] == "bosh" } }
   let(:bosh_jobs) { bosh_instance["jobs"] }
+  let(:director) { bosh_instance.dig("properties", "director") }
 
   describe "instance" do
     it "has a big disk" do
@@ -157,6 +158,15 @@ RSpec.describe "generic manifest validations" do
         it "is m5.large" do
           expect(instance_type).to eq("m5.large")
         end
+      end
+    end
+  end
+
+  describe "director" do
+    describe "tasks" do
+      it "cleans up tasks every day" do
+        schedule = director.dig("tasks_cleanup_schedule")
+        expect(schedule).to eq("0 0 0 * * * UTC")
       end
     end
   end


### PR DESCRIPTION
What
----

instead of every week

By default BOSH cleans up tasks every week, however we run tasks very often because we have:

* health monitor "scan and fix"
* prometheus exporter "vm stats"

which generates a lot of tasks on disk

we reckon that we can do 40k tasks cleaned up in one go, which is more than: 3 * 60 * 24 * 7 which is 3 tasks per minute
(we tested 40k)

however if the cleanup job does not run once then we may seen a large task build up

instead if we run the task cleanup job every day, then we are less likely to observe a task build up

Paired with @schmie we will merge/deploy tomorrow