### PR TITLE
BAU: Add tomrosier to concourse config

### DIFF
--- a/manifests/concourse-manifest/github_auth/config.yml
+++ b/manifests/concourse-manifest/github_auth/config.yml
@@ -32,3 +32,4 @@ instance_groups:
                     - cadmiumcat
                     - poveyd
                     - risicle
+                    - tomrosier

--- a/manifests/concourse-manifest/github_auth/dev_ci_additional_users.yml
+++ b/manifests/concourse-manifest/github_auth/dev_ci_additional_users.yml
@@ -28,3 +28,4 @@ instance_groups:
                     - cadmiumcat
                     - poveyd
                     - risicle
+                    - tomrosier


### PR DESCRIPTION
What
----

It be nice to log into concourse without manually adding myself via the admin user.

How to review
-------------

Tom can log into other concourses

Who can review
--------------

Not me.

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
