### PR TITLE
183138602 - Bump Concourse postgres version to 13.7

### DIFF
--- a/terraform/concourse/rds.tf
+++ b/terraform/concourse/rds.tf
@@ -48,7 +48,7 @@ resource "aws_db_instance" "concourse" {
   allocated_storage          = 100
   storage_type               = "gp2"
   engine                     = "postgres"
-  engine_version             = "13.4"
+  engine_version             = "13.7"
   instance_class             = var.concourse_db_instance_class
   username                   = "concourse"
   password                   = random_password.concourse_rds_password.result


### PR DESCRIPTION
Description:
- Update Concourse RDS instance to postgres 13.7

