### PR TITLE
Get ruby 2.7-slim from a pinned version of ours in GHCR

### DIFF
--- a/concourse/pipelines/create-bosh-concourse.yml
+++ b/concourse/pipelines/create-bosh-concourse.yml
@@ -27,8 +27,8 @@ meta:
     ruby-slim: &ruby-slim-image-resource
       type: docker-image
       source:
-        repository: ruby
-        tag: 2.7-slim
+        repository: ghcr.io/alphagov/paas/ruby
+        tag: 8d6c556abd2d54f27c0fda934d00df8beafac1f8
     self-update-pipelines: &self-update-pipelines-image-resource
       type: docker-image
       source:


### PR DESCRIPTION
What
----

Get ruby 2.7-slim from a pinned version of ours in GHCR

How to review
-------------

ruby 2.7-slim upstream seems to have changed, some time since about 12th
August, in a way that generates 'Operation not permitted' errors when
interacting with the filesystem. This is a problem for e.g. generate-secrets.

Who can review
--------------

Not @Krenair

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
