### PR TITLE
Detect when the Concourse GPG keys file hasn't been updated

### DIFF
--- a/concourse/spec/vars_files_spec.rb
+++ b/concourse/spec/vars_files_spec.rb
@@ -1,0 +1,10 @@
+REPO_ROOT = File.expand_path(File.join(SPEC_DIR, "..", ".."))
+
+RSpec.describe "vars files" do
+  it "gpg-keys.yml was updated after a change to .gpg-id" do
+    gpg_id_mod_time = File.mtime(File.join(REPO_ROOT, ".gpg-id"))
+    gpg_keys_mod_time = File.mtime(File.join(REPO_ROOT, "concourse", "vars-files", "gpg-keys.yml"))
+
+    expect(gpg_keys_mod_time).to be >= gpg_id_mod_time
+  end
+end


### PR DESCRIPTION
What
----

Adds a simple test that compares the file modification time of `./.gpg-id` to
that of `./concourse/vars-files/gpg-keys.yml`. In theory, we should never
updated `.gpg-id` without updating `gpg-keys.yml`, and so we should always see
the latters file modification time is after the formers.

Test failure looks like
```
  1) vars files gpg-keys.yml was updated after a change to .gpg-id
     Failure/Error: expect(gpg_keys_mod_time).to be >= gpg_id_mod_time

       expected: >= 2022-07-27 10:43:07.433614004 +0000
            got:    2022-07-27 10:41:41.427827006 +0000
```

How to review
-------------

See https://github.com/alphagov/paas-cf/pull/2942


---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
