### PR TITLE
Update concourse to 7.1.0 in manifest and vagrant

### DIFF
--- a/manifests/concourse-manifest/concourse-base.yml
+++ b/manifests/concourse-manifest/concourse-base.yml
@@ -16,9 +16,9 @@ stemcells:
 # relevant tag of https://github.com/concourse/concourse-bosh-deployment
 releases:
   - name: "concourse"
-    version: "7.0.0"
-    url: "https://bosh.io/d/github.com/concourse/concourse-bosh-release?v=7.0.0"
-    sha1: "90bc416cfd6c9bd03447b77accb3d9f185d69281"
+    version: "7.1.0"
+    url: "https://bosh.io/d/github.com/concourse/concourse-bosh-release?v=7.1.0"
+    sha1: "f3eff35f35438517069c4637108259fc86e14ede"
   - name: "bpm"
     version: "1.1.9"
     url: "https://bosh.io/d/github.com/cloudfoundry/bpm-release?v=1.1.9"

--- a/vagrant/docker-compose.yml
+++ b/vagrant/docker-compose.yml
@@ -10,7 +10,7 @@ services:
     - PGDATA=/database
 
   concourse-web:
-    image: concourse/concourse:6.6.0
+    image: concourse/concourse:7.1.0
     command: web
     privileged: true
     depends_on: [concourse-db]
@@ -32,7 +32,7 @@ services:
     - CONCOURSE_SESSION_SIGNING_KEY=/keys/session_signing_key
 
   concourse-worker-colocated:
-    image: concourse/concourse:6.6.0
+    image: concourse/concourse:7.1.0
     command: worker
     privileged: true
     depends_on: [concourse-db, concourse-web]
@@ -50,7 +50,7 @@ services:
     - CONCOURSE_GARDEN_DNS_SERVER=169.254.169.253
 
   concourse-worker-normal:
-    image: concourse/concourse:6.6.0
+    image: concourse/concourse:7.1.0
     command: worker
     privileged: true
     depends_on: [concourse-db, concourse-web]


### PR DESCRIPTION
What
----

Updated concourse to use 7.1.0 as it's the latest version for both manifest and vagrant

How to review
-------------

code review and check out https://deployer.leeporte.dev.cloudpipeline.digital/

Who can review
--------------

Anyone

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
