### PR TITLE
[#180965549] Update ELB security policy to 'ELBSecurityPolicy-TLS-1-2-2017-01'

### DIFF
--- a/terraform/concourse/elb.tf
+++ b/terraform/concourse/elb.tf
@@ -30,13 +30,13 @@ resource "aws_elb" "concourse" {
 }
 
 resource "aws_lb_ssl_negotiation_policy" "concourse" {
-  name          = "paas-${var.default_elb_security_policy}"
+  name          = "paas-${var.default_classic_load_balancer_security_policy}"
   load_balancer = aws_elb.concourse.id
   lb_port       = 443
 
   attribute {
     name  = "Reference-Security-Policy"
-    value = var.default_elb_security_policy
+    value = var.default_classic_load_balancer_security_policy
   }
 }
 

--- a/terraform/globals.tf
+++ b/terraform/globals.tf
@@ -103,8 +103,8 @@ variable "admin_cidrs" {
 }
 
 /* See https://docs.aws.amazon.com/elasticloadbalancing/latest/classic/elb-security-policy-table.html */
-variable "default_elb_security_policy" {
-  description = "Which Security policy to use for ELBs. This controls things like available SSL protocols/ciphers."
+variable "default_classic_load_balancer_security_policy" {
+  description = "Which Security policy to use for classic load balancers. This controls things like available SSL protocols/ciphers."
   default     = "ELBSecurityPolicy-TLS-1-2-2017-01"
 }
 


### PR DESCRIPTION
What
----

Also renames the `default_elb_security_policy` variable to `default_classic_load_balancer_security_policy`. This is to disambiguate between ELBs (classic) and ALB/NLBs (ELBv2).

How to review
-------------

1. Code review
2. I don't believe this should cause any downtime for us.

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
