### PR TITLE
destroy-bosh-concourse: fix to work with terraform 1.2

### DIFF
--- a/concourse/pipelines/destroy-bosh-concourse.yml
+++ b/concourse/pipelines/destroy-bosh-concourse.yml
@@ -258,7 +258,7 @@ jobs:
               cd paas-bootstrap/terraform/bosh || exit
               terraform init
 
-              sh paas-bootstrap/terraform/./update-terraform-providers.sh updated-bosh-tfstate/bosh.tfstate
+              sh ../../../paas-bootstrap/terraform/update-terraform-providers.sh ../../../updated-bosh-tfstate/bosh.tfstate
 
               terraform apply \
                 -auto-approve=true \
@@ -382,7 +382,7 @@ jobs:
 
               cd paas-bootstrap/terraform/concourse || exit
               terraform init
-              terraform destroy -force \
+              terraform destroy -auto-approve \
                 -var-file="../../../paas-bootstrap/terraform/((aws_account)).tfvars" \
                 -var-file="../../../paas-bootstrap/terraform/((aws_region)).tfvars" \
                 -state=../../../updated-concourse-tfstate/concourse.tfstate
@@ -578,7 +578,7 @@ jobs:
 
                 sh paas-bootstrap/terraform/./update-terraform-providers.sh updated-bosh-tfstate/bosh.tfstate
 
-                terraform destroy -force \
+                terraform destroy -auto-approve \
                   -var concourse_egress_cidr="${CONCOURSE_EGRESS_IP}/32" \
                   -var env="((deploy_env))" \
                   -var-file="../../../paas-bootstrap/terraform/((aws_account)).tfvars" \
@@ -625,7 +625,7 @@ jobs:
 
               sh paas-bootstrap/terraform/./update-terraform-providers.sh updated-vpc-tfstate/vpc.tfstate
 
-              terraform destroy -force \
+              terraform destroy -auto-approve \
                 -var-file="../../../paas-bootstrap/terraform/((aws_account)).tfvars" \
                 -var-file="../../../paas-bootstrap/terraform/((aws_region)).tfvars" \
                 -state=../../../updated-vpc-tfstate/vpc.tfstate
@@ -671,7 +671,7 @@ jobs:
 
               sh paas-bootstrap/terraform/./update-terraform-providers.sh updated-bootstrap-cyber-tfstate/bootstrap-cyber.tfstate
 
-              terraform destroy -force \
+              terraform destroy -auto-approve \
                 -var-file="../../../paas-bootstrap/terraform/((aws_account)).tfvars" \
                 -var-file="../../../paas-bootstrap/terraform/((aws_region)).tfvars" \
                 -var-file="../../../bootstrap-cyber-tfvars/bootstrap-cyber.tfvars" \
@@ -712,7 +712,7 @@ jobs:
             - |
               cd paas-bootstrap/terraform/bucket || exit
               terraform init
-              terraform destroy -force \
+              terraform destroy -auto-approve \
                 -var-file="../../../paas-bootstrap/terraform/((aws_account)).tfvars" \
                 -var-file="../../../paas-bootstrap/terraform/((aws_region)).tfvars" \
                 -state=../../../bucket-terraform-state/bucket.tfstate


### PR DESCRIPTION
What
----

This pipeline hasn't worked since #476, where terraform was upgraded from 0.13 -> 1.0. Terraform now has to be run from the root module's directory and the `terraform destroy -force` argument had been removed.

How to review
-------------

Do you really want to run a full env teardown?

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
