### PR TITLE
Enable DNS hostnames on VPC

### DIFF
--- a/terraform/vpc/vpc.tf
+++ b/terraform/vpc/vpc.tf
@@ -1,6 +1,9 @@
 resource "aws_vpc" "paas" {
   cidr_block = var.vpc_cidr
 
+  enable_dns_support   = true
+  enable_dns_hostnames = true
+
   tags = {
     Name = var.env
   }


### PR DESCRIPTION
What
----

Enabling DNS hostnames in the VPC will cause Amazon to assign a DNS name to each EC2 instance with a public IP address [1]. We have historically not had this enabled because it defaults to being off.

However, we will need it enabled to use certain types of AWS VPC endpoints. Enabling it should have no negative affects on the rest of the VPC.

[1] https://docs.aws.amazon.com/vpc/latest/userguide/vpc-dns.html#vpc-dns-hostnames

How to review
-------------

Do you know of any reasons why we shouldn't enable this? Are there any risks we're exposing ourselves to?

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
