### PR TITLE
create-bosh-concourse pipeline: start `pipeline-trigger` after `init-bucket`

### DIFF
--- a/concourse/pipelines/create-bosh-concourse.yml
+++ b/concourse/pipelines/create-bosh-concourse.yml
@@ -495,15 +495,9 @@ jobs:
                 echo 'self-update-pipeline failed'
                 exit 1
 
-      - put: pipeline-trigger
-        params: {bump: patch}
-
   - name: init-bucket
     serial: true
     plan:
-      - get: pipeline-trigger
-        passed: ['update-pipeline']
-        trigger: true
       - get: paas-bootstrap
         trigger: true
         passed: ['update-pipeline']
@@ -561,6 +555,9 @@ jobs:
           put: bucket-terraform-state
           params:
             file: updated-bucket-state/bucket.tfstate
+
+      - put: pipeline-trigger
+        params: {bump: patch}
 
   - name: check-for-secrets
     serial: true


### PR DESCRIPTION
What
----

In #536 we split the state bucket creation out of the `update-pipeline` job, but kept the starting of the `pipeline-trigger` on the `update-pipeline` job, but this uses the state-bucket to operate and won't work on a clean deployment where the state bucket doesn't yet exist. So move the start of the `pipeline-trigger` to the end of the `init-bucket` job.

How to review
-------------

Deploy to a dev env? If you're really keen, use it to initialize a new dev env but that will probably take half a day...

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
