### PR TITLE
Move Jani from dev and CI to full Concourse access

### DIFF
--- a/manifests/concourse-manifest/github_auth/config.yml
+++ b/manifests/concourse-manifest/github_auth/config.yml
@@ -14,6 +14,7 @@ instance_groups:
                 users:
                 - 46bit
                 - AP-Hunt
+                - kr8n3r
                 - LeePorte
                 - mogds
                 - paroxp

--- a/manifests/concourse-manifest/github_auth/dev_ci_additional_users.yml
+++ b/manifests/concourse-manifest/github_auth/dev_ci_additional_users.yml
@@ -11,7 +11,6 @@ instance_groups:
               github:
                 users:
                   - (( append ))
-                  - kr8n3r
                   - poveyd
                   - szd55gds
                   - philandstuff


### PR DESCRIPTION
What
----

Added Jani to the full concourse access list. He needs this in order to undertake debugging of admin deploys

How to review
-------------

Code review

Who can review
--------------

@schmie has context
