### PR TITLE
[#183921001] Upgrade stemcell for bosh and concourse to jammy

### DIFF
--- a/manifests/bosh-manifest/operations.d/030-set-stemcell.yml
+++ b/manifests/bosh-manifest/operations.d/030-set-stemcell.yml
@@ -2,5 +2,5 @@
 - type: replace
   path: /resource_pools/name=vms/stemcell
   value:
-    url: https://bosh.io/d/stemcells/bosh-aws-xen-hvm-ubuntu-bionic-go_agent?v=1.107
-    sha1: 568ef13c51092376612c31999519af7fee20ef4f
+    url: https://bosh.io/d/stemcells/bosh-aws-xen-hvm-ubuntu-jammy-go_agent?v=1.75
+    sha1: 3ab28cca0adbd866f3886667b4a833d13ae4b422

--- a/manifests/bosh-manifest/operations.d/130-use-bionic-UPSTREAM.yml
+++ b/manifests/bosh-manifest/operations.d/130-use-bionic-UPSTREAM.yml
@@ -1,1 +1,0 @@
-../upstream/aws/use-bionic.yml

--- a/manifests/bosh-manifest/operations.d/400-audit.yml
+++ b/manifests/bosh-manifest/operations.d/400-audit.yml
@@ -4,17 +4,17 @@
   path: /releases/-
   value:
     name: awslogs
-    version: 0.1.6
-    url: https://s3-eu-west-1.amazonaws.com/gds-paas-build-releases/awslogs-0.1.6.tgz
-    sha1: db6d8cf0b5da5c9ecabb6be08df0ad5442b4a401
+    version: 0.1.8
+    url: https://s3-eu-west-1.amazonaws.com/gds-paas-build-releases/awslogs-0.1.8.tgz
+    sha1: f2a5fc665b8d6581c302bc90aaa49a7ccd72efb9
 
 - type: replace
   path: /instance_groups/name=bosh/jobs?/-
   value:
-    name: awslogs-bionic
+    name: awslogs-jammy
     release: awslogs
     properties:
-      awslogs-bionic:
+      awslogs-jammy:
         region: ((region))
         awslogs_files_config:
 

--- a/manifests/concourse-manifest/concourse-base.yml
+++ b/manifests/concourse-manifest/concourse-base.yml
@@ -1,15 +1,15 @@
 ---
 meta:
   stemcell:
-    name: bosh-aws-xen-hvm-ubuntu-bionic-go_agent
-    version: "1.107"
+    name: bosh-aws-xen-hvm-ubuntu-jammy-go_agent
+    version: "1.75"
 
 name: concourse
 
 stemcells:
   # Using spruce grab operation because of the upload step in pipeline
   - alias: default
-    os: ubuntu-bionic
+    os: ubuntu-jammy
     version: (( grab meta.stemcell.version ))
 
 # These versions and checksums are taken from the versions.yml file from the
@@ -24,9 +24,9 @@ releases:
     url: "https://bosh.io/d/github.com/cloudfoundry/bpm-release?v=1.1.18"
     sha1: "86675f90d66f7018c57f4ae0312f1b3834dd58c9"
   - name: awslogs
-    version: 0.1.6
-    url: https://s3-eu-west-1.amazonaws.com/gds-paas-build-releases/awslogs-0.1.6.tgz
-    sha1: db6d8cf0b5da5c9ecabb6be08df0ad5442b4a401
+    version: 0.1.8
+    url: https://s3-eu-west-1.amazonaws.com/gds-paas-build-releases/awslogs-0.1.8.tgz
+    sha1: f2a5fc665b8d6581c302bc90aaa49a7ccd72efb9
 
 instance_groups:
   - name: concourse

--- a/manifests/concourse-manifest/operations.d/400-audit.yml
+++ b/manifests/concourse-manifest/operations.d/400-audit.yml
@@ -2,10 +2,10 @@
 instance_groups:
   - name: concourse
     jobs:
-      - name: awslogs-bionic
+      - name: awslogs-jammy
         release: awslogs
         properties:
-          awslogs-bionic:
+          awslogs-jammy:
             region: ((region))
             awslogs_files_config:
 

--- a/manifests/runtime-config/runtime-config-base.yml
+++ b/manifests/runtime-config/runtime-config-base.yml
@@ -11,10 +11,10 @@
 addons:
   - name: awslogs
     jobs:
-      - name: awslogs-bionic
+      - name: awslogs-jammy
         release: awslogs
         properties:
-          awslogs-bionic:
+          awslogs-jammy:
             region: ((aws_region))
             awslogs_files_config:
               - name: /var/log/auth.log
@@ -25,7 +25,7 @@ addons:
                 datetime_format: "%Y-%m-%dT%H:%M:%S"
     exclude:
       jobs:
-        - name: awslogs-bionic
+        - name: awslogs-jammy
           release: awslogs
     include:
       lifecycle: service
@@ -39,12 +39,13 @@ addons:
         - os: ubuntu-trusty
         - os: ubuntu-xenial
         - os: ubuntu-bionic
+        - os: ubuntu-jammy
 
 releases:
   - name: awslogs
-    version: 0.1.6
-    url: https://s3-eu-west-1.amazonaws.com/gds-paas-build-releases/awslogs-0.1.6.tgz
-    sha1: db6d8cf0b5da5c9ecabb6be08df0ad5442b4a401
+    version: 0.1.8
+    url: https://s3-eu-west-1.amazonaws.com/gds-paas-build-releases/awslogs-0.1.8.tgz
+    sha1: f2a5fc665b8d6581c302bc90aaa49a7ccd72efb9
     properties: {}
 
   - name: node-exporter

--- a/manifests/runtime-config/scripts/generate-unix-users-ops-file.rb
+++ b/manifests/runtime-config/scripts/generate-unix-users-ops-file.rb
@@ -37,6 +37,7 @@ def generate_unix_users_ops_file(config_file, aws_account)
             { "os" => "ubuntu-trusty" },
             { "os" => "ubuntu-xenial" },
             { "os" => "ubuntu-bionic" },
+            { "os" => "ubuntu-jammy" },
           ],
         },
         "jobs" => [{

--- a/manifests/runtime-config/spec/generate_unix_users_ops_file_spec.rb
+++ b/manifests/runtime-config/spec/generate_unix_users_ops_file_spec.rb
@@ -38,6 +38,7 @@ RSpec.describe "Generating unix users ops file" do
               { "os" => "ubuntu-trusty" },
               { "os" => "ubuntu-xenial" },
               { "os" => "ubuntu-bionic" },
+              { "os" => "ubuntu-jammy" },
             ],
           },
           "jobs" => [
@@ -116,6 +117,7 @@ RSpec.describe "Generating unix users ops file" do
               { "os" => "ubuntu-trusty" },
               { "os" => "ubuntu-xenial" },
               { "os" => "ubuntu-bionic" },
+              { "os" => "ubuntu-jammy" },
             ],
           },
           "jobs" => [

--- a/vagrant/Vagrantfile
+++ b/vagrant/Vagrantfile
@@ -65,10 +65,16 @@ AWS_ACCOUNT_DATA = {
 }.freeze
 AWS_ACCOUNT_VARIABLES = AWS_ACCOUNT_DATA.fetch(AWS_ACCOUNT).fetch(AWS_REGION)
 
-# ubuntu/images/hvm-ssd/ubuntu-bionic-18.04-amd64-server-20180912
+# eu-west-1:
+# Canonical, Ubuntu, 22.04 LTS, amd64 jammy image build on 2022-12-06
+# ami-026e72e4e468afa7b
+# eu-west-2:
+# Canonical, Ubuntu, 22.04 LTS, amd64 jammy image build on 2022-12-06
+# ami-01b8d743224353ffe
+
 AWS_AMI = {
-  "eu-west-1" => "ami-00035f41c82244dab",
-  "eu-west-2" => "ami-0b0a60c0a2bd40612",
+  "eu-west-1" => "ami-026e72e4e468afa7b",
+  "eu-west-2" => "ami-01b8d743224353ffe",
 }.freeze
 Vagrant.configure(2) do |config|
   config.vm.box = ENV["VAGRANT_BOX_NAME"] || "aws_vagrant_box"


### PR DESCRIPTION
What
----

Upgrade stemcell to Jammy for bosh, concourse and the vagrant vm.

Why
----

Bionic support ends in April.

How to review
-------------

Changes have been applied dev04.
Look at the change.


---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
