### PR TITLE
Fix bosh terraform log group dependency order

### DIFF
--- a/terraform/bosh/cloudwatch_logs.tf
+++ b/terraform/bosh/cloudwatch_logs.tf
@@ -12,7 +12,7 @@ resource "aws_cloudwatch_log_group" "bosh_director_vm" {
 resource "aws_cloudwatch_log_subscription_filter" "ship_bosh_logs_to_cyber" {
   count           = length(local.log_groups)
   name            = element(local.log_groups, count.index)
-  log_group_name  = element(local.log_groups, count.index)
+  log_group_name  = aws_cloudwatch_log_group.bosh_director_vm[count.index].name
   destination_arn = local.destination_arn
   filter_pattern  = "" # Matches all events
   distribution    = "Random"


### PR DESCRIPTION
What
----

Fix the bosh terraform dependency order between aws_cloudwatch_log_group and aws_cloudwatch_log_subscription_filter.

Without this fix the bosh terraform can randomly fail on first run.

An example build this change can be viewed [here](https://deployer.dev04.dev.cloudpipeline.digital/teams/main/pipelines/create-bosh-concourse/jobs/bosh-terraform/builds/1).

How to review
-------------

Check you are happy with the way the fix has been implemented.

Who can review
--------------

One of the old timers.

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
