### PR TITLE
TMP Fix: Override `git` resource with docker image

### DIFF
--- a/concourse/pipelines/create-bosh-concourse.yml
+++ b/concourse/pipelines/create-bosh-concourse.yml
@@ -82,6 +82,15 @@ resource_types:
     repository: ghcr.io/alphagov/paas/semver-resource
     tag: f2a80c95481056aa57d837e3b14f0012b542fdb3
 
+  # FIX ME: The server certificate verification fails when using the concourse
+  # version of the resource_type `git`. As a temporary fix we have docker image
+  # of the resource. This resource_type can be deleted when the issue is resolved
+- name: git
+  type: docker-image
+  source:
+    repository: ghcr.io/alphagov/paas/git-resource
+    tag: 1f84d4a76b4a2491283e0107ae7ed4bc83c84d1b
+
 resources:
   - name: paas-bootstrap
     type: git

--- a/concourse/pipelines/destroy-bosh-concourse.yml
+++ b/concourse/pipelines/destroy-bosh-concourse.yml
@@ -43,6 +43,14 @@ resource_types:
     repository: ghcr.io/alphagov/paas/semver-resource
     tag: f2a80c95481056aa57d837e3b14f0012b542fdb3
 
+  # FIX ME: The server certificate verification fails when using the concourse
+  # version of the resource_type `git`. As a temporary fix we have docker image
+  # of the resource. This resource_type can be deleted when the issue is resolved
+- name: git
+  type: docker-image
+  source:
+    repository: ghcr.io/alphagov/paas/git-resource
+    tag: 1f84d4a76b4a2491283e0107ae7ed4bc83c84d1b
 resources:
   - name: paas-bootstrap
     type: git


### PR DESCRIPTION
Workaround for issues with Let's Encrypt https://github.com/concourse/concourse/discussions/7630

What
----

The server certificate verification fails when using the concourse version of the resource_type `git`. As a temporary fix we have docker image of the resource. This resource_type can be deleted when the issue is resolved

How to review
-------------

Who can review
--------------

Anyone, but @whpearson 

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
