### PR TITLE
drop-bosh-credentials-for-rotation: preserve `credhub_encryption_password`

### DIFF
--- a/concourse/pipelines/create-bosh-concourse.yml
+++ b/concourse/pipelines/create-bosh-concourse.yml
@@ -2240,6 +2240,7 @@ jobs:
                   --passwords \
                   --ssh \
                   --rsa \
+                  --preserve credhub_encryption_password \
                   > modified-bosh-vars-store/bosh-vars-store.yml
         on_success:
           in_parallel:


### PR DESCRIPTION
What
----

Discovered when testing https://www.pivotaltracker.com/story/show/183708862

If we rotate `credhub_encryption_password`, credhub is unable to access its database and the next pipeline run will fail. If you really *do* want to rotate the `credhub_encryption_password` you're either going to lose the contents of the credhub database, in which case you may as well just delete the whole vars file and start again, or you'll have to perform some deeper magic than this job is capable of to re-encrypt them with a new key.

How to review
-------------

Deploy to a dev env, run https://team-manual.cloud.service.gov.uk/team/rotating_credentials/#rotating-bosh-credentials-and-certificates ?

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
