### PR TITLE
Docker images should conform to my arbitrary standards

### DIFF
--- a/concourse/pipelines/destroy-bosh-concourse.yml
+++ b/concourse/pipelines/destroy-bosh-concourse.yml
@@ -35,7 +35,7 @@ resource_types:
   type: docker-image
   source:
     repository: governmentpaas/s3-resource
-    tag: 90f9f534ed5a3887b9c5d55a20cca6561f7de6a4
+    tag: 97e441efbfb06ac7fb09786fd74c64b05f9cc907
 
 - name: semver-iam
   type: docker-image

--- a/concourse/pipelines/destroy-bosh-concourse.yml
+++ b/concourse/pipelines/destroy-bosh-concourse.yml
@@ -41,7 +41,7 @@ resource_types:
   type: docker-image
   source:
     repository: governmentpaas/semver-resource
-    tag: 90f9f534ed5a3887b9c5d55a20cca6561f7de6a4
+    tag: f2a80c95481056aa57d837e3b14f0012b542fdb3
 
 resources:
   - name: paas-bootstrap

--- a/concourse/spec/image_resource_spec.rb
+++ b/concourse/spec/image_resource_spec.rb
@@ -1,0 +1,58 @@
+# Disable this cop because we are testing YAML anchors
+# rubocop:disable Security/YAMLLoad
+
+require "yaml"
+
+RSpec.describe "image resources" do
+  concourse_fragments = concourse_tasks
+    .concat(concourse_pipelines)
+    .map { |_, contents| YAML.load(contents) }
+
+  image_tags_by_repo = concourse_fragments
+    .flat_map { |f| all_image_resources(f) }
+    .group_by { |image_def| image_def[:repository] }
+    .map { |repo, image_defs| [repo, image_defs.map { |d| d[:tag] }.uniq] }
+
+  it "exists" do
+    expect(image_tags_by_repo).not_to be_empty
+  end
+
+  describe "tag checking" do
+    image_tags_by_repo.each do |repo, tags|
+      it "never is 'latest' (#{repo})" do
+        tags.each do |tag|
+          expect(tag).not_to eq("latest")
+        end
+      end
+    end
+  end
+
+  describe "governmentpaas docker images" do
+    image_tags_by_repo
+      .select { |repo, _| repo.match?(%r{^governmentpaas/}) }
+      .each do |repo, tags|
+      context "repo #{repo}" do
+        it "has only one tag" do
+          expect(tags.length).to eq(1)
+        end
+
+        it "is a lowercase git hash" do
+          expect(tags.first).to match(/^[a-f0-9]{40}$/)
+        end
+      end
+    end
+
+    describe "things that are not resource types" do
+      image_tags_by_repo
+        .select { |repo, _| repo.match?(%r{^governmentpaas/}) }
+        .reject { |repo, _| repo.match?(/-resource$/) }
+        .to_h.values .flatten .uniq.tap do |all_tags|
+          it "onlies have one tag" do
+            expect(all_tags.length).to eq(1)
+          end
+        end
+    end
+  end
+end
+
+# rubocop:enable Security/YAMLLoad

--- a/concourse/spec/spec_helper.rb
+++ b/concourse/spec/spec_helper.rb
@@ -90,3 +90,33 @@ RSpec.configure do |config|
   # as the one that triggered the failure.
   Kernel.srand config.seed
 end
+
+SPEC_DIR = File.expand_path(__dir__)
+CONCOURSE_DIR = File.expand_path(File.join(SPEC_DIR, ".."))
+TASKS_DIR = File.join(CONCOURSE_DIR, "tasks")
+PIPELINES_DIR = File.join(CONCOURSE_DIR, "pipelines")
+
+def concourse_tasks
+  Dir
+    .glob(File.join(TASKS_DIR, "*.yml"))
+    .map { |f| [File.basename(f), File.read(f)] }
+end
+
+def concourse_pipelines
+  Dir
+    .glob(File.join(PIPELINES_DIR, "*.yml"))
+    .map { |f| [File.basename(f), File.read(f)] }
+end
+
+def all_image_resources(frag)
+  if frag.is_a?(Array)
+    frag.flat_map { |val| all_image_resources(val) }
+  elsif !frag.is_a?(Hash)
+    []
+  elsif [frag.dig("source", "repository"), frag.dig("source", "tag")].none?
+    frag.values.flat_map { |val| all_image_resources(val) }
+  else
+    [{ repository: frag.dig("source", "repository"),
+       tag: frag.dig("source", "tag") }]
+  end
+end

--- a/concourse/tasks/delete-ssh-keys.yml
+++ b/concourse/tasks/delete-ssh-keys.yml
@@ -4,7 +4,7 @@ image_resource:
   type: docker-image
   source:
     repository: governmentpaas/awscli
-    tag: 34c0ca163291c796ed6936b1ed0697321a9548b8
+    tag: 90f9f534ed5a3887b9c5d55a20cca6561f7de6a4
 inputs:
   - name: paas-bootstrap
 run:


### PR DESCRIPTION
What
----

I tried to destroy the `isoseg` development environment and was greeted by Concourse errors: it could not find an image for a resource type `s3-iam` and `semver-iam`.

It could not find these images presumably because of new Docker Hub retention rules: no one had pulled the images used by the destroy pipeline recently, therefore they disappeared forever.

We do not run the `destroy-bosh-concourse` pipeline often, and so this is likely to happen again. We do however run `create-bosh-concourse` often, and therefore if we use the same docker image tags, then we will not lose images.

Therefore this PR:
- duplicates the tests from paas-cf which ensures all of our non-resource images use the same tag
- duplicates the tests from paas-cf which ensures all usages of a resource image use the same tag
- makes the tests pass

Once I did the above, I was then able to destroy the `isoseg` development environment

How to review
-------------

Try `docker pull governmentpaas/s3-resource: 90f9f534ed5a3887b9c5d55a20cca6561f7de6a4` and be disappointed

Review my code