### PR TITLE
181770492 update bosh uaa

### DIFF
--- a/manifests/bosh-manifest/operations.d/040-cloud-provider.yml
+++ b/manifests/bosh-manifest/operations.d/040-cloud-provider.yml
@@ -9,7 +9,3 @@
 - type: replace
   path: /cloud_provider/properties/aws/max_retries?
   value: 16
-
-- type: replace
-  path: /cloud_provider/ssh_tunnel/host
-  value: ((bosh_fqdn_external))


### PR DESCRIPTION
What
----

This updates the BOSH UAA submodule to the newest version. This also removes the ssh_tunnel option from the ops file as it is no longer present in the BOSH manifest due to BOSH removing Registry. Removed `ssh_tunnel` options as this was only used by the CPI for BOSH Registry and doesn't affect SSH-ing into the BOSH Director. This is part
 of a larger piece of work to remove BOSH Registry from the BOSH Deployment. See the discussion at https://github.com/cloudfoundry/bosh/discussions/2355

How to review
-------------

dev01 is currently deployed with the newer BOSH UAA so check that one can SSH into the BOSH Director and Credhub CLI.

Who can review
--------------

Describe who can review the changes. Or more importantly, list the people
that can't review, because they worked on it.

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
