### PR TITLE
update docker containers to latest hash

### DIFF
--- a/.github/workflows/test_on_pr.yml
+++ b/.github/workflows/test_on_pr.yml
@@ -1,7 +1,7 @@
 ---
 on: pull_request
 env:
-  TF_VERSION: "0.13.2"
+  TF_VERSION: "1.0.8"
   SPRUCE_VERSION: "1.24.1"
   BOSH_CLI_VERSION: "6.1.1"
   CERTSTRAP_VERSION: "1.2.0"

--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,6 @@ vagrant/.vagrant/
 bin/fly*
 *vagrant-bootstrap-concourse
 *.swp
+terraform/.terraform/
+terraform/*/.terraform/
 

--- a/concourse/pipelines/concourse-lite-self-terminate.yml
+++ b/concourse/pipelines/concourse-lite-self-terminate.yml
@@ -8,7 +8,7 @@ meta:
       type: docker-image
       source:
         repository: ghcr.io/alphagov/paas/awscli
-        tag: 8d6c556abd2d54f27c0fda934d00df8beafac1f8
+        tag: 168a6c8b43fdec99607fd8bc01c5986a46a72dc0
 
 resources:
   - name: delete-timer

--- a/concourse/pipelines/create-bosh-concourse.yml
+++ b/concourse/pipelines/create-bosh-concourse.yml
@@ -8,42 +8,42 @@ meta:
       type: docker-image
       source:
         repository: ghcr.io/alphagov/paas/awscli
-        tag: 8d6c556abd2d54f27c0fda934d00df8beafac1f8
+        tag: 168a6c8b43fdec99607fd8bc01c5986a46a72dc0
     bosh-cli-v2: &gov-paas-bosh-cli-v2-image-resource
       type: docker-image
       source:
         repository: ghcr.io/alphagov/paas/bosh-cli-v2
-        tag: 8d6c556abd2d54f27c0fda934d00df8beafac1f8
+        tag: 168a6c8b43fdec99607fd8bc01c5986a46a72dc0
     certstrap: &certstrap-image-resource
       type: docker-image
       source:
         repository: ghcr.io/alphagov/paas/certstrap
-        tag: 8d6c556abd2d54f27c0fda934d00df8beafac1f8
+        tag: 168a6c8b43fdec99607fd8bc01c5986a46a72dc0
     git-ssh: &git-ssh-image-resource
       type: docker-image
       source:
         repository: ghcr.io/alphagov/paas/git-ssh
-        tag: 8d6c556abd2d54f27c0fda934d00df8beafac1f8
+        tag: 168a6c8b43fdec99607fd8bc01c5986a46a72dc0
     ruby-slim: &ruby-slim-image-resource
       type: docker-image
       source:
         repository: ghcr.io/alphagov/paas/ruby
-        tag: 8d6c556abd2d54f27c0fda934d00df8beafac1f8
+        tag: 168a6c8b43fdec99607fd8bc01c5986a46a72dc0
     self-update-pipelines: &self-update-pipelines-image-resource
       type: docker-image
       source:
         repository: ghcr.io/alphagov/paas/self-update-pipelines
-        tag: 8d6c556abd2d54f27c0fda934d00df8beafac1f8
+        tag: 168a6c8b43fdec99607fd8bc01c5986a46a72dc0
     spruce: &spruce-image-resource
       type: docker-image
       source:
         repository: ghcr.io/alphagov/paas/spruce
-        tag: 8d6c556abd2d54f27c0fda934d00df8beafac1f8
+        tag: 168a6c8b43fdec99607fd8bc01c5986a46a72dc0
     terraform: &terraform-image-resource
       type: docker-image
       source:
         repository: ghcr.io/alphagov/paas/terraform
-        tag: 8d6c556abd2d54f27c0fda934d00df8beafac1f8
+        tag: 168a6c8b43fdec99607fd8bc01c5986a46a72dc0
 
 groups:
   - name: all

--- a/concourse/pipelines/create-bosh-concourse.yml
+++ b/concourse/pipelines/create-bosh-concourse.yml
@@ -534,14 +534,14 @@ jobs:
             - -e
             - |
               [ -f bucket-state/bucket.tfstate ] && cp bucket-state/bucket.tfstate updated-bucket-state/bucket.tfstate
-              terraform init paas-bootstrap/terraform/bucket
+              cd paas-bootstrap/terraform/bucket || exit
+              terraform init
 
               terraform apply \
                 -auto-approve=true \
-                -var-file="paas-bootstrap/terraform/((aws_account)).tfvars" \
-                -var-file="paas-bootstrap/terraform/((aws_region)).tfvars" \
-                -state=updated-bucket-state/bucket.tfstate \
-                paas-bootstrap/terraform/bucket
+                -var-file="../../../paas-bootstrap/terraform/((aws_account)).tfvars" \
+                -var-file="../../../paas-bootstrap/terraform/((aws_region)).tfvars" \
+                -state=../../../updated-bucket-state/bucket.tfstate
         on_success:
           put: bucket-terraform-state
           params:
@@ -620,15 +620,15 @@ jobs:
             - |
               CONCOURSE_EGRESS_IP=$(wget -q -O - http://169.254.169.254/latest/meta-data/public-ipv4)
               cp vpc-tfstate/vpc.tfstate updated-vpc-tfstate/vpc.tfstate
-              terraform init paas-bootstrap/terraform/vpc
+              cd paas-bootstrap/terraform/vpc || exit
+              terraform init
 
               terraform apply \
                 -auto-approve=true \
                 -var concourse_egress_cidr="${CONCOURSE_EGRESS_IP}/32" \
-                -var-file="paas-bootstrap/terraform/((aws_account)).tfvars" \
-                -var-file="paas-bootstrap/terraform/((aws_region)).tfvars" \
-                -state=updated-vpc-tfstate/vpc.tfstate \
-                paas-bootstrap/terraform/vpc
+                -var-file="../../../paas-bootstrap/terraform/((aws_account)).tfvars" \
+                -var-file="../../../paas-bootstrap/terraform/((aws_region)).tfvars" \
+                -state=../../../updated-vpc-tfstate/vpc.tfstate
         ensure:
           put: vpc-tfstate
           params:
@@ -671,17 +671,16 @@ jobs:
               - |
                 cp bootstrap-cyber-tfstate/bootstrap-cyber.tfstate \
                    updated-bootstrap-cyber-tfstate/bootstrap-cyber.tfstate
-
-                terraform init paas-bootstrap/terraform/cyber
+                cd paas-bootstrap/terraform/cyber || exit
+                terraform init
 
                 terraform apply \
                   -auto-approve=true \
                   -var env="((deploy_env))" \
-                  -var-file="paas-bootstrap/terraform/((aws_account)).tfvars" \
-                  -var-file="paas-bootstrap/terraform/((aws_region)).tfvars" \
-                  -var-file="bootstrap-cyber-tfvars/bootstrap-cyber.tfvars" \
-                  -state=updated-bootstrap-cyber-tfstate/bootstrap-cyber.tfstate \
-                  paas-bootstrap/terraform/cyber
+                  -var-file="../../../paas-bootstrap/terraform/((aws_account)).tfvars" \
+                  -var-file="../../../paas-bootstrap/terraform/((aws_region)).tfvars" \
+                  -var-file="../../../bootstrap-cyber-tfvars/bootstrap-cyber.tfvars" \
+                  -state=../../../updated-bootstrap-cyber-tfstate/bootstrap-cyber.tfstate
 
         ensure:
           put: bootstrap-cyber-tfstate
@@ -876,17 +875,17 @@ jobs:
                 CONCOURSE_EGRESS_IP=$(wget -q -O - http://169.254.169.254/latest/meta-data/public-ipv4)
 
                 cp bosh-tfstate/bosh.tfstate updated-bosh-tfstate/bosh.tfstate
-                terraform init paas-bootstrap/terraform/bosh
+                cd paas-bootstrap/terraform/bosh || exit
+                terraform init
 
                 terraform apply \
                   -auto-approve=true \
                   -var concourse_egress_cidr="${CONCOURSE_EGRESS_IP}/32" \
                   -var env="((deploy_env))" \
-                  -var-file="paas-bootstrap/terraform/((aws_account)).tfvars" \
-                  -var-file="paas-bootstrap/terraform/((aws_region)).tfvars" \
-                  -var-file="bootstrap-cyber-tfvars/bootstrap-cyber.tfvars" \
-                  -state=updated-bosh-tfstate/bosh.tfstate \
-                  paas-bootstrap/terraform/bosh
+                  -var-file="../../../paas-bootstrap/terraform/((aws_account)).tfvars" \
+                  -var-file="../../../paas-bootstrap/terraform/((aws_region)).tfvars" \
+                  -var-file="../../../bootstrap-cyber-tfvars/bootstrap-cyber.tfvars" \
+                  -state=../../../updated-bosh-tfstate/bosh.tfstate
         ensure:
           put: bosh-tfstate
           params:
@@ -1256,15 +1255,15 @@ jobs:
               CONCOURSE_EGRESS_IP=$(wget -q -O - http://169.254.169.254/latest/meta-data/public-ipv4)
 
               cp concourse-tfstate/concourse.tfstate updated-concourse-tfstate/concourse.tfstate
-              terraform init paas-bootstrap/terraform/concourse
+              cd paas-bootstrap/terraform/concourse || exit
+              terraform init
 
               terraform apply \
                 -auto-approve=true \
                 -var concourse_egress_cidr="${CONCOURSE_EGRESS_IP}/32" \
-                -var-file="paas-bootstrap/terraform/((aws_account)).tfvars" \
-                -var-file="paas-bootstrap/terraform/((aws_region)).tfvars" \
-                -state=updated-concourse-tfstate/concourse.tfstate \
-                paas-bootstrap/terraform/concourse
+                -var-file="../../../paas-bootstrap/terraform/((aws_account)).tfvars" \
+                -var-file="../../../paas-bootstrap/terraform/((aws_region)).tfvars" \
+                -state=../../../updated-concourse-tfstate/concourse.tfstate
         ensure:
           put: concourse-tfstate
           params:
@@ -2025,16 +2024,16 @@ jobs:
             - -c
             - |
               cp vpc-tfstate/vpc.tfstate updated-vpc-tfstate/vpc.tfstate
-              terraform init paas-bootstrap/terraform/vpc
+              cd paas-bootstrap/terraform/vpc || exit
+              terraform init
 
               terraform apply \
                 -auto-approve=true \
                 -target=aws_security_group.office-access-ssh \
-                -var-file="paas-bootstrap/terraform/((aws_account)).tfvars" \
-                -var-file="paas-bootstrap/terraform/((aws_region)).tfvars" \
+                -var-file="../../../paas-bootstrap/terraform/((aws_account)).tfvars" \
+                -var-file="../../../paas-bootstrap/terraform/((aws_region)).tfvars" \
                 -target=aws_subnet.infra \
-                -state=updated-vpc-tfstate/vpc.tfstate \
-                paas-bootstrap/terraform/vpc
+                -state=../../../updated-vpc-tfstate/vpc.tfstate
         ensure:
           put: vpc-tfstate
           params:
@@ -2069,16 +2068,16 @@ jobs:
               export TF_VAR_bosh_az=""
 
               cp bosh-tfstate/bosh.tfstate updated-bosh-tfstate/bosh.tfstate
-              terraform init paas-bootstrap/terraform/bosh
+              cd paas-bootstrap/terraform/bosh || exit
+              terraform init
 
               terraform apply \
                 -auto-approve=true \
                 -target=aws_security_group.bosh \
-                -state=updated-bosh-tfstate/bosh.tfstate \
-                -var-file="paas-bootstrap/terraform/((aws_account)).tfvars" \
-                -var-file="paas-bootstrap/terraform/((aws_region)).tfvars" \
-                -var-file="bootstrap-cyber-tfvars/bootstrap-cyber.tfvars" \
-                paas-bootstrap/terraform/bosh
+                -state=../../../updated-bosh-tfstate/bosh.tfstate \
+                -var-file="../../../paas-bootstrap/terraform/((aws_account)).tfvars" \
+                -var-file="../../../paas-bootstrap/terraform/((aws_region)).tfvars" \
+                -var-file="../../../bootstrap-cyber-tfvars/bootstrap-cyber.tfvars"
         ensure:
           put: bosh-tfstate
           params:
@@ -2112,15 +2111,15 @@ jobs:
               . bosh-terraform-outputs/tfvars.sh
 
               cp concourse-tfstate/concourse.tfstate updated-concourse-tfstate/concourse.tfstate
-              terraform init paas-bootstrap/terraform/concourse
+              cd paas-bootstrap/terraform/concourse || exit
+              terraform init
 
               terraform apply \
                 -auto-approve=true \
                 -target=aws_security_group.concourse \
-                -var-file="paas-bootstrap/terraform/((aws_account)).tfvars" \
-                -var-file="paas-bootstrap/terraform/((aws_region)).tfvars" \
-                -state=updated-concourse-tfstate/concourse.tfstate \
-                paas-bootstrap/terraform/concourse
+                -var-file="../../../paas-bootstrap/terraform/((aws_account)).tfvars" \
+                -var-file="../../../paas-bootstrap/terraform/((aws_region)).tfvars" \
+                -state=../../../updated-concourse-tfstate/concourse.tfstate
         ensure:
           put: concourse-tfstate
           params:

--- a/concourse/pipelines/destroy-bosh-concourse.yml
+++ b/concourse/pipelines/destroy-bosh-concourse.yml
@@ -255,7 +255,8 @@ jobs:
               CONCOURSE_EGRESS_IP=$(wget -q -O - http://169.254.169.254/latest/meta-data/public-ipv4)
 
               cp bosh-tfstate/bosh.tfstate updated-bosh-tfstate/bosh.tfstate
-              terraform init paas-bootstrap/terraform/bosh
+              cd paas-bootstrap/terraform/bosh || exit
+              terraform init
 
               sh paas-bootstrap/terraform/./update-terraform-providers.sh updated-bosh-tfstate/bosh.tfstate
 
@@ -263,11 +264,10 @@ jobs:
                 -auto-approve=true \
                 -var concourse_egress_cidr="${CONCOURSE_EGRESS_IP}/32" \
                 -target=aws_security_group.bosh \
-                -state=updated-bosh-tfstate/bosh.tfstate \
-                -var-file="paas-bootstrap/terraform/((aws_account)).tfvars" \
-                -var-file="paas-bootstrap/terraform/((aws_region)).tfvars" \
-                -var-file="bootstrap-cyber-tfvars/bootstrap-cyber.tfvars" \
-                paas-bootstrap/terraform/bosh
+                -state=../../../updated-bosh-tfstate/bosh.tfstate \
+                -var-file="../../../paas-bootstrap/terraform/((aws_account)).tfvars" \
+                -var-file="../../../paas-bootstrap/terraform/((aws_region)).tfvars" \
+                -var-file="../../../bootstrap-cyber-tfvars/bootstrap-cyber.tfvars"
         ensure:
           put: bosh-tfstate
           params:
@@ -380,12 +380,12 @@ jobs:
                 exit 0
               fi
 
-              terraform init paas-bootstrap/terraform/concourse
+              cd paas-bootstrap/terraform/concourse || exit
+              terraform init
               terraform destroy -force \
-                -var-file="paas-bootstrap/terraform/((aws_account)).tfvars" \
-                -var-file="paas-bootstrap/terraform/((aws_region)).tfvars" \
-                -state=updated-concourse-tfstate/concourse.tfstate \
-                paas-bootstrap/terraform/concourse
+                -var-file="../../../paas-bootstrap/terraform/((aws_account)).tfvars" \
+                -var-file="../../../paas-bootstrap/terraform/((aws_region)).tfvars" \
+                -state=../../../updated-concourse-tfstate/concourse.tfstate
         ensure:
           put: concourse-tfstate
           params:
@@ -573,18 +573,18 @@ jobs:
                 CONCOURSE_EGRESS_IP=$(wget -q -O - http://169.254.169.254/latest/meta-data/public-ipv4)
 
                 cp bosh-tfstate/bosh.tfstate updated-bosh-tfstate/bosh.tfstate
-                terraform init paas-bootstrap/terraform/bosh
+                cd paas-bootstrap/terraform/bosh || exit
+                terraform init
 
                 sh paas-bootstrap/terraform/./update-terraform-providers.sh updated-bosh-tfstate/bosh.tfstate
 
                 terraform destroy -force \
                   -var concourse_egress_cidr="${CONCOURSE_EGRESS_IP}/32" \
                   -var env="((deploy_env))" \
-                  -var-file="paas-bootstrap/terraform/((aws_account)).tfvars" \
-                  -var-file="paas-bootstrap/terraform/((aws_region)).tfvars" \
-                  -var-file="bootstrap-cyber-tfvars/bootstrap-cyber.tfvars" \
-                  -state=updated-bosh-tfstate/bosh.tfstate \
-                  paas-bootstrap/terraform/bosh
+                  -var-file="../../../paas-bootstrap/terraform/((aws_account)).tfvars" \
+                  -var-file="../../../paas-bootstrap/terraform/((aws_region)).tfvars" \
+                  -var-file="../../../bootstrap-cyber-tfvars/bootstrap-cyber.tfvars" \
+                  -state=../../../updated-bosh-tfstate/bosh.tfstate
         ensure:
           put: bosh-tfstate
           params:
@@ -620,15 +620,15 @@ jobs:
             - -c
             - |
               cp vpc-tfstate/vpc.tfstate updated-vpc-tfstate/vpc.tfstate
-              terraform init paas-bootstrap/terraform/vpc
+              cd paas-bootstrap/terraform/vpc || exit
+              terraform init
 
               sh paas-bootstrap/terraform/./update-terraform-providers.sh updated-vpc-tfstate/vpc.tfstate
 
               terraform destroy -force \
-                -var-file="paas-bootstrap/terraform/((aws_account)).tfvars" \
-                -var-file="paas-bootstrap/terraform/((aws_region)).tfvars" \
-                -state=updated-vpc-tfstate/vpc.tfstate \
-                paas-bootstrap/terraform/vpc
+                -var-file="../../../paas-bootstrap/terraform/((aws_account)).tfvars" \
+                -var-file="../../../paas-bootstrap/terraform/((aws_region)).tfvars" \
+                -state=../../../updated-vpc-tfstate/vpc.tfstate
         ensure:
           put: vpc-tfstate
           params:
@@ -666,16 +666,16 @@ jobs:
             - -c
             - |
               cp bootstrap-cyber-tfstate/bootstrap-cyber.tfstate updated-bootstrap-cyber-tfstate/bootstrap-cyber.tfstate
-              terraform init paas-bootstrap/terraform/cyber
+              cd paas-bootstrap/terraform/cyber || exit
+              terraform init
 
               sh paas-bootstrap/terraform/./update-terraform-providers.sh updated-bootstrap-cyber-tfstate/bootstrap-cyber.tfstate
 
               terraform destroy -force \
-                -var-file="paas-bootstrap/terraform/((aws_account)).tfvars" \
-                -var-file="paas-bootstrap/terraform/((aws_region)).tfvars" \
-                -var-file="bootstrap-cyber-tfvars/bootstrap-cyber.tfvars" \
-                -state=updated-bootstrap-cyber-tfstate/bootstrap-cyber.tfstate \
-                paas-bootstrap/terraform/cyber
+                -var-file="../../../paas-bootstrap/terraform/((aws_account)).tfvars" \
+                -var-file="../../../paas-bootstrap/terraform/((aws_region)).tfvars" \
+                -var-file="../../../bootstrap-cyber-tfvars/bootstrap-cyber.tfvars" \
+                -state=../../../updated-bootstrap-cyber-tfstate/bootstrap-cyber.tfstate
         ensure:
           put: bootstrap-cyber-tfstate
           params:
@@ -710,9 +710,9 @@ jobs:
             - -e
             - -c
             - |
-              terraform init paas-bootstrap/terraform/bucket
+              cd paas-bootstrap/terraform/bucket || exit
+              terraform init
               terraform destroy -force \
-                -var-file="paas-bootstrap/terraform/((aws_account)).tfvars" \
-                -var-file="paas-bootstrap/terraform/((aws_region)).tfvars" \
-                -state=bucket-terraform-state/bucket.tfstate \
-                paas-bootstrap/terraform/bucket
+                -var-file="../../../paas-bootstrap/terraform/((aws_account)).tfvars" \
+                -var-file="../../../paas-bootstrap/terraform/((aws_region)).tfvars" \
+                -state=../../../bucket-terraform-state/bucket.tfstate

--- a/concourse/pipelines/destroy-bosh-concourse.yml
+++ b/concourse/pipelines/destroy-bosh-concourse.yml
@@ -8,12 +8,12 @@ meta:
       type: docker-image
       source:
         repository: ghcr.io/alphagov/paas/awscli
-        tag: 8d6c556abd2d54f27c0fda934d00df8beafac1f8
+        tag: 168a6c8b43fdec99607fd8bc01c5986a46a72dc0
     bosh-cli-v2: &gov-paas-bosh-cli-v2-image-resource
       type: docker-image
       source:
         repository: ghcr.io/alphagov/paas/bosh-cli-v2
-        tag: 8d6c556abd2d54f27c0fda934d00df8beafac1f8
+        tag: 168a6c8b43fdec99607fd8bc01c5986a46a72dc0
     ruby-slim: &ruby-slim-image-resource
       type: docker-image
       source:
@@ -23,12 +23,12 @@ meta:
       type: docker-image
       source:
         repository: ghcr.io/alphagov/paas/self-update-pipelines
-        tag: 8d6c556abd2d54f27c0fda934d00df8beafac1f8
+        tag: 168a6c8b43fdec99607fd8bc01c5986a46a72dc0
     terraform: &terraform-image-resource
       type: docker-image
       source:
         repository: ghcr.io/alphagov/paas/terraform
-        tag: 8d6c556abd2d54f27c0fda934d00df8beafac1f8
+        tag: 168a6c8b43fdec99607fd8bc01c5986a46a72dc0
 
 resource_types:
 - name: s3-iam

--- a/concourse/tasks/delete-ssh-keys.yml
+++ b/concourse/tasks/delete-ssh-keys.yml
@@ -4,7 +4,7 @@ image_resource:
   type: docker-image
   source:
     repository: ghcr.io/alphagov/paas/awscli
-    tag: 8d6c556abd2d54f27c0fda934d00df8beafac1f8
+    tag: 168a6c8b43fdec99607fd8bc01c5986a46a72dc0
 inputs:
   - name: paas-bootstrap
 run:

--- a/scripts/lint_terraform.sh
+++ b/scripts/lint_terraform.sh
@@ -7,8 +7,12 @@ trap 'rm -r "${TF_DATA_DIR}"' EXIT
 
 export TF_DATA_DIR
 
+CWD=$(pwd)
+
 for dir in terraform/*/; do
-  terraform init "${dir}" >/dev/null
-  terraform validate "${dir}" >/dev/null
-  terraform fmt -check -diff "${dir}"
+  cd "${dir}"
+  terraform init >/dev/null
+  terraform validate >/dev/null
+  terraform fmt -check -diff
+  cd "${CWD}"
 done

--- a/terraform/.terraform.lock.hcl
+++ b/terraform/.terraform.lock.hcl
@@ -1,0 +1,58 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "3.61.0"
+  constraints = "~> 3.61.0"
+  hashes = [
+    "h1:0WQSlLpN11nCeKu/k07BwcpypK0AfZDcbfkCxI/QbiE=",
+    "zh:0483ca802ddb0ae4f73144b4357ba72242c6e2641aeb460b1aa9a6f6965464b0",
+    "zh:274712214ebeb0c1269cbc468e5705bb5741dc45b05c05e9793ca97f22a1baa1",
+    "zh:3c6bd97a2ca809469ae38f6893348386c476cb3065b120b785353c1507401adf",
+    "zh:53dd41a9aed9860adbbeeb71a23e4f8195c656fd15a02c90fa2d302a5f577d8c",
+    "zh:65c639c547b97bc880fd83e65511c0f4bbfc91b63cada3b8c0d5776444221700",
+    "zh:a2769e19137ff480c1dd3e4f248e832df90fb6930a22c66264d9793895161714",
+    "zh:a5897a99332cc0071e46a71359b86a8e53ab09c1453e94cd7cf45a0b577ff590",
+    "zh:bdc2353642d16d8e2437a9015cd4216a1772be9736645cc17d1a197480e2b5b7",
+    "zh:cbeace1deae938f6c0aca3734e6088f3633ca09611aff701c15cb6d42f2b918a",
+    "zh:d33ca19012aabd98cc03fdeccd0bd5ce56e28f61a1dfbb2eea88e89487de7fb3",
+    "zh:d548b29a864b0687e85e8a993f208e25e3ecc40fcc5b671e1985754b32fdd658",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/random" {
+  version     = "3.1.0"
+  constraints = "~> 3.1.0"
+  hashes = [
+    "h1:BZMEPucF+pbu9gsPk0G0BHx7YP04+tKdq2MrRDF1EDM=",
+    "zh:2bbb3339f0643b5daa07480ef4397bd23a79963cc364cdfbb4e86354cb7725bc",
+    "zh:3cd456047805bf639fbf2c761b1848880ea703a054f76db51852008b11008626",
+    "zh:4f251b0eda5bb5e3dc26ea4400dba200018213654b69b4a5f96abee815b4f5ff",
+    "zh:7011332745ea061e517fe1319bd6c75054a314155cb2c1199a5b01fe1889a7e2",
+    "zh:738ed82858317ccc246691c8b85995bc125ac3b4143043219bd0437adc56c992",
+    "zh:7dbe52fac7bb21227acd7529b487511c91f4107db9cc4414f50d04ffc3cab427",
+    "zh:a3a9251fb15f93e4cfc1789800fc2d7414bbc18944ad4c5c98f466e6477c42bc",
+    "zh:a543ec1a3a8c20635cf374110bd2f87c07374cf2c50617eee2c669b3ceeeaa9f",
+    "zh:d9ab41d556a48bd7059f0810cf020500635bfc696c9fc3adab5ea8915c1d886b",
+    "zh:d9e13427a7d011dbd654e591b0337e6074eef8c3b9bb11b2e39eaaf257044fd7",
+    "zh:f7605bd1437752114baf601bdf6931debe6dc6bfe3006eb7e9bb9080931dca8a",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/template" {
+  version     = "2.2.0"
+  constraints = "2.2.0"
+  hashes = [
+    "h1:94qn780bi1qjrbC3uQtjJh3Wkfwd5+tTtJHOb7KTg9w=",
+    "zh:01702196f0a0492ec07917db7aaa595843d8f171dc195f4c988d2ffca2a06386",
+    "zh:09aae3da826ba3d7df69efeb25d146a1de0d03e951d35019a0f80e4f58c89b53",
+    "zh:09ba83c0625b6fe0a954da6fbd0c355ac0b7f07f86c91a2a97849140fea49603",
+    "zh:0e3a6c8e16f17f19010accd0844187d524580d9fdb0731f675ffcf4afba03d16",
+    "zh:45f2c594b6f2f34ea663704cc72048b212fe7d16fb4cfd959365fa997228a776",
+    "zh:77ea3e5a0446784d77114b5e851c970a3dde1e08fa6de38210b8385d7605d451",
+    "zh:8a154388f3708e3df5a69122a23bdfaf760a523788a5081976b3d5616f7d30ae",
+    "zh:992843002f2db5a11e626b3fc23dc0c87ad3729b3b3cff08e32ffb3df97edbde",
+    "zh:ad906f4cebd3ec5e43d5cd6dc8f4c5c9cc3b33d2243c89c5fc18f97f7277b51d",
+    "zh:c979425ddb256511137ecd093e23283234da0154b7fa8b21c2687182d9aea8b2",
+  ]
+}

--- a/terraform/concourse/acm.tf
+++ b/terraform/concourse/acm.tf
@@ -5,18 +5,27 @@ resource "aws_acm_certificate" "system" {
 }
 
 resource "aws_route53_record" "system_cert_validation" {
-  name    = aws_acm_certificate.system.domain_validation_options.0.resource_record_name
-  type    = aws_acm_certificate.system.domain_validation_options.0.resource_record_type
-  zone_id = var.system_dns_zone_id
-  records = [aws_acm_certificate.system.domain_validation_options.0.resource_record_value]
-  ttl     = 60
+  for_each = {
+    for dvo in aws_acm_certificate.system.domain_validation_options : dvo.domain_name => {
+      name   = dvo.resource_record_name
+      record = dvo.resource_record_value
+      type   = dvo.resource_record_type
+    }
+  }
+
+  allow_overwrite = true
+  name            = each.value.name
+  type            = each.value.type
+  zone_id         = var.system_dns_zone_id
+  records         = [each.value.record]
+  ttl             = 60
 }
 
 resource "aws_acm_certificate_validation" "system" {
   certificate_arn = aws_acm_certificate.system.arn
 
   validation_record_fqdns = [
-    aws_route53_record.system_cert_validation.fqdn,
+    for record in aws_route53_record.system_cert_validation : record.fqdn
   ]
 }
 

--- a/terraform/concourse/outputs.tf
+++ b/terraform/concourse/outputs.tf
@@ -52,7 +52,8 @@ output "concourse_db_username" {
 }
 
 output "concourse_db_password" {
-  value = random_password.concourse_rds_password.result
+  value     = random_password.concourse_rds_password.result
+  sensitive = true
 }
 
 output "concourse_db_address" {

--- a/terraform/versions.tf
+++ b/terraform/versions.tf
@@ -2,16 +2,16 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~>2.0"
+      version = "~>3.61.0"
     }
     random = {
       source  = "hashicorp/random"
-      version = "~>2.3"
+      version = "~>3.1.0"
     }
     template = {
       source  = "hashicorp/template"
-      version = "2.1.2"
+      version = "2.2.0"
     }
   }
-  required_version = ">= 0.13"
+  required_version = ">= 1.0.8"
 }


### PR DESCRIPTION
What
----

Update docker containers to get the latest terraform

How to review
-------------

Check the hash matches the latest from https://concourse.build.ci.cloudpipeline.digital/teams/main/pipelines/build-docker-containers/jobs/build-terraform/builds/7

Who can review
--------------

Anyone

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
