### PR TITLE
[#171404935] Bump Xenial stemcell version to 621.95

### DIFF
--- a/manifests/bosh-manifest/operations.d/030-set-stemcell.yml
+++ b/manifests/bosh-manifest/operations.d/030-set-stemcell.yml
@@ -2,5 +2,5 @@
 - type: replace
   path: /resource_pools/name=vms/stemcell
   value:
-    url: https://bosh.io/d/stemcells/bosh-aws-xen-hvm-ubuntu-xenial-go_agent?v=621.94
-    sha1: 37ef7c541f31cbdbae53b77edbb04afbddd48685
+    url: https://bosh.io/d/stemcells/bosh-aws-xen-hvm-ubuntu-xenial-go_agent?v=621.95
+    sha1: 6947a8aa5f5a3fe4cf834307e3261bb9e8fb3858

--- a/manifests/concourse-manifest/concourse-base.yml
+++ b/manifests/concourse-manifest/concourse-base.yml
@@ -2,7 +2,7 @@
 meta:
   stemcell:
     name: bosh-aws-xen-hvm-ubuntu-xenial-go_agent
-    version: "621.94"
+    version: "621.95"
 
 name: concourse
 
@@ -63,7 +63,7 @@ instance_groups:
             auth:
               local:
                 users:
-                - admin
+                  - admin
           postgresql:
             database: (( grab terraform_outputs_concourse_db_name ))
             host: (( grab terraform_outputs_concourse_db_address ))


### PR DESCRIPTION
What
----
Bumping to match the version bump that's happening as part of [upgrading from
cf-deployment v15.0.0 to v15.4.0](https://github.com/alphagov/paas-cf/pull/2569)

How to review
-------------
1. Code review
2. Check it ran down [my pipeline](https://deployer.whi-tw.dev.cloudpipeline.digital/teams/main/pipelines/create-bosh-concourse) OK

Who can review
--------------
Anyone