### PR TITLE
Fix build concourse

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -98,7 +98,7 @@ dev: globals check-env-vars ## Set Environment to DEV
 .PHONY: ci
 ci: globals check-env-vars ## Set Environment to CI
 	$(eval export DEPLOY_ENV=ci)
-	$(eval export SYSTEM_DNS_ZONE_NAME=${DEPLOY_ENV}.ci.cloudpipeline.digital)
+	$(eval export SYSTEM_DNS_ZONE_NAME=build.${DEPLOY_ENV}.cloudpipeline.digital)
 	$(eval export SYSTEM_DNS_ZONE_ID=Z2PF4LCV9VR1MV)
 	$(eval export AWS_ACCOUNT=ci)
 	$(eval export MAKEFILE_ENV_TARGET=ci)

--- a/scripts/bosh
+++ b/scripts/bosh
@@ -17,7 +17,7 @@ case "$AWS_ACCOUNT" in
 	SYSTEM_DNS_ZONE_NAME="${DEPLOY_ENV}.dev.cloudpipeline.digital"
   ;;
   ci)
-	SYSTEM_DNS_ZONE_NAME="${DEPLOY_ENV}.ci.cloudpipeline.digital"
+	SYSTEM_DNS_ZONE_NAME="build.${DEPLOY_ENV}.cloudpipeline.digital"
   ;;
   staging)
 	SYSTEM_DNS_ZONE_NAME="staging.london.cloudpipeline.digital"


### PR DESCRIPTION
What
----

We've made some work to incorporate persistent dev environments into our
lives. This brought some difficulties with the secrets and has been
addressed in e14faf5678abda425968de208afd6c81984ddce1.

This however, breaks the weird separation in our Build CI system, where
the DEPLOY_ENV is suppose to be `build` but it should live in the `ci`
namespace... Story for another time...

This change, is suppose to fix this confusion and always set the correct
concourse URL for the build CI despite what environment variable is
responsible for this...

How to review
-------------

- Sanity check

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
