### PR TITLE
[#184324630] Add aws endpoints subnet and secrets manager endpoint

### DIFF
--- a/terraform/globals.tf
+++ b/terraform/globals.tf
@@ -125,3 +125,12 @@ variable "bosh_log_groups_to_ship_to_csls" {
   ]
 }
 
+variable "aws_vpc_endpoint_cidrs_per_zone" {
+  description = "CIDR for AWS VPC endpoint subnets indexed by AZ"
+
+  default = {
+    zone0 = "10.0.79.0/28"
+    zone1 = "10.0.79.16/28"
+    zone2 = "10.0.79.32/28"
+  }
+}

--- a/terraform/vpc/endpoints.tf
+++ b/terraform/vpc/endpoints.tf
@@ -1,0 +1,57 @@
+resource "aws_vpc_endpoint" "secrets_manager" {
+  vpc_id            = aws_vpc.paas.id
+  service_name      = "com.amazonaws.${var.region}.secretsmanager"
+  vpc_endpoint_type = "Interface"
+
+  security_group_ids = [
+    aws_security_group.secrets_manager_endpoint_access.id,
+  ]
+
+  subnet_ids          = aws_subnet.vpc_aws_endpoint[*].id
+  private_dns_enabled = true
+
+  tags = {
+    Build       = "terraform"
+    Resource    = "aws_vpc_endpoint"
+    Environment = var.env
+    Name        = "${var.env}-secrets-manager"
+  }
+}
+
+resource "aws_security_group" "secrets_manager_endpoint_access" {
+  name        = "${var.env}-secrets-manager-endpoint"
+  description = "Allow HTTPS inbound traffic for security manager vpc endpoint"
+  vpc_id      = aws_vpc.paas.id
+
+  ingress {
+    description = "HTTPS for security manager vpc endpoint"
+    from_port   = 443
+    to_port     = 443
+    protocol    = "tcp"
+    cidr_blocks = [var.vpc_cidr]
+  }
+
+  tags = {
+    Build       = "terraform"
+    Resource    = "aws_security_group"
+    Environment = var.env
+    Name        = "${var.env}-secrets-manager-endpoint"
+  }
+}
+
+resource "aws_subnet" "vpc_aws_endpoint" {
+  count = length(var.aws_vpc_endpoint_cidrs_per_zone)
+
+  vpc_id            = aws_vpc.paas.id
+  cidr_block        = var.aws_vpc_endpoint_cidrs_per_zone[format("zone%d", count.index)]
+  availability_zone = var.zones[format("zone%d", count.index)]
+
+  map_public_ip_on_launch = false
+
+  tags = {
+    Build       = "terraform"
+    Resource    = "aws_subnet"
+    Environment = var.env
+    Name        = "${var.env}-vpc-endpoint-${count.index}"
+  }
+}

--- a/terraform/vpc/outputs.tf
+++ b/terraform/vpc/outputs.tf
@@ -46,3 +46,14 @@ output "infra_subnet_ids" {
   value = join(",", aws_subnet.infra.*.id)
 }
 
+output "vpc_endpoints_ip_range_zone0" {
+  value = "${cidrhost(var.aws_vpc_endpoint_cidrs_per_zone.zone0, 0)}-${cidrhost(var.aws_vpc_endpoint_cidrs_per_zone.zone0, -1)}"
+}
+
+output "vpc_endpoints_ip_range_zone1" {
+  value = "${cidrhost(var.aws_vpc_endpoint_cidrs_per_zone.zone1, 0)}-${cidrhost(var.aws_vpc_endpoint_cidrs_per_zone.zone1, -1)}"
+}
+
+output "vpc_endpoints_ip_range_zone2" {
+  value = "${cidrhost(var.aws_vpc_endpoint_cidrs_per_zone.zone2, 0)}-${cidrhost(var.aws_vpc_endpoint_cidrs_per_zone.zone2, -1)}"
+}


### PR DESCRIPTION
What
----

Add aws endpoints subnet and secrets manager endpoint to vpc terraform. This has been moved from the paas-cf dms terraform to ensure consistency between the environments.

How to review
-------------

This has been tested in dev01.

Who can review
--------------

Any team member familiar with the dms setup.


🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
