### PR TITLE
Use GP3 disk type where GP2 was used in EC2 instances

### DIFF
--- a/manifests/bosh-manifest/operations.d/023-cpi-uses-gp3-disks.yml
+++ b/manifests/bosh-manifest/operations.d/023-cpi-uses-gp3-disks.yml
@@ -1,0 +1,9 @@
+---
+- type: replace
+  path: /resource_pools/name=vms/cloud_properties/ephemeral_disk/type
+  value: gp3
+
+- type: replace
+  path: /disk_pools/name=disks/cloud_properties/type
+  value: gp3
+

--- a/manifests/cloud-config/paas-bootstrap-cloud-config.yml
+++ b/manifests/cloud-config/paas-bootstrap-cloud-config.yml
@@ -24,7 +24,7 @@ vm_types:
       auto_assign_public_ip: true
       ephemeral_disk:
         size: 20480
-        type: gp2
+        type: gp3
 
   - name: concourse
     cloud_properties:
@@ -32,7 +32,7 @@ vm_types:
       instance_type: (( grab $CONCOURSE_INSTANCE_TYPE ))
       ephemeral_disk:
         size: 102400
-        type: gp2
+        type: gp3
 
   - name: concourse_worker
     cloud_properties:
@@ -41,7 +41,7 @@ vm_types:
       instance_type: (( grab $CONCOURSE_INSTANCE_TYPE ))
       ephemeral_disk:
         size: 102400
-        type: gp2
+        type: gp3
 
 
 vm_extensions:


### PR DESCRIPTION
What
----

Amazon has released a new type of disk: GP3 [1]. It is a straight upgrade in
every way from GP2, and costs 20% less. It's a no-brainer for us to use it.

[1] https://aws.amazon.com/ebs/general-purpose/

How to review
-------------

1. Bootstrap your env with this branch
2. Code review, make sure I didn't miss a spot
3. [See it went down my env just fine](https://deployer.andyhunt.dev.cloudpipeline.digital/teams/main/pipelines/create-bosh-concourse)