### PR TITLE
We don't use postgres 9.5 for bosh any longer

### DIFF
--- a/terraform/bosh/rds.tf
+++ b/terraform/bosh/rds.tf
@@ -28,12 +28,6 @@ resource "aws_security_group" "bosh_rds" {
   }
 }
 
-resource "aws_db_parameter_group" "bosh_pg_9_5" {
-  name        = "${var.env}-pg95-bosh"
-  family      = "postgres9.5"
-  description = "RDS Postgres 9.5 default parameter group"
-}
-
 resource "aws_db_parameter_group" "bosh_pg_11" {
   name        = "${var.env}-pg11-bosh"
   family      = "postgres11"


### PR DESCRIPTION
What
----

As we don't use postgres 9.5 with BOSH there is no point in having a parameter group for
something we don't use.

How to review
-------------

Code review

Who can review
--------------

Anyone

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
