### PR TITLE
[#184266539] Fix create-bosh-concourse in the build environment

### DIFF
--- a/terraform/bosh/security_groups.tf
+++ b/terraform/bosh/security_groups.tf
@@ -1,3 +1,15 @@
+data "aws_instances" "concourse_workers" {
+  filter {
+    name   = "tag:instance_group"
+    values = ["concourse-worker", "concourse-lite"]
+  }
+
+  filter {
+    name   = "tag:deploy_env"
+    values = [var.env]
+  }
+}
+
 resource "aws_security_group" "bosh" {
   name        = "${var.env}-bosh"
   description = "Bosh security group"
@@ -14,7 +26,7 @@ resource "aws_security_group" "bosh" {
     from_port   = 22
     to_port     = 22
     protocol    = "tcp"
-    cidr_blocks = compact([var.concourse_egress_cidr])
+    cidr_blocks = formatlist("%s/32", data.aws_instances.concourse_workers.public_ips)
   }
 
   ingress {
@@ -31,7 +43,7 @@ resource "aws_security_group" "bosh" {
     from_port   = 6868
     to_port     = 6868
     protocol    = "tcp"
-    cidr_blocks = compact([var.concourse_egress_cidr])
+    cidr_blocks = formatlist("%s/32", data.aws_instances.concourse_workers.public_ips)
   }
 
   ingress {

--- a/vagrant/Vagrantfile
+++ b/vagrant/Vagrantfile
@@ -111,7 +111,11 @@ Vagrant.configure(2) do |config|
     aws.secret_access_key = ENV["AWS_SECRET_ACCESS_KEY"]
     aws.session_token = ENV["AWS_SESSION_TOKEN"]
     aws.associate_public_ip = true
-    aws.tags = { "Name" => "#{ENV['DEPLOY_ENV'] || ENV['USER']} concourse" }
+    aws.tags = {
+      "Name" => "#{ENV['DEPLOY_ENV'] || ENV['USER']} concourse",
+      "instance_group" => "concourse-lite",
+      "deploy_env" => ENV["DEPLOY_ENV"],
+    }
     aws.keypair_name = ENV["VAGRANT_SSH_KEY_NAME"]
 
     aws.block_device_mapping = [{ "DeviceName" => "/dev/sda1", "Ebs.VolumeSize" => 50 }]


### PR DESCRIPTION
What
----

create-bosh-concourse has been "unreliable" on ci build for a long time now.

It turns out that this is because the pipeline doesn't support multiple concourse workers. This is why is worked from concourse-lite with a single worker.

One part of the pipeline gets the workers current ip, then next job adds the ip to the security group and a further job requires this firewall rule to be open. If these jobs happen to run on different concourse worker nodes the pipeline will fail.

This change ensures all workers are granted access to the required endpoints. 

How to review
-------------

Look at the change

Who can review
--------------

Any team member.

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
