### PR TITLE
Split init-bucket pipeline into update-pipeline and terraform bucket

### DIFF
--- a/concourse/pipelines/create-bosh-concourse.yml
+++ b/concourse/pipelines/create-bosh-concourse.yml
@@ -48,6 +48,7 @@ meta:
 groups:
   - name: all
     jobs:
+      - update-pipeline
       - init-bucket
       - check-for-secrets
       - vpc
@@ -365,7 +366,7 @@ resources:
       versioned_file: paas-bootstrap-cloud-config.yml
 
 jobs:
-  - name: init-bucket
+  - name: update-pipeline
     serial: true
     plan:
       - get: paas-bootstrap
@@ -494,6 +495,19 @@ jobs:
                 echo 'self-update-pipeline failed'
                 exit 1
 
+      - put: pipeline-trigger
+        params: {bump: patch}
+
+  - name: init-bucket
+    serial: true
+    plan:
+      - get: pipeline-trigger
+        passed: ['update-pipeline']
+        trigger: true
+      - get: paas-bootstrap
+        trigger: true
+        passed: ['update-pipeline']
+
       - task: try-fetch-bucket-state
         config:
           platform: linux
@@ -547,9 +561,6 @@ jobs:
           put: bucket-terraform-state
           params:
             file: updated-bucket-state/bucket.tfstate
-
-      - put: pipeline-trigger
-        params: {bump: patch}
 
   - name: check-for-secrets
     serial: true


### PR DESCRIPTION
What
----

Currently the init-bucket job both updates the pipeline and runs the bucket terraform. This means that if you update the terraform pipeline it won't take effect until you rerun the pipeline. This affected our recent terraform upgrade where a 'double tap' of the build pipeline was required.

This change splits out the bucket terraform from the update pipeline to reduce the cases where this 'double tap' would be required.

How to review
-------------

Check you are happy with the pipeline changes.

New pipeline can be viewed [here](https://deployer.dev04.dev.cloudpipeline.digital/teams/main/pipelines/create-bosh-concourse)

Simulated failure that didn't require a 'double tap' can be viewed [here](https://deployer.dev04.dev.cloudpipeline.digital/teams/main/pipelines/create-bosh-concourse/jobs/init-bucket/builds/4#L635ab972:1).

Who can review
--------------

One of the old timers.
---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
