### PR TITLE
181770492 - Update BOSH deployment

### DIFF
--- a/manifests/bosh-manifest/operations.d/040-cloud-provider.yml
+++ b/manifests/bosh-manifest/operations.d/040-cloud-provider.yml
@@ -9,7 +9,3 @@
 - type: replace
   path: /cloud_provider/properties/aws/max_retries?
   value: 16
-
-- type: replace
-  path: /cloud_provider/ssh_tunnel/host
-  value: ((bosh_fqdn_external))

--- a/manifests/bosh-manifest/operations.d/120-cpi.yml
+++ b/manifests/bosh-manifest/operations.d/120-cpi.yml
@@ -6,6 +6,6 @@
   type: replace
   value:
     name: "bosh-aws-cpi"
-    version: "91"
-    url: "https://bosh.io/d/github.com/cloudfoundry/bosh-aws-cpi-release?v=91"
-    sha1: "c8fdf45dd3baa0c85f5f64b472b55b2ff3432cb4"
+    version: "93"
+    url: "https://bosh.io/d/github.com/cloudfoundry/bosh-aws-cpi-release?v=93"
+    sha1: "1b4d0f542faa1b8e6fd5aaae375073ecf7833291"


### PR DESCRIPTION
What
----

- Updated Git submodule to point to latest version for BOSH deployment
- Removed ssh_tunnel options as this was only used by the CPI for BOSH Registry and doesn't affect SSH-ing into the BOSH Director. This is part of a larger piece of work to remove BOSH Registry from the BOSH Deployment. See the discussion at [https://github.com/cloudfoundry/bosh/discussions/2355](https://github.com/cloudfoundry/bosh/discussions/2355)

How to review
-------------

dev01 is currently on 181770492-Update-BOSH-UAA which is this same branch that I renamed to more properly reflect the nature of the PR. To review see if one can SSH properly into BOSH, CredHub etc...

Who can review
--------------

Describe who can review the changes. Or more importantly, list the people
that can't review, because they worked on it.

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
