### PR TITLE
Bump Concourse RDS instance type to db.m5.xlarge

### DIFF
--- a/terraform/concourse/rds.tf
+++ b/terraform/concourse/rds.tf
@@ -46,7 +46,7 @@ resource "aws_db_instance" "concourse" {
   storage_type               = "gp2"
   engine                     = "postgres"
   engine_version             = "11.5"
-  instance_class             = "db.m5.large"
+  instance_class             = "db.m5.xlarge"
   username                   = "concourse"
   password                   = random_password.concourse_rds_password.result
   db_subnet_group_name       = aws_db_subnet_group.concourse_rds.name


### PR DESCRIPTION

What
----

Bump Concourse RDS instance type to db.m5.xlarge.

Why
----

We just switched from db.t3.small in permanent burst to db.m5.large, however, the CPU load is still very high (~constantly >90%) since the upgrade to Concourse 6.6.0.

How to review
-------------

- Test bootstrap in dev env

Who can review
--------------

not @schmie 
