### PR TITLE
Upgrade Bosh to 276.1.1

### DIFF
--- a/manifests/bosh-manifest/operations.d/120-cpi.yml
+++ b/manifests/bosh-manifest/operations.d/120-cpi.yml
@@ -6,6 +6,6 @@
   type: replace
   value:
     name: "bosh-aws-cpi"
-    version: "93"
-    url: "https://bosh.io/d/github.com/cloudfoundry/bosh-aws-cpi-release?v=93"
-    sha1: "1b4d0f542faa1b8e6fd5aaae375073ecf7833291"
+    version: "96"
+    url: "https://bosh.io/d/github.com/cloudfoundry/bosh-aws-cpi-release?v=96"
+    sha1: "451c4c812d5218849e7f1c790f0f1cd4ff544b1a"


### PR DESCRIPTION
What
----

- Routine Bosh upgrade - 276.1.1
- Upgrades bosh-aws-cpi release to match the one in bosh-deployment 

How to review
-------------
Check dev03 for successful:
- [bosh deploy](https://deployer.dev03.dev.cloudpipeline.digital/teams/main/pipelines/create-bosh-concourse/jobs/bosh-deploy/builds/11), 
- [cf-deploy](https://deployer.dev03.dev.cloudpipeline.digital/teams/main/pipelines/create-cloudfoundry/jobs/cf-deploy/builds/37)
- [test-certificate-rotation](https://deployer.dev03.dev.cloudpipeline.digital/teams/main/pipelines/test-certificate-rotation/jobs/end/builds/1)

I've checked that we can rotate the BOSH credentials. There's [an issue with credhub's one](https://github.com/alphagov/paas-bootstrap/pull/540), but it's unrelated to this PR


Who can review
--------------
Anyone

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
