### PR TITLE
Revert to ubuntu 20.04 for concourse-lite

### DIFF
--- a/vagrant/Vagrantfile
+++ b/vagrant/Vagrantfile
@@ -66,15 +66,17 @@ AWS_ACCOUNT_DATA = {
 AWS_ACCOUNT_VARIABLES = AWS_ACCOUNT_DATA.fetch(AWS_ACCOUNT).fetch(AWS_REGION)
 
 # eu-west-1:
-# Canonical, Ubuntu, 22.04 LTS, amd64 jammy image build on 2022-12-06
-# ami-026e72e4e468afa7b
+# Canonical, Ubuntu, 20.04 LTS, amd64 focal image build on 2023-01-12
+# ami-0c68b55d1c875067e
 # eu-west-2:
-# Canonical, Ubuntu, 22.04 LTS, amd64 jammy image build on 2022-12-06
-# ami-01b8d743224353ffe
-
+# Canonical, Ubuntu, 20.04 LTS, amd64 focal image build on 2023-01-12
+# ami-00de6c6491fdd3ef5
+# WARNING: As of 2021-01-13, the latest Ubuntu 22.04 AMI is causing an issue
+#          with the concourse workers not being able to start. This is looks
+#          related to a docker-in-docker issue.
 AWS_AMI = {
-  "eu-west-1" => "ami-026e72e4e468afa7b",
-  "eu-west-2" => "ami-01b8d743224353ffe",
+  "eu-west-1" => "ami-0c68b55d1c875067e",
+  "eu-west-2" => "ami-00de6c6491fdd3ef5",
 }.freeze
 Vagrant.configure(2) do |config|
   config.vm.box = ENV["VAGRANT_BOX_NAME"] || "aws_vagrant_box"


### PR DESCRIPTION
What
----

There is a problem with ubuntu 22.04 and our concourse-lite. 

The concourse worker docker images fail to start with error messages like:

```
{\"timestamp\":\"2023-01-20T11:28:44.313419615Z\",\"level\":\"error\",\"source\":\"guardian\",\"message\":\"guardian.starting-guardian-backend\",\"data\":{\"error\":\"bulk starter: mounting subsystem 'cpuset' in '/sys/fs/cgroup/cpuset': operation not permitted\"}}\n","stream":"stdout","time":"2023-01-20T11:28:44.313485743Z"}
...
{"timestamp":"2023-01-20T11:28:47.212622587Z","level":"error","source":"worker","message":"worker.beacon-runner.beacon.forward-conn.failed-to-dial","data":{"addr":"127.0.0.1:7788","error":"dial tcp 127.0.0.1:7788: connect: connection refused","network":"tcp","session":"4.1.5"}}
```

I believe this is related to a switch to cgroups v2 in jammy and the concourse workers needing to start docker containers from a docker container.

Reverting to ubuntu 20.04 (focal) for now. 
 
How to review
-------------

Examine the changes

Who can review
--------------

Any team member.

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
