### PR TITLE
182889645 bosh upgrade

### DIFF
--- a/manifests/bosh-manifest/operations.d/130-bosh-UPSTREAM.yml
+++ b/manifests/bosh-manifest/operations.d/130-bosh-UPSTREAM.yml
@@ -1,0 +1,1 @@
+../upstream/misc/source-releases/bosh.yml

--- a/manifests/bosh-manifest/operations.d/130-use-bionic-UPSTREAM.yml
+++ b/manifests/bosh-manifest/operations.d/130-use-bionic-UPSTREAM.yml
@@ -1,0 +1,1 @@
+../upstream/aws/use-bionic.yml


### PR DESCRIPTION
What
----

Upgrades Bosh to 273.1.0. 

This version uses Jammy stemcells by default. We want to stay on Bionic stemcells, so I've added the two ops files suggested in the [bosh-deployment repo](https://github.com/cloudfoundry/bosh-deployment#jammy-stemcells)

How to review
-------------
- Code review
- I've already deployed it to dev01 https://deployer.dev01.dev.cloudpipeline.digital/teams/main/pipelines/create-bosh-concourse/jobs/bosh-deploy/builds/66 although I did so in two stages: first 272.6.0, then to 273.1.0

Who can review
--------------
Anyone

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
