### PR TITLE
[#177474241] Use DEPLOY_ENV not MAKEFILE_ENV_TARGET in GitHub secrets path

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -97,6 +97,7 @@ dev: globals check-env-vars ## Set Environment to DEV
 
 .PHONY: ci
 ci: globals check-env-vars ## Set Environment to CI
+	$(eval export DEPLOY_ENV=ci)
 	$(eval export SYSTEM_DNS_ZONE_NAME=${DEPLOY_ENV}.ci.cloudpipeline.digital)
 	$(eval export SYSTEM_DNS_ZONE_ID=Z2PF4LCV9VR1MV)
 	$(eval export AWS_ACCOUNT=ci)

--- a/scripts/upload-secrets/manage-github-secrets.sh
+++ b/scripts/upload-secrets/manage-github-secrets.sh
@@ -38,8 +38,8 @@ setup_env() {
 
 get_creds_from_env_or_pass() {
   setup_env
-  GITHUB_CLIENT_ID="${GITHUB_CLIENT_ID:-$(pass "github.com/concourse/${MAKEFILE_ENV_TARGET}/client_id")}"
-  GITHUB_CLIENT_SECRET="${GITHUB_CLIENT_SECRET:-$(pass "github.com/concourse/${MAKEFILE_ENV_TARGET}/client_secret")}"
+  GITHUB_CLIENT_ID="${GITHUB_CLIENT_ID:-$(pass "github.com/concourse/${DEPLOY_ENV}/client_id")}"
+  GITHUB_CLIENT_SECRET="${GITHUB_CLIENT_SECRET:-$(pass "github.com/concourse/${DEPLOY_ENV}/client_secret")}"
 }
 
 upload() {


### PR DESCRIPTION
What
----

We're creating two development environments which will be shared among the
team, and they each need their own GitHub OAuth credentials.

Previously, the path to the secrets in the password store was
"github.com/concourse/${MAKEFILE_ENV_TARGET}/", which works perfectly well because

1. Each distinct non-prod environment had a distinct value for the variable.
2. Individuals keep their dev environment credentials in their own password
   store, under "github.com/concourse/dev/".

However, now that we're introducing shared development environments, we want to
keep the GitHub credentials for them in the shared password store. That means
the path "github.com/concourse/dev/" is insufficient.

To resolve this, we begin using the DEPLOY_ENV environment variable instead.
For all non-dev environments, MAKEFILE_ENV_TARGET == DEPLOY_ENV, so this change
has no effect. For dev environments, it will mean that individuals will have to
change the path of the secrets in their own secrets store.

How to review
-------------

Do you agree with the change?
Can you see any problems arising from the change?


---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
