### PR TITLE
Give those of us with restricted permissions pipeline-operator in prod/staging

### DIFF
--- a/manifests/concourse-manifest/concourse-base.yml
+++ b/manifests/concourse-manifest/concourse-base.yml
@@ -59,11 +59,6 @@ instance_groups:
           add_local_users:
             - admin:((concourse_web_password))
           auth_duration: (( grab $CONCOURSE_AUTH_DURATION ))
-          main_team:
-            auth:
-              local:
-                users:
-                  - admin
           postgresql:
             database: (( grab terraform_outputs_concourse_db_name ))
             host: (( grab terraform_outputs_concourse_db_address ))

--- a/manifests/concourse-manifest/github_auth/config.yml
+++ b/manifests/concourse-manifest/github_auth/config.yml
@@ -10,12 +10,22 @@ instance_groups:
             client_secret: (( grab $GITHUB_CLIENT_SECRET ))
           main_team:
             auth:
-              github:
-                users:
-                - AP-Hunt
-                - kr8n3r
-                - LeePorte
-                - mogds
-                - paroxp
-                - schmie
-                - whi-tw
+              config: |+
+                roles:
+                - name: owner
+                  github:
+                    users:
+                    - AP-Hunt
+                    - kr8n3r
+                    - LeePorte
+                    - mogds
+                    - paroxp
+                    - schmie
+                    - whi-tw
+                - name: pipeline-operator
+                  github:
+                    users:
+                    - 0atman
+                    - poveyd
+                    - Krenair
+                    - risicle

--- a/manifests/concourse-manifest/github_auth/config.yml
+++ b/manifests/concourse-manifest/github_auth/config.yml
@@ -13,6 +13,9 @@ instance_groups:
               config: |+
                 roles:
                 - name: owner
+                  local:
+                    users:
+                    - admin
                   github:
                     users:
                     - AP-Hunt

--- a/manifests/concourse-manifest/github_auth/dev_ci_additional_users.yml
+++ b/manifests/concourse-manifest/github_auth/dev_ci_additional_users.yml
@@ -8,10 +8,20 @@ instance_groups:
         properties:
           main_team:
             auth:
-              github:
-                users:
-                  - (( append ))
-                  - 0atman
-                  - poveyd
-                  - Krenair
-                  - risicle
+              config: |+
+                roles:
+                - name: owner
+                  github:
+                    users:
+                    - AP-Hunt
+                    - kr8n3r
+                    - LeePorte
+                    - mogds
+                    - paroxp
+                    - schmie
+                    - whi-tw
+
+                    - 0atman
+                    - poveyd
+                    - Krenair
+                    - risicle

--- a/manifests/concourse-manifest/github_auth/dev_ci_additional_users.yml
+++ b/manifests/concourse-manifest/github_auth/dev_ci_additional_users.yml
@@ -11,6 +11,9 @@ instance_groups:
               config: |+
                 roles:
                 - name: owner
+                  local:
+                    users:
+                    - admin
                   github:
                     users:
                     - AP-Hunt

--- a/manifests/concourse-manifest/spec/manifest_generation_spec.rb
+++ b/manifests/concourse-manifest/spec/manifest_generation_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe "manifest generation" do
 
     it "sets up the main team users" do
       expect(
-        web_job.dig("properties", "main_team", "auth", "github", "users"),
+        web_job.dig("properties", "main_team", "auth", "config"),
       ).not_to be_empty
     end
   end


### PR DESCRIPTION
What
----

This duplicates the prod/staging list of owners - am open to better solutions,
as long as we don't keep having to guess what's going on in prod/staging.

Note this config block is a string that happens to contain YAML.
Note also Concourse doesn't let us define a role twice: https://github.com/concourse/concourse/blob/a9ec0f6edab6703caa6835154f7696267ce51e17/skymarshal/skycmd/flags.go#L141

How to review
-------------


Code review

Who can review
--------------

Not @Krenair

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨