### PR TITLE
Fix pipelines.sh scripts interaction with manage-github-secrets.sh

### DIFF
--- a/concourse/scripts/pipelines.sh
+++ b/concourse/scripts/pipelines.sh
@@ -63,7 +63,8 @@ EOF
 }
 
 if [ "${ENABLE_GITHUB}" = "true" ] ; then
-  eval "$("${SCRIPT_DIR}"/../../scripts/upload-secrets/manage-github-secrets.sh retrieve)"
+  SECRETS=$("${SCRIPT_DIR}"/../../scripts/upload-secrets/manage-github-secrets.sh retrieve)
+  eval "${SECRETS}"
 fi
 
 generate_vars_file > /dev/null # Check for missing vars

--- a/scripts/upload-secrets/manage-github-secrets.sh
+++ b/scripts/upload-secrets/manage-github-secrets.sh
@@ -58,17 +58,17 @@ get_creds_from_env_or_pass() {
   PASS_ENV_TARGET="${MAKEFILE_ENV_TARGET}"
 
   if [ "${MAKEFILE_ENV_TARGET}" = "dev" ] &&  [ "${PASSWORD_STORE_DIR}" = "${HOME}/.paas-pass" ]; then
-    echo "Detected that you're probably setting the Github secrets for a shared dev env"
+    echo "Detected that you're probably setting the Github secrets for a shared dev env" >> /dev/stderr
     PASS_ENV_TARGET=${DEPLOY_ENV}
   fi
 
   if [ -z "${GITHUB_CLIENT_ID+x}" ]; then
-    echo "Fetching secret from path 'github.com/concourse/${PASS_ENV_TARGET}/client_id' in '${PASSWORD_STORE_DIR}'"
+    echo "Fetching secret from path 'github.com/concourse/${PASS_ENV_TARGET}/client_id' in '${PASSWORD_STORE_DIR}'" >> /dev/stderr
   fi
   GITHUB_CLIENT_ID="${GITHUB_CLIENT_ID:-$(pass "github.com/concourse/${PASS_ENV_TARGET}/client_id")}"
-
+  
   if [ -z "${GITHUB_CLIENT_SECRET+x}" ]; then
-    echo "Fetching secret from path 'github.com/concourse/${PASS_ENV_TARGET}/client_secret' in '${PASSWORD_STORE_DIR}'"
+    echo "Fetching secret from path 'github.com/concourse/${PASS_ENV_TARGET}/client_secret' in '${PASSWORD_STORE_DIR}'" >> /dev/stderr
   fi
   GITHUB_CLIENT_SECRET="${GITHUB_CLIENT_SECRET:-$(pass "github.com/concourse/${PASS_ENV_TARGET}/client_secret")}"
 }
@@ -98,12 +98,12 @@ retrieve() {
     GITHUB_CLIENT_ID="${GITHUB_CLIENT_ID:-$(val_from_yaml github_client_id "${secrets_file}")}"
     GITHUB_CLIENT_SECRET="${GITHUB_CLIENT_SECRET:-$(val_from_yaml github_client_secret "${secrets_file}")}"
   else
-    echo "Warning: Cannot retrieve github secrets from S3. Retriving from environment or from pass." 1>&2
+    echo "Warning: Cannot retrieve github secrets from S3. Retriving from environment or from pass." >> /dev/stderr
     get_creds_from_env_or_pass
   fi
 
   if [ -z "${GITHUB_CLIENT_ID}" ] || [ -z "${GITHUB_CLIENT_SECRET}" ] ; then
-    echo "\$GITHUB_CLIENT_ID or \$GITHUB_CLIENT_SECRET not set, failing" 1>&2
+    echo "\$GITHUB_CLIENT_ID or \$GITHUB_CLIENT_SECRET not set, failing" >> /dev/stderr
   else
     echo "export GITHUB_CLIENT_ID=\"${GITHUB_CLIENT_ID}\""
     echo "export GITHUB_CLIENT_SECRET=\"${GITHUB_CLIENT_SECRET}\""


### PR DESCRIPTION
## What

The pipelines.sh calls manage-github-scripts.sh file with an eval. The eval is necessary to load the environment variables from manage-github-secrets.

It looks like this interaction was broken by this [change](https://github.com/alphagov/paas-bootstrap/commit/2966888fbcb80a2d514feb13b570a60be98dedba). The change added echo's which are also eval'd by pipelines.sh and obviously don't parse. This problem would only show up if you were running the script against an environment without secrets already in the bucket.

This updates the echos to output to stderr and splits the eval and script to ensure we exit with a failure if manage-github-secrets fails.

## How to review

This was tested on the command line while creating the vagrant box.
Check you are happy with the way this has been fixed.

## Who can review

One of the old timers

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
