### PR TITLE
[#176478704] Upgrade Bosh and Concourse

### DIFF
--- a/manifests/bosh-manifest/operations.d/120-cpi.yml
+++ b/manifests/bosh-manifest/operations.d/120-cpi.yml
@@ -5,7 +5,7 @@
 - path: /releases/name=bosh-aws-cpi
   type: replace
   value:
-    name: bosh-aws-cpi
-    version: "83"
-    url: "https://bosh.io/d/github.com/cloudfoundry/bosh-aws-cpi-release?v=83"
-    sha1: "cabcdf15846adabe2000fe892314a3a2f72c9177"
+    name: "bosh-aws-cpi"
+    version: "85"
+    url: "https://bosh.io/d/github.com/cloudfoundry/bosh-aws-cpi-release?v=85"
+    sha1: "ab16bba3ae74b1a59f67d1579de22bc26ae95c53"

--- a/manifests/concourse-manifest/concourse-base.yml
+++ b/manifests/concourse-manifest/concourse-base.yml
@@ -96,6 +96,8 @@ instance_groups:
           tags: [colocated-with-web]
           garden:
             allow_host_access: true
+          baggageclaim:
+            driver: overlay
 
     networks:
       - name: public
@@ -134,6 +136,8 @@ instance_groups:
             host_public_key: ((concourse_tsa_host_key.public_key))
           garden:
             allow_host_access: true
+          baggageclaim:
+            driver: overlay
 
     networks:
       - name: concourse

--- a/manifests/concourse-manifest/concourse-base.yml
+++ b/manifests/concourse-manifest/concourse-base.yml
@@ -16,9 +16,9 @@ stemcells:
 # relevant tag of https://github.com/concourse/concourse-bosh-deployment
 releases:
   - name: "concourse"
-    version: "6.6.0"
-    url: "https://bosh.io/d/github.com/concourse/concourse-bosh-release?v=6.6.0"
-    sha1: "4cac2f29591ae88fbd97539e3020ecd06a6fe4c1"
+    version: "7.0.0"
+    url: "https://bosh.io/d/github.com/concourse/concourse-bosh-release?v=7.0.0"
+    sha1: "90bc416cfd6c9bd03447b77accb3d9f185d69281"
   - name: "bpm"
     version: "1.1.9"
     url: "https://bosh.io/d/github.com/cloudfoundry/bpm-release?v=1.1.9"


### PR DESCRIPTION
What
----
1. Upgrades Bosh
2. Upgrades Concourse
3. Uses OverlayFS in Concourse worker

How to review
-------------
1. Deploy it and check Concourse continues to work; I ran `create-cloudfoundry` pipeline to test that.

🚨 After deploy🚨 
----
Concourse 7 appears to have changed the URI used for OAuth redirects. After Concourse is deployed to staging and production, go to https://github.com/organizations/alphagov/settings/applications and update the relevant redirect URIs to `https://concourse.${SYSTEM_DNS_ZONE_NAME}/sky/issuer/callback`.

Keep a record for the current value before changing it, in case the change was some oddness with my dev env.

Had to terminate the instances after changing the FS

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
