### PR TITLE
Automatically rotate BOSH leaf certificates

### DIFF
--- a/concourse/pipelines/create-bosh-concourse.yml
+++ b/concourse/pipelines/create-bosh-concourse.yml
@@ -2251,6 +2251,7 @@ jobs:
     plan:
 
     - in_parallel:
+      - get: paas-bootstrap
       - get: bosh-manifest-pre-vars
       - get: bosh-vars-store
 
@@ -2259,116 +2260,15 @@ jobs:
         platform: linux
         image_resource: *ruby-slim-image-resource
         inputs:
+          - name: paas-bootstrap
           - name: bosh-manifest-pre-vars
           - name: bosh-vars-store
         run:
-          path: ruby
+          path: sh
           args:
             - -e
+            - -c
             - |
-              # rubocop:disable Layout/MultilineMethodCallIndentation
-              # rubocop:disable Metrics/MethodLength
-              # rubocop:disable Metrics/CyclomaticComplexity
-              # rubocop:disable Metrics/AbcSize
-              #
-              # frozen_string_literal: true
-
-              require 'openssl'
-              require 'yaml'
-
-              CERT_REGEX = /[-]{5}\s*BEGIN CERTIFICATE\s*[-]{5}[^-]*[-]{5}\s*END CERTIFICATE\s*[-]{5}/m.freeze
-
-              ManifestCert = Struct.new(:filepath, :path, :cert, keyword_init: true)
-
-              def find_certificates(yaml, path)
-                return [] if yaml.is_a? Numeric
-                return [] if yaml.is_a? TrueClass
-                return [] if yaml.is_a? FalseClass
-
-                if yaml.is_a? String
-                  return yaml.scan(CERT_REGEX).map do |cert_str|
-                    ManifestCert.new(
-                      path: path,
-                      cert: OpenSSL::X509::Certificate.new(cert_str)
-                    )
-                  end
-                end
-
-                if yaml.is_a? Array
-                  return yaml.each_with_index.map do |v, k|
-                    find_certificates(v, "#{path}/#{k}")
-                  end
-                end
-
-                if yaml.is_a? Hash
-                  return yaml.map do |k, v|
-                    find_certificates(v, "#{path}/#{k}")
-                  end
-                end
-
-                raise "Unknown class #{yaml.class}"
-              end
-
-              manifest_certs = []
-
-              Dir
-                .glob('**/*.y*ml')
-                .each do |filepath|
-                  puts "Finding certificates in #{filepath}"
-                  yaml = YAML.safe_load(File.read(filepath))
-
-                  initial_path = ''
-                  certs = find_certificates(yaml, initial_path).flatten
-                  certs.each { |cert| cert.filepath = filepath }
-
-                  puts "Found #{certs.length} certs"
-
-                  manifest_certs += certs
-                end
-
-              expd_manifest_certs = manifest_certs.select do |cert|
-                cert.cert.not_after <= Time.now
-              end
-
-              thirty_days_time = Time.now + (30 * 86_400)
-              exp_manifest_certs = manifest_certs
-                .select { |cert| cert.cert.not_after <= thirty_days_time }
-                .select { |cert| cert.cert.not_after >= Time.now }
-
-              puts
-              puts "Found #{manifest_certs.length} certs"
-
-              puts
-              puts "Found #{expd_manifest_certs.length} expired certs:"
-              expd_manifest_certs.group_by(&:filepath).each do |filepath, certs|
-                puts "  filepath: #{filepath}"
-                puts '  certs:'
-                certs.each do |cert|
-                  puts "    - path:    #{cert.path}"
-                  puts "      expired: #{cert.cert.not_after}"
-                  puts "      subject: #{cert.cert.subject}"
-                  puts "      issuer:  #{cert.cert.issuer}"
-                end
-              end
-
-              puts
-              puts "Found #{exp_manifest_certs.length} certs close to expiry:"
-              exp_manifest_certs.group_by(&:filepath).each do |filepath, certs|
-                puts "  filepath: #{filepath}"
-                puts '  certs:'
-                certs.each do |cert|
-                  expiry_days = ((cert.cert.not_after - Time.now) / 86_400).to_i
-                  puts "    - path:       #{cert.path}:"
-                  puts "      expires:    #{cert.cert.not_after}"
-                  puts "      subject:    #{cert.cert.subject}"
-                  puts "      issuer:     #{cert.cert.issuer}"
-                  puts "      expires in: #{expiry_days} days"
-                end
-              end
-
-              exit 1 unless expd_manifest_certs.empty?
-              exit 1 unless exp_manifest_certs.empty?
-              # rubocop:enable Layout/MultilineMethodCallIndentation
-              # rubocop:enable Metrics/MethodLength
-              # rubocop:enable Metrics/CyclomaticComplexity
-              # rubocop:enable Metrics/AbcSize
+              ./paas-bootstrap/manifests/shared/scripts/check-certificates.rb \
+                  bosh-manifest-pre-vars/bosh-manifest-pre-vars.yml \
+                  bosh-vars-store/bosh-vars-store.yml

--- a/concourse/pipelines/create-bosh-concourse.yml
+++ b/concourse/pipelines/create-bosh-concourse.yml
@@ -64,8 +64,8 @@ groups:
   - name: credentials
     jobs:
       - clear-concourse-credentials
-      - rotate-bosh-credentials
-      - rotate-bosh-leaf-certs
+      - drop-bosh-credentials-for-rotation
+      - drop-bosh-leaf-certs-for-rotation
       - delete-old-bosh-certs
       - check-certificates
 
@@ -1010,7 +1010,7 @@ jobs:
         output_mapping:
           bosh-manifest: bosh-manifest-pre-vars
 
-      - task: check-and-rotate-bosh-leaf-certs
+      - task: check-and-drop-bosh-leaf-certs-for-rotation
         config:
           platform: linux
           image_resource: *ruby-slim-image-resource
@@ -1019,7 +1019,7 @@ jobs:
             - name: bosh-manifest-pre-vars
             - name: bosh-vars-store-cleaned
           outputs:
-            - name: bosh-vars-store-rotated
+            - name: bosh-vars-store-dropped-for-rotation
           run:
             path: sh
             args:
@@ -1031,19 +1031,19 @@ jobs:
                   bosh-vars-store-cleaned/bosh-vars-store.yml ; then
 
                   # certs are ok - perform a no-op "rotation"
-                  cp bosh-vars-store-cleaned/bosh-vars-store.yml bosh-vars-store-rotated/bosh-vars-store.yml
+                  cp bosh-vars-store-cleaned/bosh-vars-store.yml bosh-vars-store-dropped-for-rotation/bosh-vars-store.yml
 
                 else
 
                   # certificates due for rotation were detected.
                   # this isn't particularly sophisticated - *any* leaf certificate
                   # being due for rotation will cause them *all* to be regenerated.
-                  echo "Rotating bosh leaf certs..."
-                  ./paas-bootstrap/manifests/shared/scripts/rotate-vars-store-secrets.rb \
+                  echo "Dropping bosh leaf certs for rotation..."
+                  ./paas-bootstrap/manifests/shared/scripts/drop-vars-store-secrets-for-rotation.rb \
                     --leaf \
                     --manifest bosh-manifest-pre-vars/bosh-manifest.yml \
                     --vars-store bosh-vars-store-cleaned/bosh-vars-store.yml \
-                    > bosh-vars-store-rotated/bosh-vars-store.yml
+                    > bosh-vars-store-dropped-for-rotation/bosh-vars-store.yml
 
                 fi
 
@@ -1058,7 +1058,7 @@ jobs:
           BOSH_FQDN_EXTERNAL: ((bosh_fqdn_external))
           BOSH_INSTANCE_PROFILE: ((bosh_instance_profile))
         input_mapping:
-          bosh-vars-store: bosh-vars-store-rotated
+          bosh-vars-store: bosh-vars-store-dropped-for-rotation
         output_mapping:
           bosh-manifest: bosh-manifest
 
@@ -2177,13 +2177,14 @@ jobs:
           BUCKET: ((state_bucket))
           SSH_KEY_PREFIX: concourse_
 
-  - name: rotate-bosh-credentials
+  - name: drop-bosh-credentials-for-rotation
+    old_name: rotate-bosh-credentials
     plan:
       - in_parallel:
         - get: bosh-vars-store
         - get: bosh-manifest-pre-vars
         - get: paas-bootstrap
-      - task: rotate-bosh-secrets
+      - task: drop-vars-store-secrets-for-rotation
         config:
           platform: linux
           image_resource: *ruby-slim-image-resource
@@ -2203,7 +2204,7 @@ jobs:
                 # Wipe all the file
                 echo {} > modified-secrets/bosh-secrets.yml
 
-                ./paas-bootstrap/manifests/shared/scripts/rotate-vars-store-secrets.rb \
+                ./paas-bootstrap/manifests/shared/scripts/drop-vars-store-secrets-for-rotation.rb \
                   --vars-store bosh-vars-store/bosh-vars-store.yml \
                   --manifest bosh-manifest-pre-vars/bosh-manifest-pre-vars.yml \
                   --passwords \
@@ -2225,14 +2226,15 @@ jobs:
           BUCKET: ((state_bucket))
           SSH_KEY_PREFIX: bosh_
 
-  - name: rotate-bosh-leaf-certs
+  - name: drop-bosh-leaf-certs-for-rotation
+    old_name: rotate-bosh-leaf-certs
     serial: true
     plan:
     - in_parallel:
       - get: paas-bootstrap
       - get: bosh-vars-store
       - get: bosh-manifest-pre-vars
-    - task: rotate-bosh-leaf-certs
+    - task: drop-vars-store-secrets-for-rotation
       config:
         platform: linux
         image_resource: *ruby-slim-image-resource
@@ -2248,7 +2250,8 @@ jobs:
             - -e
             - -c
             - |
-              ./paas-bootstrap/manifests/shared/scripts/rotate-vars-store-secrets.rb --leaf \
+              ./paas-bootstrap/manifests/shared/scripts/drop-vars-store-secrets-for-rotation.rb \
+                --leaf \
                 --manifest bosh-manifest-pre-vars/bosh-manifest-pre-vars.yml \
                 --vars-store bosh-vars-store/bosh-vars-store.yml \
                 > updated-bosh-vars-store/bosh-vars-store.yml
@@ -2278,7 +2281,8 @@ jobs:
             - -e
             - -c
             - |
-              ./paas-bootstrap/manifests/shared/scripts/rotate-vars-store-secrets.rb --delete \
+              ./paas-bootstrap/manifests/shared/scripts/drop-vars-store-secrets-for-rotation.rb \
+                --delete \
                 --manifest bosh-manifest-pre-vars/bosh-manifest-pre-vars.yml \
                 --vars-store bosh-vars-store/bosh-vars-store.yml \
                 > updated-bosh-certs/bosh-vars-store.yml

--- a/concourse/pipelines/create-bosh-concourse.yml
+++ b/concourse/pipelines/create-bosh-concourse.yml
@@ -974,63 +974,104 @@ jobs:
                   paas-trusted-people/users.yml "((aws_account))" > unix-users-ops-file/unix-users-ops-file.yml
                 cat unix-users-ops-file/unix-users-ops-file.yml
 
-      - task: render-bosh-manifest
+      - task: clean-bosh-vars-store
         config:
           platform: linux
           image_resource: *gov-paas-bosh-cli-v2-image-resource
           inputs:
-            - name: paas-bootstrap
-            - name: terraform-outputs
-            - name: bosh-secrets
-            - name: bosh-ca
             - name: bosh-vars-store
-            - name: bosh-uaa-google-oauth-secrets
-            - name: bosh-cyber-secrets
-            - name: unix-users-ops-file
-            - name: uaa-users-ops-file
+            - name: paas-bootstrap
           outputs:
-            - name: bosh-manifest
+            - name: bosh-vars-store-cleaned
+          run:
+            path: sh
+            args:
+            - -c
+            - -e
+            - |
+              cp bosh-vars-store/bosh-vars-store.yml bosh-vars-store-cleaned/bosh-vars-store.yml
+
+              paas-bootstrap/manifests/bosh-manifest/scripts/cleanup-bosh-vars-store.rb \
+                bosh-vars-store-cleaned/bosh-vars-store.yml
+
+      - task: render-bosh-manifest-pre-vars
+        # i.e. a copy of the manifest before variable interpolation has
+        # taken place, with a `variables:` section still present
+        file: paas-bootstrap/concourse/tasks/render-bosh-manifest.yml
+        params:
+          USE_VARS_STORE: false
+          DEPLOY_ENV: ((deploy_env))
+          AWS_ACCOUNT: ((aws_account))
+          AWS_DEFAULT_REGION: ((aws_region))
+          SYSTEM_DNS_ZONE_NAME: ((system_dns_zone_name))
+          BOSH_FQDN: ((bosh_fqdn))
+          BOSH_FQDN_EXTERNAL: ((bosh_fqdn_external))
+          BOSH_INSTANCE_PROFILE: ((bosh_instance_profile))
+        output_mapping:
+          bosh-manifest: bosh-manifest-pre-vars
+
+      - task: check-and-rotate-bosh-leaf-certs
+        config:
+          platform: linux
+          image_resource: *ruby-slim-image-resource
+          inputs:
+            - name: paas-bootstrap
             - name: bosh-manifest-pre-vars
-            - name: bosh-vars-store-updated
-          params:
-            DEPLOY_ENV: ((deploy_env))
-            AWS_ACCOUNT: ((aws_account))
-            AWS_DEFAULT_REGION: ((aws_region))
-            SYSTEM_DNS_ZONE_NAME: ((system_dns_zone_name))
-            BOSH_FQDN: ((bosh_fqdn))
-            BOSH_FQDN_EXTERNAL: ((bosh_fqdn_external))
-            BOSH_INSTANCE_PROFILE: ((bosh_instance_profile))
+            - name: bosh-vars-store-cleaned
+          outputs:
+            - name: bosh-vars-store-rotated
           run:
             path: sh
             args:
               - -e
               - -c
               - |
-                mkdir -p certs
-                tar -xvzf bosh-ca/bosh-CA.tar.gz -C certs
+                if ./paas-bootstrap/manifests/shared/scripts/check-certificates.rb \
+                  --skip-ca-certs \
+                  bosh-vars-store-cleaned/bosh-vars-store.yml ; then
 
-                paas-bootstrap/manifests/bosh-manifest/scripts/generate-manifest.sh \
-                  > bosh-manifest-pre-vars/bosh-manifest-pre-vars.yml
+                  # certs are ok - perform a no-op "rotation"
+                  cp bosh-vars-store-cleaned/bosh-vars-store.yml bosh-vars-store-rotated/bosh-vars-store.yml
 
-                cp bosh-vars-store/bosh-vars-store.yml bosh-vars-store-updated/bosh-vars-store.yml
+                else
 
-                paas-bootstrap/manifests/bosh-manifest/scripts/cleanup-bosh-vars-store.rb \
-                  bosh-vars-store-updated/bosh-vars-store.yml
+                  # certificates due for rotation were detected.
+                  # this isn't particularly sophisticated - *any* leaf certificate
+                  # being due for rotation will cause them *all* to be regenerated.
+                  echo "Rotating bosh leaf certs..."
+                  ./paas-bootstrap/manifests/shared/scripts/rotate-vars-store-secrets.rb \
+                    --leaf \
+                    --manifest bosh-manifest-pre-vars/bosh-manifest.yml \
+                    --vars-store bosh-vars-store-cleaned/bosh-vars-store.yml \
+                    > bosh-vars-store-rotated/bosh-vars-store.yml
 
-                VARS_STORE=bosh-vars-store-updated/bosh-vars-store.yml \
-                  paas-bootstrap/manifests/bosh-manifest/scripts/generate-manifest.sh \
-                    > bosh-manifest/bosh-manifest.yml
-        on_success:
-          in_parallel:
-          - put: bosh-manifest
-            params:
-              file: bosh-manifest/bosh-manifest.yml
-          - put: bosh-manifest-pre-vars
-            params:
-              file: bosh-manifest-pre-vars/bosh-manifest-pre-vars.yml
-          - put: bosh-vars-store
-            params:
-              file: bosh-vars-store-updated/bosh-vars-store.yml
+                fi
+
+      - task: render-bosh-manifest
+        file: paas-bootstrap/concourse/tasks/render-bosh-manifest.yml
+        params:
+          DEPLOY_ENV: ((deploy_env))
+          AWS_ACCOUNT: ((aws_account))
+          AWS_DEFAULT_REGION: ((aws_region))
+          SYSTEM_DNS_ZONE_NAME: ((system_dns_zone_name))
+          BOSH_FQDN: ((bosh_fqdn))
+          BOSH_FQDN_EXTERNAL: ((bosh_fqdn_external))
+          BOSH_INSTANCE_PROFILE: ((bosh_instance_profile))
+        input_mapping:
+          bosh-vars-store: bosh-vars-store-rotated
+        output_mapping:
+          bosh-manifest: bosh-manifest
+
+      - in_parallel:
+        - put: bosh-manifest
+          params:
+            file: bosh-manifest/bosh-manifest.yml
+        - put: bosh-manifest-pre-vars
+          params:
+            file: bosh-manifest-pre-vars/bosh-manifest.yml
+        - put: bosh-vars-store
+          params:
+            file: bosh-vars-store-updated/bosh-vars-store.yml
 
   - name: bosh-deploy
     serial: true

--- a/concourse/tasks/render-bosh-manifest.yml
+++ b/concourse/tasks/render-bosh-manifest.yml
@@ -1,0 +1,47 @@
+---
+platform: linux
+image_resource:
+  type: docker-image
+  source:
+    repository: ghcr.io/alphagov/paas/bosh-cli-v2
+    tag: 168a6c8b43fdec99607fd8bc01c5986a46a72dc0
+inputs:
+  - name: bosh-vars-store
+    optional: true
+  - name: paas-bootstrap
+  - name: terraform-outputs
+  - name: bosh-secrets
+  - name: bosh-ca
+  - name: bosh-uaa-google-oauth-secrets
+  - name: bosh-cyber-secrets
+  - name: unix-users-ops-file
+  - name: uaa-users-ops-file
+outputs:
+  - name: bosh-manifest
+  - name: bosh-vars-store-updated
+params:
+  USE_VARS_STORE:
+  DEPLOY_ENV:
+  AWS_ACCOUNT:
+  AWS_DEFAULT_REGION:
+  SYSTEM_DNS_ZONE_NAME:
+  BOSH_FQDN:
+  BOSH_FQDN_EXTERNAL:
+  BOSH_INSTANCE_PROFILE:
+run:
+  path: sh
+  args:
+    - -e
+    - -c
+    - |
+      mkdir -p certs
+      tar -xvzf bosh-ca/bosh-CA.tar.gz -C certs
+
+      if { [ -z "$USE_VARS_STORE" ] && [ -d bosh-vars-store ]; } \
+        || { [ -n "$USE_VARS_STORE" ] && [ "$USE_VARS_STORE" != "0" ] && [ "$USE_VARS_STORE" != "false" ]; } ; then
+        cp bosh-vars-store/bosh-vars-store.yml bosh-vars-store-updated/bosh-vars-store.yml
+        export VARS_STORE=bosh-vars-store-updated/bosh-vars-store.yml
+      fi
+
+      paas-bootstrap/manifests/bosh-manifest/scripts/generate-manifest.sh \
+        > bosh-manifest/bosh-manifest.yml

--- a/manifests/shared/scripts/check-certificates.rb
+++ b/manifests/shared/scripts/check-certificates.rb
@@ -1,0 +1,108 @@
+#!/usr/bin/env ruby
+# rubocop:disable Layout/MultilineMethodCallIndentation
+# rubocop:disable Metrics/MethodLength
+# rubocop:disable Metrics/CyclomaticComplexity
+# rubocop:disable Metrics/AbcSize
+#
+# frozen_string_literal: true
+
+require 'openssl'
+require 'yaml'
+
+CERT_REGEX = /[-]{5}\s*BEGIN CERTIFICATE\s*[-]{5}[^-]*[-]{5}\s*END CERTIFICATE\s*[-]{5}/m.freeze
+PRE_WARNING_DAYS = 400
+
+ManifestCert = Struct.new(:filepath, :path, :cert, keyword_init: true)
+
+def find_certificates(yaml, path)
+  return [] if yaml.is_a? Numeric
+  return [] if yaml.is_a? TrueClass
+  return [] if yaml.is_a? FalseClass
+
+  if yaml.is_a? String
+    return yaml.scan(CERT_REGEX).map do |cert_str|
+      ManifestCert.new(
+        path: path,
+        cert: OpenSSL::X509::Certificate.new(cert_str)
+      )
+    end
+  end
+
+  if yaml.is_a? Array
+    return yaml.each_with_index.map do |v, k|
+      find_certificates(v, "#{path}/#{k}")
+    end
+  end
+
+  if yaml.is_a? Hash
+    return yaml.map do |k, v|
+      find_certificates(v, "#{path}/#{k}")
+    end
+  end
+
+  raise "Unknown class #{yaml.class}"
+end
+
+manifest_certs = []
+
+puts ARGV
+
+ARGV.each do |filepath|
+  puts "Finding certificates in #{filepath}"
+  yaml = YAML.safe_load(File.read(filepath))
+
+  initial_path = ''
+  certs = find_certificates(yaml, initial_path).flatten
+  certs.each { |cert| cert.filepath = filepath }
+
+  puts "Found #{certs.length} certs"
+
+  manifest_certs += certs
+end
+
+expd_manifest_certs = manifest_certs.select do |cert|
+  cert.cert.not_after <= Time.now
+end
+
+n_days_time = Time.now + (PRE_WARNING_DAYS * 86_400)
+exp_manifest_certs = manifest_certs
+  .select { |cert| cert.cert.not_after <= n_days_time }
+  .select { |cert| cert.cert.not_after >= Time.now }
+
+puts
+puts "Found #{manifest_certs.length} certs"
+
+puts
+puts "Found #{expd_manifest_certs.length} expired certs:"
+expd_manifest_certs.group_by(&:filepath).each do |filepath, certs|
+  puts "  filepath: #{filepath}"
+  puts '  certs:'
+  certs.each do |cert|
+    puts "    - path:    #{cert.path}"
+    puts "      expired: #{cert.cert.not_after}"
+    puts "      subject: #{cert.cert.subject}"
+    puts "      issuer:  #{cert.cert.issuer}"
+  end
+end
+
+puts
+puts "Found #{exp_manifest_certs.length} certs close to expiry:"
+exp_manifest_certs.group_by(&:filepath).each do |filepath, certs|
+  puts "  filepath: #{filepath}"
+  puts '  certs:'
+  certs.each do |cert|
+    expiry_days = ((cert.cert.not_after - Time.now) / 86_400).to_i
+    puts "    - path:       #{cert.path}:"
+    puts "      expires:    #{cert.cert.not_after}"
+    puts "      subject:    #{cert.cert.subject}"
+    puts "      issuer:     #{cert.cert.issuer}"
+    puts "      expires in: #{expiry_days} days"
+  end
+end
+
+exit 1 unless expd_manifest_certs.empty?
+exit 1 unless exp_manifest_certs.empty?
+# rubocop:enable Layout/MultilineMethodCallIndentation
+# rubocop:enable Metrics/MethodLength
+# rubocop:enable Metrics/CyclomaticComplexity
+# rubocop:enable Metrics/AbcSize

--- a/manifests/shared/scripts/check-certificates.rb
+++ b/manifests/shared/scripts/check-certificates.rb
@@ -1,42 +1,62 @@
 #!/usr/bin/env ruby
-# rubocop:disable Layout/MultilineMethodCallIndentation
-# rubocop:disable Metrics/MethodLength
-# rubocop:disable Metrics/CyclomaticComplexity
-# rubocop:disable Metrics/AbcSize
-#
-# frozen_string_literal: true
 
-require 'openssl'
-require 'yaml'
+require "openssl"
+require "yaml"
+require "optparse"
 
 CERT_REGEX = /[-]{5}\s*BEGIN CERTIFICATE\s*[-]{5}[^-]*[-]{5}\s*END CERTIFICATE\s*[-]{5}/m.freeze
-PRE_WARNING_DAYS = 400
+
+options = {
+  min_remaining_days: 180,
+  skip_ca_certs: false,
+}
+option_parser = OptionParser.new do |opts|
+  opts.on("--min-remaining-days [DAYS]", Integer) do |days|
+    options[:min_remaining_days] = days
+  end
+  opts.on("--skip-ca-certs") do
+    options[:skip_ca_certs] = true
+  end
+end
+option_parser.parse!
 
 ManifestCert = Struct.new(:filepath, :path, :cert, keyword_init: true)
 
-def find_certificates(yaml, path)
+def basic_constraints_value(cert)
+  cert.extensions.find { |ext| ext.oid == "basicConstraints" }.value
+end
+
+def is_ca(cert)
+  basic_constraints_value(cert) != "CA:FALSE"
+end
+
+def find_certificates(yaml, path, skip_ca_certs)
   return [] if yaml.is_a? Numeric
   return [] if yaml.is_a? TrueClass
   return [] if yaml.is_a? FalseClass
 
   if yaml.is_a? String
     return yaml.scan(CERT_REGEX).map do |cert_str|
+      cert = OpenSSL::X509::Certificate.new(cert_str)
+
+      return [] if skip_ca_certs && is_ca(cert)
+
       ManifestCert.new(
         path: path,
-        cert: OpenSSL::X509::Certificate.new(cert_str)
+        cert: cert,
       )
     end
   end
 
   if yaml.is_a? Array
     return yaml.each_with_index.map do |v, k|
-      find_certificates(v, "#{path}/#{k}")
+      find_certificates(v, "#{path}/#{k}", skip_ca_certs)
     end
   end
 
   if yaml.is_a? Hash
     return yaml.map do |k, v|
-      find_certificates(v, "#{path}/#{k}")
+      find_certificates(v, "#{path}/#{k}", skip_ca_certs)
     end
   end
 
@@ -45,14 +65,14 @@ end
 
 manifest_certs = []
 
-puts ARGV
+raise "No filenames supplied" if ARGV.empty?
 
 ARGV.each do |filepath|
   puts "Finding certificates in #{filepath}"
   yaml = YAML.safe_load(File.read(filepath))
 
-  initial_path = ''
-  certs = find_certificates(yaml, initial_path).flatten
+  initial_path = ""
+  certs = find_certificates(yaml, initial_path, options[:skip_ca_certs]).flatten
   certs.each { |cert| cert.filepath = filepath }
 
   puts "Found #{certs.length} certs"
@@ -60,12 +80,12 @@ ARGV.each do |filepath|
   manifest_certs += certs
 end
 
-expd_manifest_certs = manifest_certs.select do |cert|
+expired_manifest_certs = manifest_certs.select do |cert|
   cert.cert.not_after <= Time.now
 end
 
-n_days_time = Time.now + (PRE_WARNING_DAYS * 86_400)
-exp_manifest_certs = manifest_certs
+n_days_time = Time.now + (options[:min_remaining_days] * 86_400)
+expiring_manifest_certs = manifest_certs
   .select { |cert| cert.cert.not_after <= n_days_time }
   .select { |cert| cert.cert.not_after >= Time.now }
 
@@ -73,36 +93,34 @@ puts
 puts "Found #{manifest_certs.length} certs"
 
 puts
-puts "Found #{expd_manifest_certs.length} expired certs:"
-expd_manifest_certs.group_by(&:filepath).each do |filepath, certs|
+puts "Found #{expired_manifest_certs.length} expired certs:"
+expired_manifest_certs.group_by(&:filepath).each do |filepath, certs|
   puts "  filepath: #{filepath}"
-  puts '  certs:'
+  puts "  certs:"
   certs.each do |cert|
-    puts "    - path:    #{cert.path}"
-    puts "      expired: #{cert.cert.not_after}"
-    puts "      subject: #{cert.cert.subject}"
-    puts "      issuer:  #{cert.cert.issuer}"
+    puts "    - path:             #{cert.path}"
+    puts "      expired:          #{cert.cert.not_after}"
+    puts "      subject:          #{cert.cert.subject}"
+    puts "      issuer:           #{cert.cert.issuer}"
+    puts "      basicConstraints: #{basic_constraints_value(cert.cert)}"
   end
 end
 
 puts
-puts "Found #{exp_manifest_certs.length} certs close to expiry:"
-exp_manifest_certs.group_by(&:filepath).each do |filepath, certs|
+puts "Found #{expiring_manifest_certs.length} certs close to expiry:"
+expiring_manifest_certs.group_by(&:filepath).each do |filepath, certs|
   puts "  filepath: #{filepath}"
-  puts '  certs:'
+  puts "  certs:"
   certs.each do |cert|
     expiry_days = ((cert.cert.not_after - Time.now) / 86_400).to_i
-    puts "    - path:       #{cert.path}:"
-    puts "      expires:    #{cert.cert.not_after}"
-    puts "      subject:    #{cert.cert.subject}"
-    puts "      issuer:     #{cert.cert.issuer}"
-    puts "      expires in: #{expiry_days} days"
+    puts "    - path:             #{cert.path}:"
+    puts "      expires:          #{cert.cert.not_after}"
+    puts "      subject:          #{cert.cert.subject}"
+    puts "      issuer:           #{cert.cert.issuer}"
+    puts "      basicConstraints: #{basic_constraints_value(cert.cert)}"
+    puts "      expires in:       #{expiry_days} days"
   end
 end
 
-exit 1 unless expd_manifest_certs.empty?
-exit 1 unless exp_manifest_certs.empty?
-# rubocop:enable Layout/MultilineMethodCallIndentation
-# rubocop:enable Metrics/MethodLength
-# rubocop:enable Metrics/CyclomaticComplexity
-# rubocop:enable Metrics/AbcSize
+exit 1 unless expired_manifest_certs.empty?
+exit 1 unless expiring_manifest_certs.empty?

--- a/manifests/shared/scripts/drop-vars-store-secrets-for-rotation.rb
+++ b/manifests/shared/scripts/drop-vars-store-secrets-for-rotation.rb
@@ -12,16 +12,16 @@ BLANK_CERT = {
 def parse_args
   options = { vars_to_preserve: [] }
   parser = OptionParser.new
-  parser.banner = "Usage: rotate-vars-store-secrets.rb [options]"
-  parser.on("--ca", "Rotate CA certs") { options[:ca] = true }
-  parser.on("--leaf", "Rotate leaf certs") { options[:leaf] = true }
-  parser.on("--passwords", "Rotate passwords") { options[:passwords] = true }
-  parser.on("--rsa", "Rotate rsa keys") { options[:rsa] = true }
-  parser.on("--ssh", "Rotate ssh keys") { options[:ssh] = true }
-  parser.on("--delete", "Delete _old variables") { options[:delete] = true }
+  parser.banner = "Usage: drop-vars-store-secrets-for-rotation.rb [options]"
+  parser.on("--ca", "Drop CA certs") { options[:ca] = true }
+  parser.on("--leaf", "Drop leaf certs") { options[:leaf] = true }
+  parser.on("--passwords", "Drop passwords") { options[:passwords] = true }
+  parser.on("--rsa", "Drop rsa keys") { options[:rsa] = true }
+  parser.on("--ssh", "Drop ssh keys") { options[:ssh] = true }
+  parser.on("--delete-old", "Delete _old variables") { options[:delete] = true }
   parser.on("--manifest MANIFEST", "BOSH manifest") { |v| options[:manifest] = v }
   parser.on("--vars-store VARS", "BOSH variable store") { |v| options[:vars_store] = v }
-  parser.on("--preserve VAR", "variables to not rotate") do |v|
+  parser.on("--preserve VAR", "variables to not drop") do |v|
     options[:vars_to_preserve] << v
   end
   parser.parse!

--- a/manifests/shared/spec/scripts/drop_vars_store_secrets_for_rotation_spec.rb
+++ b/manifests/shared/spec/scripts/drop_vars_store_secrets_for_rotation_spec.rb
@@ -1,4 +1,4 @@
-require_relative "../../scripts/rotate-vars-store-secrets.rb"
+require_relative "../../scripts/drop-vars-store-secrets-for-rotation.rb"
 
 RSpec.describe "rotate-cf-certs" do
   let(:manifest) do


### PR DESCRIPTION
What
----
https://www.pivotaltracker.com/story/show/178640681

We decided to integrate the rotation process with the release pipeline in a similar way to the `create-cloudfoundry` pipeline's certificate handling rather than having some time-based trigger asynchronously causing the certificate update to happen behind the scenes. This does mean that it relies on the pipeline being run _during_ the expiry period for the rotation to happen in time, which is a concern because the `create-bosh-concourse` pipeline is run so much less frequently than `create-cloudfoundry`. To this end I increased the grace period to 180 days before the certificate expiry to give us a better chance.

Because all we're rotating here are the leaf certificates, I realized we don't have to do any clever two-phase rollouts for the rotation - the old certificates aren't being made invalid (they remain valid until their expiry date). So simply inspecting the certificates _before_ rollout and replacing certificates then (if deemed necessary) will suffice.

The existing `check-certificates` job was split to a separate script and given the ability to ignore CA certificates. This is then used to detect certificates close to expiry. As noted in the comments it is not sophisticated enough to rotate just those certificates that need it, but I suspect all of our leaf certificates share the same timestamp anyway.

This also does a bit of refactoring of the `create-bosh-concourse` pipeline's bosh credential handling which I found quite puzzling initially. Hopefully the end result is a little easier to understand than before. In particular, the script `rotate-vars-store-secrets.rb` was renamed to `drop-vars-store-secrets-for-rotation.rb` (along with its associated jobs & tasks) because it _doesn't actually_ rotate the secrets. It simply drops them (or possibly moves them to an `_old` sibling key) so that the next call to `generate-manifest.rb` will do the regeneration.

How to review
-------------

Deploy to a dev env and perform a deployment. If your certificates aren't due for regeneration, you can hack a `--min-remaining-days 400` flag into the `check-certificates.rb` call in the `check-bosh-leaf-certs` task, which will _always_ consider the certificates to be due for renewal.

Probably best to also check the standalone `drop-bosh-leaf-certs-for-rotation` and `check-certificates` jobs (visible in the `credentials` group) work for you.

Who can review
--------------
Not @risicle, not @milesb-gds, possibly not @cadmiumcat .

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
