### PR TITLE
Fix warning for undeclared db maintenance windows

### DIFF
--- a/terraform/globals.tf
+++ b/terraform/globals.tf
@@ -122,3 +122,10 @@ variable "bosh_log_groups_to_ship_to_csls" {
   ]
 }
 
+variable "concourse_db_maintenance_window" {
+  description = "Maintenance windown for concourse db"
+}
+
+variable "bosh_db_maintenance_window" {
+  description = "Maintenance windown for bosh db"
+}


### PR DESCRIPTION
What
----

Describe what you have changed and why.

During the `cyber-terraform` job these warning occurred.

```
Warning: Value for undeclared variable

The root module does not declare a variable named
"concourse_db_maintenance_window" but a value was found in file
"paas-bootstrap/terraform/dev.tfvars". To use this value, add a "variable"
block to the configuration.

Using a variables file to set an undeclared variable is deprecated and will
become an error in a future release. If you wish to provide certain "global"
settings to all configurations in your organization, use TF_VAR_...
environment variables to set these instead.

Warning: Value for undeclared variable

The root module does not declare a variable named "bosh_db_maintenance_window"
but a value was found in file "paas-bootstrap/terraform/dev.tfvars". To use
this value, add a "variable" block to the configuration.

Using a variables file to set an undeclared variable is deprecated and will
become an error in a future release. If you wish to provide certain "global"
settings to all configurations in your organization, use TF_VAR_...
environment variables to set these instead.
```

Proactively fix the warnings by adding them to globals.tf so it is not an issue in the future



How to review
-------------

Run the `cyber-terraform` off this branch and check for warnings


Who can review
--------------

Describe who can review the changes. Or more importantly, list the people
that can't review, because they worked on it.

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
