### PR TITLE
Update docker images to be inline with paas-cf

### DIFF
--- a/concourse/pipelines/concourse-lite-self-terminate.yml
+++ b/concourse/pipelines/concourse-lite-self-terminate.yml
@@ -5,7 +5,7 @@ display:
 meta:
   containers:
     awscli: &awscli-image-resource
-      type: docker-image
+      type: registry-image
       source:
         repository: ghcr.io/alphagov/paas/awscli
         tag: 8621ead7e4ef0dd653aec80a15b6727b06927e59

--- a/concourse/pipelines/concourse-lite-self-terminate.yml
+++ b/concourse/pipelines/concourse-lite-self-terminate.yml
@@ -8,7 +8,7 @@ meta:
       type: registry-image
       source:
         repository: ghcr.io/alphagov/paas/awscli
-        tag: 8621ead7e4ef0dd653aec80a15b6727b06927e59
+        tag: b25554b10d0efb9da2aef192f9a890199863f59e
 
 resources:
   - name: delete-timer

--- a/concourse/pipelines/create-bosh-concourse.yml
+++ b/concourse/pipelines/create-bosh-concourse.yml
@@ -8,42 +8,42 @@ meta:
       type: registry-image
       source:
         repository: ghcr.io/alphagov/paas/awscli
-        tag: 8621ead7e4ef0dd653aec80a15b6727b06927e59
+        tag: b25554b10d0efb9da2aef192f9a890199863f59e
     bosh-cli-v2: &gov-paas-bosh-cli-v2-image-resource
       type: registry-image
       source:
         repository: ghcr.io/alphagov/paas/bosh-cli-v2
-        tag: 8621ead7e4ef0dd653aec80a15b6727b06927e59
+        tag: b25554b10d0efb9da2aef192f9a890199863f59e
     certstrap: &certstrap-image-resource
       type: registry-image
       source:
         repository: ghcr.io/alphagov/paas/certstrap
-        tag: 8621ead7e4ef0dd653aec80a15b6727b06927e59
+        tag: b25554b10d0efb9da2aef192f9a890199863f59e
     git-ssh: &git-ssh-image-resource
       type: registry-image
       source:
         repository: ghcr.io/alphagov/paas/git-ssh
-        tag: 8621ead7e4ef0dd653aec80a15b6727b06927e59
+        tag: b25554b10d0efb9da2aef192f9a890199863f59e
     ruby-slim: &ruby-slim-image-resource
       type: registry-image
       source:
         repository: ghcr.io/alphagov/paas/ruby
-        tag: 8621ead7e4ef0dd653aec80a15b6727b06927e59
+        tag: b25554b10d0efb9da2aef192f9a890199863f59e
     self-update-pipelines: &self-update-pipelines-image-resource
       type: registry-image
       source:
         repository: ghcr.io/alphagov/paas/self-update-pipelines
-        tag: 8621ead7e4ef0dd653aec80a15b6727b06927e59
+        tag: b25554b10d0efb9da2aef192f9a890199863f59e
     spruce: &spruce-image-resource
       type: registry-image
       source:
         repository: ghcr.io/alphagov/paas/spruce
-        tag: 8621ead7e4ef0dd653aec80a15b6727b06927e59
+        tag: b25554b10d0efb9da2aef192f9a890199863f59e
     terraform: &terraform-image-resource
       type: registry-image
       source:
         repository: ghcr.io/alphagov/paas/terraform
-        tag: 8621ead7e4ef0dd653aec80a15b6727b06927e59
+        tag: b25554b10d0efb9da2aef192f9a890199863f59e
 
 groups:
   - name: all

--- a/concourse/pipelines/create-bosh-concourse.yml
+++ b/concourse/pipelines/create-bosh-concourse.yml
@@ -5,42 +5,42 @@ display:
 meta:
   containers:
     awscli: &awscli-image-resource
-      type: docker-image
+      type: registry-image
       source:
         repository: ghcr.io/alphagov/paas/awscli
         tag: 8621ead7e4ef0dd653aec80a15b6727b06927e59
     bosh-cli-v2: &gov-paas-bosh-cli-v2-image-resource
-      type: docker-image
+      type: registry-image
       source:
         repository: ghcr.io/alphagov/paas/bosh-cli-v2
         tag: 8621ead7e4ef0dd653aec80a15b6727b06927e59
     certstrap: &certstrap-image-resource
-      type: docker-image
+      type: registry-image
       source:
         repository: ghcr.io/alphagov/paas/certstrap
         tag: 8621ead7e4ef0dd653aec80a15b6727b06927e59
     git-ssh: &git-ssh-image-resource
-      type: docker-image
+      type: registry-image
       source:
         repository: ghcr.io/alphagov/paas/git-ssh
         tag: 8621ead7e4ef0dd653aec80a15b6727b06927e59
     ruby-slim: &ruby-slim-image-resource
-      type: docker-image
+      type: registry-image
       source:
         repository: ghcr.io/alphagov/paas/ruby
         tag: 8621ead7e4ef0dd653aec80a15b6727b06927e59
     self-update-pipelines: &self-update-pipelines-image-resource
-      type: docker-image
+      type: registry-image
       source:
         repository: ghcr.io/alphagov/paas/self-update-pipelines
         tag: 8621ead7e4ef0dd653aec80a15b6727b06927e59
     spruce: &spruce-image-resource
-      type: docker-image
+      type: registry-image
       source:
         repository: ghcr.io/alphagov/paas/spruce
         tag: 8621ead7e4ef0dd653aec80a15b6727b06927e59
     terraform: &terraform-image-resource
-      type: docker-image
+      type: registry-image
       source:
         repository: ghcr.io/alphagov/paas/terraform
         tag: 8621ead7e4ef0dd653aec80a15b6727b06927e59
@@ -73,13 +73,13 @@ groups:
 
 resource_types:
 - name: s3-iam
-  type: docker-image
+  type: registry-image
   source:
     repository: ghcr.io/alphagov/paas/s3-resource
     tag: 96b47010a10ca13b40bc604b49b4ab9158cfe2c7
 
 - name: semver-iam
-  type: docker-image
+  type: registry-image
   source:
     repository: ghcr.io/alphagov/paas/semver-resource
     tag: f2a80c95481056aa57d837e3b14f0012b542fdb3
@@ -88,7 +88,7 @@ resource_types:
   # version of the resource_type `git`. As a temporary fix we have docker image
   # of the resource. This resource_type can be deleted when the issue is resolved
 - name: git
-  type: docker-image
+  type: registry-image
   source:
     repository: ghcr.io/alphagov/paas/git-resource
     tag: 1f84d4a76b4a2491283e0107ae7ed4bc83c84d1b

--- a/concourse/pipelines/destroy-bosh-concourse.yml
+++ b/concourse/pipelines/destroy-bosh-concourse.yml
@@ -8,12 +8,12 @@ meta:
       type: registry-image
       source:
         repository: ghcr.io/alphagov/paas/awscli
-        tag: 8621ead7e4ef0dd653aec80a15b6727b06927e59
+        tag: b25554b10d0efb9da2aef192f9a890199863f59e
     bosh-cli-v2: &gov-paas-bosh-cli-v2-image-resource
       type: registry-image
       source:
         repository: ghcr.io/alphagov/paas/bosh-cli-v2
-        tag: 8621ead7e4ef0dd653aec80a15b6727b06927e59
+        tag: b25554b10d0efb9da2aef192f9a890199863f59e
     ruby-slim: &ruby-slim-image-resource
       type: registry-image
       source:
@@ -23,12 +23,12 @@ meta:
       type: registry-image
       source:
         repository: ghcr.io/alphagov/paas/self-update-pipelines
-        tag: 8621ead7e4ef0dd653aec80a15b6727b06927e59
+        tag: b25554b10d0efb9da2aef192f9a890199863f59e
     terraform: &terraform-image-resource
       type: registry-image
       source:
         repository: ghcr.io/alphagov/paas/terraform
-        tag: 8621ead7e4ef0dd653aec80a15b6727b06927e59
+        tag: b25554b10d0efb9da2aef192f9a890199863f59e
 
 resource_types:
 - name: s3-iam

--- a/concourse/pipelines/destroy-bosh-concourse.yml
+++ b/concourse/pipelines/destroy-bosh-concourse.yml
@@ -5,40 +5,40 @@ display:
 meta:
   containers:
     awscli: &awscli-image-resource
-      type: docker-image
+      type: registry-image
       source:
         repository: ghcr.io/alphagov/paas/awscli
         tag: 8621ead7e4ef0dd653aec80a15b6727b06927e59
     bosh-cli-v2: &gov-paas-bosh-cli-v2-image-resource
-      type: docker-image
+      type: registry-image
       source:
         repository: ghcr.io/alphagov/paas/bosh-cli-v2
         tag: 8621ead7e4ef0dd653aec80a15b6727b06927e59
     ruby-slim: &ruby-slim-image-resource
-      type: docker-image
+      type: registry-image
       source:
         repository: ruby
         tag: 2.7-slim
     self-update-pipelines: &self-update-pipelines-image-resource
-      type: docker-image
+      type: registry-image
       source:
         repository: ghcr.io/alphagov/paas/self-update-pipelines
         tag: 8621ead7e4ef0dd653aec80a15b6727b06927e59
     terraform: &terraform-image-resource
-      type: docker-image
+      type: registry-image
       source:
         repository: ghcr.io/alphagov/paas/terraform
         tag: 8621ead7e4ef0dd653aec80a15b6727b06927e59
 
 resource_types:
 - name: s3-iam
-  type: docker-image
+  type: registry-image
   source:
     repository: ghcr.io/alphagov/paas/s3-resource
     tag: 96b47010a10ca13b40bc604b49b4ab9158cfe2c7
 
 - name: semver-iam
-  type: docker-image
+  type: registry-image
   source:
     repository: ghcr.io/alphagov/paas/semver-resource
     tag: f2a80c95481056aa57d837e3b14f0012b542fdb3
@@ -47,7 +47,7 @@ resource_types:
   # version of the resource_type `git`. As a temporary fix we have docker image
   # of the resource. This resource_type can be deleted when the issue is resolved
 - name: git
-  type: docker-image
+  type: registry-image
   source:
     repository: ghcr.io/alphagov/paas/git-resource
     tag: 1f84d4a76b4a2491283e0107ae7ed4bc83c84d1b

--- a/concourse/scripts/fly_sync_and_login.sh
+++ b/concourse/scripts/fly_sync_and_login.sh
@@ -7,13 +7,8 @@ set -euo pipefail
   $FLY_CMD \
   $FLY_TARGET
 
-if [ "$USER" == "root" ] ; then
-  # We are running in Concourse
-  # Required env vars
-  # shellcheck disable=SC2086
-  : $CONCOURSE_WEB_USER \
-    $CONCOURSE_WEB_PASSWORD
-fi
+CONCOURSE_WEB_USER=${CONCOURSE_WEB_USER:-}
+CONCOURSE_WEB_PASSWORD=${CONCOURSE_WEB_PASSWORD:-}
 
 fetch_fly() {
   echo "Downloading fly .."
@@ -34,17 +29,16 @@ fly_sync() {
 
 fly_login() {
   echo "Doing fly login .."
-  if [ "$USER" == "root" ] ; then
-    # We are running in Concourse
+  if [ -n "$CONCOURSE_WEB_USER" ] && [ -n "$CONCOURSE_WEB_PASSWORD" ] ; then
     $FLY_CMD -t "${FLY_TARGET}" login --concourse-url "${CONCOURSE_URL}" -u "${CONCOURSE_WEB_USER}" -p "${CONCOURSE_WEB_PASSWORD}"
   else
-    # We are running from our computer
+    # shellcheck disable=SC2016
+    echo '$CONCOURSE_WEB_USER and/or $CONCOURSE_WEB_PASSWORD not set - not attempting basic auth...'
     # Check if we are logged in, if we aren't then use the browser
     $FLY_CMD -t "${FLY_TARGET}" status || \
       $FLY_CMD -t "${FLY_TARGET}" login --concourse-url "${CONCOURSE_URL}"
   fi
 }
-
 
 fly_is_runnable() {
   [ -x "${FLY_CMD}" ]

--- a/concourse/tasks/delete-ssh-keys.yml
+++ b/concourse/tasks/delete-ssh-keys.yml
@@ -4,7 +4,7 @@ image_resource:
   type: registry-image
   source:
     repository: ghcr.io/alphagov/paas/awscli
-    tag: 8621ead7e4ef0dd653aec80a15b6727b06927e59
+    tag: b25554b10d0efb9da2aef192f9a890199863f59e
 inputs:
   - name: paas-bootstrap
 run:

--- a/concourse/tasks/delete-ssh-keys.yml
+++ b/concourse/tasks/delete-ssh-keys.yml
@@ -1,7 +1,7 @@
 ---
 platform: linux
 image_resource:
-  type: docker-image
+  type: registry-image
   source:
     repository: ghcr.io/alphagov/paas/awscli
     tag: 8621ead7e4ef0dd653aec80a15b6727b06927e59

--- a/concourse/tasks/render-bosh-manifest.yml
+++ b/concourse/tasks/render-bosh-manifest.yml
@@ -1,7 +1,7 @@
 ---
 platform: linux
 image_resource:
-  type: docker-image
+  type: registry-image
   source:
     repository: ghcr.io/alphagov/paas/bosh-cli-v2
     tag: 8621ead7e4ef0dd653aec80a15b6727b06927e59

--- a/concourse/tasks/render-bosh-manifest.yml
+++ b/concourse/tasks/render-bosh-manifest.yml
@@ -4,7 +4,7 @@ image_resource:
   type: registry-image
   source:
     repository: ghcr.io/alphagov/paas/bosh-cli-v2
-    tag: 8621ead7e4ef0dd653aec80a15b6727b06927e59
+    tag: b25554b10d0efb9da2aef192f9a890199863f59e
 inputs:
   - name: bosh-vars-store
     optional: true


### PR DESCRIPTION
What
----

Upgrade images to be inline with paas-cf.

I had issues with the new images and docker-image. The images would fail to download with the error ['version is missing from previous step'](https://deployer.dev05.dev.cloudpipeline.digital/teams/main/pipelines/create-bosh-concourse/jobs/update-pipeline/builds/3#L63efb5b9/image-check:1). I've switched to the new and improved 'registry-image' resource to resolve this issue.

How to review
-------------

Tested in [dev-05](https://deployer.dev05.dev.cloudpipeline.digital/teams/main/pipelines/create-cloudfoundry/jobs/pipeline-lock/builds/38).

Who can review
--------------

Any team member.

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
