### PR TITLE
Scale up the BOSH director prod database to db.m5.large

### DIFF
--- a/terraform/bosh/rds.tf
+++ b/terraform/bosh/rds.tf
@@ -41,7 +41,7 @@ resource "aws_db_instance" "bosh" {
   storage_type               = "gp2"
   engine                     = "postgres"
   engine_version             = "11.5"
-  instance_class             = "db.t3.small"
+  instance_class             = var.bosh_db_instance_class
   username                   = "dbadmin"
   password                   = var.secrets_bosh_postgres_password
   db_subnet_group_name       = aws_db_subnet_group.bosh_rds.name

--- a/terraform/bosh/variables.tf
+++ b/terraform/bosh/variables.tf
@@ -21,6 +21,11 @@ variable "bosh_db_maintenance_window" {
   description = "The window during which updates to the Bosh database instance can occur."
 }
 
+variable "bosh_db_instance_class" {
+  description = "Instance class for the BOSH RDS database."
+  default     = "db.t3.small"
+}
+
 variable "bosh_az" {
   description = "A zone used to provision bosh"
 }

--- a/terraform/prod.tfvars
+++ b/terraform/prod.tfvars
@@ -3,6 +3,7 @@ bosh_db_multi_az                = "true"
 bosh_db_backup_retention_period = "35"
 bosh_db_skip_final_snapshot     = "false"
 bosh_db_maintenance_window      = "Thu:06:00-Thu:07:00"
+bosh_db_instance_class          = "db.m5.large"
 
 concourse_db_multi_az                = "true"
 concourse_db_backup_retention_period = "35"


### PR DESCRIPTION
What
----

We recently encountered lock-up of the BOSH director with the immediate symptom being loss of metrics. In addition to the loss of metrics we see max load on the BOSH director and high load, swap and max connections on the BOSH RDS database.
We hypothesize that the lock-up is caused by database latency in the first place.
Also abstracting bosh_db_instance_class with a default of db.t3.small. The default is in effect for all non production environments.

How to review
-------------

- Code review
- Potentially test in dev env (Would require to update dev BOSH db to HA and extend scaling to dev, so not sure about the work to gain ratio?!) 

Who can review
--------------

Not @schmie 

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
