### PR TITLE
[#180192789] Wait for secrets to be uploaded on first pipeline run

### DIFF
--- a/concourse/pipelines/create-bosh-concourse.yml
+++ b/concourse/pipelines/create-bosh-concourse.yml
@@ -49,6 +49,7 @@ groups:
   - name: all
     jobs:
       - init-bucket
+      - check-for-secrets
       - vpc
       - generate-secrets
       - bosh-terraform
@@ -550,16 +551,37 @@ jobs:
       - put: pipeline-trigger
         params: {bump: patch}
 
+  - name: check-for-secrets
+    serial: true
+    plan:
+      - get: pipeline-trigger
+        passed: ['init-bucket']
+        trigger: true
+      - get: paas-bootstrap
+        trigger: true
+        passed: ['init-bucket']
+      - task: check-secrets-have-been-uploaded-and-maybe-wait
+        config:
+          platform: linux
+          image_resource: *awscli-image-resource
+          inputs:
+          - name: paas-bootstrap
+          run:
+            path: ./paas-bootstrap/concourse/scripts/wait_for_secrets.sh
+            args:
+              - "((state_bucket))"
+              - "3600"
+
   - name: vpc
     serial: true
     plan:
       - in_parallel:
         - get: paas-bootstrap
           trigger: true
-          passed: ['init-bucket']
+          passed: ['check-for-secrets']
         - get: pipeline-trigger
           trigger: true
-          passed: ['init-bucket']
+          passed: ['check-for-secrets']
         - get: vpc-tfstate
         - get: git-ssh-public-key
         - get: git-ssh-private-key
@@ -642,9 +664,9 @@ jobs:
       - in_parallel:
         - get: pipeline-trigger
           trigger: true
-          passed: ['init-bucket']
+          passed: ['check-for-secrets']
         - get: paas-bootstrap
-          passed: ['init-bucket']
+          passed: ['check-for-secrets']
         - get: bootstrap-cyber-tfvars
         - get: bootstrap-cyber-tfstate
 
@@ -692,9 +714,9 @@ jobs:
     plan:
       - in_parallel:
         - get: paas-bootstrap
-          passed: ['init-bucket']
+          passed: ['check-for-secrets']
         - get: pipeline-trigger
-          passed: ['init-bucket']
+          passed: ['check-for-secrets']
           trigger: true
         - get: bosh-ca
         - get: bosh-ca-crt

--- a/concourse/scripts/wait_for_secrets.sh
+++ b/concourse/scripts/wait_for_secrets.sh
@@ -1,0 +1,31 @@
+#!/bin/sh
+
+BUCKET_NAME=$1
+MAX_WAIT_TIME_SECONDS=$2
+START=$(date +%s)
+
+echo "Going to look in bucket $BUCKET_NAME for secrets"
+echo ""
+
+# Using paas trusted people as a sentinel value
+if ! aws s3 ls "s3://${BUCKET_NAME}/paas-trusted-people/users.yml" > /dev/null 2>&1; then
+    END=$(( START + MAX_WAIT_TIME_SECONDS))
+    cat <<EOF
+The secrets have not been uploaded to this environment's state bucket yet. Refer to the paas-bootstrap readme for how to upload them.
+
+The pipeline will now wait until $(date -d @${END} +%H:%M:%S) to allow you to do that before moving on.
+EOF
+
+    while [ $END -gt "$(date +%s)" ]; do
+        echo "Waiting.. ($(date +%H:%M:%S))"
+        sleep 5
+        if  aws s3 ls "s3://${BUCKET_NAME}/paas-trusted-people/users.yml" > /dev/null 2>&1; then
+          echo "Secrets have been found. Continuing."
+          exit 0
+        fi
+    done
+    echo "Secrets not found and time ran out. Exiting"
+    exit 1
+else
+    echo "Secrets have been uploaded. Continuing."
+fi


### PR DESCRIPTION
What
----

The `create-bosh-concourse` pipeline will fail on its first ever run because
secrets haven't been uploaded. Instead of failing and making people work out
why, we should give them opportunity to upload the secrets once the bucket
which stores them has been created.

How to review
-------------
1. Code review
2. Run the pipeline in extant environment and see it doesn't pause
3. Run the pipeline in a new environment (or otherwise delete the file it checks for) and see it pauses for a bit; then upload the secrets and see it continues

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
