### PR TITLE
bionic stemcells: 1.36 -> 1.67

### DIFF
--- a/manifests/bosh-manifest/operations.d/030-set-stemcell.yml
+++ b/manifests/bosh-manifest/operations.d/030-set-stemcell.yml
@@ -2,5 +2,5 @@
 - type: replace
   path: /resource_pools/name=vms/stemcell
   value:
-    url: https://bosh.io/d/stemcells/bosh-aws-xen-hvm-ubuntu-bionic-go_agent?v=1.36
-    sha1: 4278c71c23a2f0345e445825baa9f631f15ad520
+    url: https://bosh.io/d/stemcells/bosh-aws-xen-hvm-ubuntu-bionic-go_agent?v=1.67
+    sha1: 625d9c36974d24423687c00e6bdf16e0a9039d54

--- a/manifests/concourse-manifest/concourse-base.yml
+++ b/manifests/concourse-manifest/concourse-base.yml
@@ -2,7 +2,7 @@
 meta:
   stemcell:
     name: bosh-aws-xen-hvm-ubuntu-bionic-go_agent
-    version: "1.36"
+    version: "1.67"
 
 name: concourse
 


### PR DESCRIPTION
What
----

Bumped bionic stemcells for bosh and concourse to 1.67.

How to review
-------------

Either deploy it to a dev env and run `create-bosh-concourse` or look at `dev03` where it's had it applied successfully.

Who can review
--------------
Anyone but @risicle 

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
