### PR TITLE
concourse: Bump number of web instances

### DIFF
--- a/manifests/concourse-manifest/concourse-base.yml
+++ b/manifests/concourse-manifest/concourse-base.yml
@@ -30,7 +30,7 @@ releases:
 
 instance_groups:
   - name: concourse
-    instances: 1
+    instances: 3
     stemcell: default
 
     azs:


### PR DESCRIPTION
What
----

Raising the number of workers will do us good for executing different set of tasks. But we also need more capacity in our brain to manage and control all of the available resources.

It would be OK to set the number at two, but in the same time, I don't want to revisit this for foreseeable future, and I want to make sure we have enough free play, when managing the instances.

How to review
-------------

* Sanity check

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
