### PR TITLE
chore(concourse): bump concourse version from 7.8.2 to 7.8.3

### DIFF
--- a/manifests/concourse-manifest/concourse-base.yml
+++ b/manifests/concourse-manifest/concourse-base.yml
@@ -16,9 +16,9 @@ stemcells:
 # relevant tag of https://github.com/concourse/concourse-bosh-deployment
 releases:
   - name: "concourse"
-    version: "7.8.2"
-    url: "https://bosh.io/d/github.com/concourse/concourse-bosh-release?v=7.8.2"
-    sha1: "2613a50ccae8966adc7b14ed9c5495eeca8a31f5"
+    version: "7.8.3"
+    url: "https://bosh.io/d/github.com/concourse/concourse-bosh-release?v=7.8.3"
+    sha1: "5d80eb00215b59b4c93f0938cb465fd28036b04d"
   - name: "bpm"
     version: "1.1.18"
     url: "https://bosh.io/d/github.com/cloudfoundry/bpm-release?v=1.1.18"

--- a/vagrant/docker-compose.yml
+++ b/vagrant/docker-compose.yml
@@ -10,7 +10,7 @@ services:
     - PGDATA=/database
 
   concourse-web:
-    image: concourse/concourse:7.8.2
+    image: concourse/concourse:7.8.3
     command: web
     privileged: true
     depends_on: [concourse-db]
@@ -32,7 +32,7 @@ services:
     - CONCOURSE_SESSION_SIGNING_KEY=/keys/session_signing_key
 
   concourse-worker-colocated:
-    image: concourse/concourse:7.8.2
+    image: concourse/concourse:7.8.3
     command: worker
     privileged: true
     depends_on: [concourse-db, concourse-web]
@@ -50,7 +50,7 @@ services:
     - CONCOURSE_GARDEN_DNS_SERVER=169.254.169.253
 
   concourse-worker-normal:
-    image: concourse/concourse:7.8.2
+    image: concourse/concourse:7.8.3
     command: worker
     privileged: true
     depends_on: [concourse-db, concourse-web]


### PR DESCRIPTION
What
----

Bumped concourse version from 7.8.2 to 7.8.3

How to review
-------------

Successful deployment here:
https://deployer.dev02.dev.cloudpipeline.digital/teams/main/pipelines/create-bosh-concourse/jobs/init-bucket/builds/116

Who can review
--------------

Any SRE

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
