### PR TITLE
Revert "Upgrade terraform to 1.3.3"

### DIFF
--- a/.github/workflows/test_on_pr.yml
+++ b/.github/workflows/test_on_pr.yml
@@ -1,7 +1,7 @@
 ---
 on: pull_request
 env:
-  TF_VERSION: "1.3.3"
+  TF_VERSION: "1.2.8"
   SPRUCE_VERSION: "1.24.1"
   BOSH_CLI_VERSION: "6.1.1"
   CERTSTRAP_VERSION: "1.2.0"

--- a/concourse/pipelines/concourse-lite-self-terminate.yml
+++ b/concourse/pipelines/concourse-lite-self-terminate.yml
@@ -8,7 +8,7 @@ meta:
       type: docker-image
       source:
         repository: ghcr.io/alphagov/paas/awscli
-        tag: 21d3babf48e7fb6818367f8b37542b178ffabbda
+        tag: 2be6cfc9a387a6b818b522304858b54273c28138
 
 resources:
   - name: delete-timer

--- a/concourse/pipelines/create-bosh-concourse.yml
+++ b/concourse/pipelines/create-bosh-concourse.yml
@@ -8,42 +8,42 @@ meta:
       type: docker-image
       source:
         repository: ghcr.io/alphagov/paas/awscli
-        tag: 21d3babf48e7fb6818367f8b37542b178ffabbda
+        tag: 2be6cfc9a387a6b818b522304858b54273c28138
     bosh-cli-v2: &gov-paas-bosh-cli-v2-image-resource
       type: docker-image
       source:
         repository: ghcr.io/alphagov/paas/bosh-cli-v2
-        tag: 21d3babf48e7fb6818367f8b37542b178ffabbda
+        tag: 2be6cfc9a387a6b818b522304858b54273c28138
     certstrap: &certstrap-image-resource
       type: docker-image
       source:
         repository: ghcr.io/alphagov/paas/certstrap
-        tag: 21d3babf48e7fb6818367f8b37542b178ffabbda
+        tag: 2be6cfc9a387a6b818b522304858b54273c28138
     git-ssh: &git-ssh-image-resource
       type: docker-image
       source:
         repository: ghcr.io/alphagov/paas/git-ssh
-        tag: 21d3babf48e7fb6818367f8b37542b178ffabbda
+        tag: 2be6cfc9a387a6b818b522304858b54273c28138
     ruby-slim: &ruby-slim-image-resource
       type: docker-image
       source:
         repository: ghcr.io/alphagov/paas/ruby
-        tag: 21d3babf48e7fb6818367f8b37542b178ffabbda
+        tag: 2be6cfc9a387a6b818b522304858b54273c28138
     self-update-pipelines: &self-update-pipelines-image-resource
       type: docker-image
       source:
         repository: ghcr.io/alphagov/paas/self-update-pipelines
-        tag: 21d3babf48e7fb6818367f8b37542b178ffabbda
+        tag: 2be6cfc9a387a6b818b522304858b54273c28138
     spruce: &spruce-image-resource
       type: docker-image
       source:
         repository: ghcr.io/alphagov/paas/spruce
-        tag: 21d3babf48e7fb6818367f8b37542b178ffabbda
+        tag: 2be6cfc9a387a6b818b522304858b54273c28138
     terraform: &terraform-image-resource
       type: docker-image
       source:
         repository: ghcr.io/alphagov/paas/terraform
-        tag: 21d3babf48e7fb6818367f8b37542b178ffabbda
+        tag: 2be6cfc9a387a6b818b522304858b54273c28138
 
 groups:
   - name: all

--- a/concourse/pipelines/destroy-bosh-concourse.yml
+++ b/concourse/pipelines/destroy-bosh-concourse.yml
@@ -8,12 +8,12 @@ meta:
       type: docker-image
       source:
         repository: ghcr.io/alphagov/paas/awscli
-        tag: 21d3babf48e7fb6818367f8b37542b178ffabbda
+        tag: 2be6cfc9a387a6b818b522304858b54273c28138
     bosh-cli-v2: &gov-paas-bosh-cli-v2-image-resource
       type: docker-image
       source:
         repository: ghcr.io/alphagov/paas/bosh-cli-v2
-        tag: 21d3babf48e7fb6818367f8b37542b178ffabbda
+        tag: 2be6cfc9a387a6b818b522304858b54273c28138
     ruby-slim: &ruby-slim-image-resource
       type: docker-image
       source:
@@ -23,12 +23,12 @@ meta:
       type: docker-image
       source:
         repository: ghcr.io/alphagov/paas/self-update-pipelines
-        tag: 21d3babf48e7fb6818367f8b37542b178ffabbda
+        tag: 2be6cfc9a387a6b818b522304858b54273c28138
     terraform: &terraform-image-resource
       type: docker-image
       source:
         repository: ghcr.io/alphagov/paas/terraform
-        tag: 21d3babf48e7fb6818367f8b37542b178ffabbda
+        tag: 2be6cfc9a387a6b818b522304858b54273c28138
 
 resource_types:
 - name: s3-iam

--- a/concourse/tasks/delete-ssh-keys.yml
+++ b/concourse/tasks/delete-ssh-keys.yml
@@ -4,7 +4,7 @@ image_resource:
   type: docker-image
   source:
     repository: ghcr.io/alphagov/paas/awscli
-    tag: 21d3babf48e7fb6818367f8b37542b178ffabbda
+    tag: 2be6cfc9a387a6b818b522304858b54273c28138
 inputs:
   - name: paas-bootstrap
 run:

--- a/concourse/tasks/render-bosh-manifest.yml
+++ b/concourse/tasks/render-bosh-manifest.yml
@@ -4,7 +4,7 @@ image_resource:
   type: docker-image
   source:
     repository: ghcr.io/alphagov/paas/bosh-cli-v2
-    tag: 21d3babf48e7fb6818367f8b37542b178ffabbda
+    tag: 2be6cfc9a387a6b818b522304858b54273c28138
 inputs:
   - name: bosh-vars-store
     optional: true

--- a/terraform/version_constraint.tf
+++ b/terraform/version_constraint.tf
@@ -1,4 +1,4 @@
 
 terraform {
-  required_version = ">= 1.3.3"
+  required_version = ">= 1.2.8"
 }


### PR DESCRIPTION
Reverts alphagov/paas-bootstrap#531

Two of the resources did not update when merging the [docker PR](https://github.com/alphagov/paas-docker-cloudfoundry-tools) - this means paas-boostrap can't find them 😢 