### PR TITLE
concourse access: temporarily remove panos' prod access

### DIFF
--- a/manifests/concourse-manifest/github_auth/config.yml
+++ b/manifests/concourse-manifest/github_auth/config.yml
@@ -20,7 +20,6 @@ instance_groups:
                     users:
                     - AP-Hunt
                     - cadmiumcat
-                    - dark5un
                     - kr8n3r
                     - jackjoy-gds
                     - LeePorte


### PR DESCRIPTION
What
----
Remove Panos' production access until SC clearance comes through.

How to review
-------------

:eyes: 

Who can review
--------------

Anyone with prod access.

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
