### PR TITLE
BAU - Clean up Go 1.18 bits

### DIFF
--- a/.github/workflows/test_on_pr.yml
+++ b/.github/workflows/test_on_pr.yml
@@ -53,8 +53,7 @@ jobs:
 
       - name: "Install Pipecleaner"
         run: |
-          go get -u github.com/alphagov/paas-cf/tools/pipecleaner
-          go install github.com/alphagov/paas-cf/tools/pipecleaner
+          go install github.com/alphagov/paas-cf/tools/pipecleaner@main
 
       - name: Install Ruby
         uses: ruby/setup-ruby@v1

--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ test: spec lint_yaml lint_terraform lint_shellcheck lint_concourse lint_ruby ## 
 .PHONY: spec
 spec:
 	cd concourse/scripts &&\
-		go get -t -d . &&\
+		go get -t . &&\
 		go test
 	cd concourse &&\
 		bundle exec rspec


### PR DESCRIPTION
Description:
- go get only updates the go.mod file so use go install but pin to a specific commit

What
----

Describe what you have changed and why.

How to review
-------------

Describe the steps required to test the changes.

Who can review
--------------

Describe who can review the changes. Or more importantly, list the people
that can't review, because they worked on it.

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
