### PR TITLE
bosh-manifest bionic stemcell: 1.76 -> 1.84

### DIFF
--- a/manifests/bosh-manifest/operations.d/030-set-stemcell.yml
+++ b/manifests/bosh-manifest/operations.d/030-set-stemcell.yml
@@ -2,5 +2,5 @@
 - type: replace
   path: /resource_pools/name=vms/stemcell
   value:
-    url: https://bosh.io/d/stemcells/bosh-aws-xen-hvm-ubuntu-bionic-go_agent?v=1.76
-    sha1: 24db899386d06ef7ff6818bbccc8fcdd591e683f
+    url: https://bosh.io/d/stemcells/bosh-aws-xen-hvm-ubuntu-bionic-go_agent?v=1.84
+    sha1: 4edabab60a970b949933f28fa971159e513ca1e7

--- a/manifests/concourse-manifest/concourse-base.yml
+++ b/manifests/concourse-manifest/concourse-base.yml
@@ -2,7 +2,7 @@
 meta:
   stemcell:
     name: bosh-aws-xen-hvm-ubuntu-bionic-go_agent
-    version: "1.76"
+    version: "1.84"
 
 name: concourse
 


### PR DESCRIPTION
What
----

https://www.pivotaltracker.com/story/show/182283743

Bumped bosh-manifest's stemcells to bionic 1.84 to address some potential vulnerabilities.

How to review
-------------

Either deploy this to a dev env of your choice or look at dev03 which is currently running this.

Who can review
--------------

Not @risicle

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
