### PR TITLE
Update VagrantFile to work with modern vagrant

### DIFF
--- a/vagrant/Vagrantfile
+++ b/vagrant/Vagrantfile
@@ -1,7 +1,22 @@
 # -*- mode: ruby -*-
 # vi: set ft=ruby :
 
-Vagrant.require_version ">= 1.8.0"
+class Hash
+  unless Hash.method_defined?(:slice)
+    def slice(*keep_keys)
+      h = {}
+      keep_keys.each { |key| h[key] = fetch(key) if key?(key) }
+      h
+    end
+  end
+  unless Hash.method_defined?(:except)
+    def except(*less_keys)
+      slice(*keys - less_keys)
+    end
+  end
+end
+
+Vagrant.require_version ">= 2.2.14"
 
 # We use bootstrap concourse SG and a subnet in default VPC in each region
 AWS_ACCOUNT = ENV.fetch("AWS_ACCOUNT", "dev")


### PR DESCRIPTION
What
----

We had let this bitrot and it required using an old version of Vagrant.
Unfortunatly there is the need to put in a hack due to this issue on the
vagrant-aws provider https://github.com/mitchellh/vagrant-aws/issues/566. 
I suspect that this provider is now abandoned as there is even a PR open 
to fix it https://github.com/mitchellh/vagrant-aws/pull/575. I propose that we
look to remove vagrant in the not too distant future.

How to review
-------------

Grab vagrant 2.2.14 from https://www.vagrantup.com/downloads
Remove your old plugins `vagrant plugin expunge` and install for this version `vagrant plugin install vagrant-aws`
Create bootstrap concourse successfully.

Who can review
--------------

Anyone
