### PR TITLE
Bump Concourse RDS instance type to db.m5.large

### DIFF
--- a/terraform/concourse/rds.tf
+++ b/terraform/concourse/rds.tf
@@ -46,7 +46,7 @@ resource "aws_db_instance" "concourse" {
   storage_type               = "gp2"
   engine                     = "postgres"
   engine_version             = "11.5"
-  instance_class             = "db.t3.small"
+  instance_class             = "db.m5.large"
   username                   = "concourse"
   password                   = random_password.concourse_rds_password.result
   db_subnet_group_name       = aws_db_subnet_group.concourse_rds.name


### PR DESCRIPTION
What
----

Bump Concourse RDS instance type to db.m5.large

Since the upgrade to Concourse version 6.6 the Concourse RDS instance is under constant high CPU load and consumes an extra 8 CPU credits per hour. This means we can save on its cost by changing to a non-burst instance type.

How to review
-------------

Code review 
Bootstrap dev-env and check concourse is happy after

Who can review
--------------
Not @schmie 
