### PR TITLE
Bump xenial stemcell version to mitigate usn-4749-1

### DIFF
--- a/manifests/bosh-manifest/operations.d/030-set-stemcell.yml
+++ b/manifests/bosh-manifest/operations.d/030-set-stemcell.yml
@@ -2,5 +2,5 @@
 - type: replace
   path: /resource_pools/name=vms/stemcell
   value:
-    url: https://bosh.io/d/stemcells/bosh-aws-xen-hvm-ubuntu-xenial-go_agent?v=621.101
-    sha1: 32c09b0fc0564c9ff767f5443388ec2cf6d5b209
+    url: https://bosh.io/d/stemcells/bosh-aws-xen-hvm-ubuntu-xenial-go_agent?v=621.108
+    sha1: 849a09680291bcaf896f4b2b28303b8f07a82c40

--- a/manifests/concourse-manifest/concourse-base.yml
+++ b/manifests/concourse-manifest/concourse-base.yml
@@ -2,7 +2,7 @@
 meta:
   stemcell:
     name: bosh-aws-xen-hvm-ubuntu-xenial-go_agent
-    version: "621.101"
+    version: "621.108"
 
 name: concourse
 


### PR DESCRIPTION
What
----

Bum xenial stemcell to 621.108 to mitigate [USN-4749-1](https://www.cloudfoundry.org/blog/usn-4749-1/)

How to review
-------------

Run down pipeline

Who can review
--------------

Not Me

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
