### PR TITLE
[#184471676] Fix for concourse egress cdrs

### DIFF
--- a/concourse/pipelines/create-bosh-concourse.yml
+++ b/concourse/pipelines/create-bosh-concourse.yml
@@ -630,6 +630,25 @@ jobs:
               params:
                 file: generated-git-ssh-keys/git_id_rsa
 
+      - task: get-concourse-egress-ips
+        config:
+          platform: linux
+          image_resource: *awscli-image-resource
+          outputs:
+          - name: concourse_egress
+          params:
+            AWS_DEFAULT_REGION: ((aws_region))
+            DEPLOY_ENV: ((deploy_env))
+          run:
+            path: sh
+            args:
+            - -e
+            - -c
+            - |
+              aws ec2 describe-instances --filters "Name=tag:instance_group,Values=concourse-worker,concourse-lite" "Name=tag:deploy_env,Values=${DEPLOY_ENV}" \
+                                                     --query "Reservations[*].Instances[*].PublicIpAddress" --output text --region ${AWS_DEFAULT_REGION} \
+              > ./concourse_egress/concourse_egress_cidrs.txt
+
       - task: deploy-vpc
         config:
           platform: linux
@@ -637,6 +656,7 @@ jobs:
           inputs:
           - name: paas-bootstrap
           - name: vpc-tfstate
+          - name: concourse_egress
           outputs:
           - name: updated-vpc-tfstate
           params:
@@ -648,14 +668,24 @@ jobs:
             - -e
             - -c
             - |
-              CONCOURSE_EGRESS_IP=$(wget -q -O - http://169.254.169.254/latest/meta-data/public-ipv4)
+              unset CIDRS
+              while read -r p
+              do
+                if [ -z "$CIDRS" ]
+                then
+                  CIDRS=$(printf '"%s"' "${p}/32")
+                else
+                  CIDRS=$(printf '%s, "%s"' "$CIDRS" "${p}/32")
+                fi
+              done <concourse_egress/concourse_egress_cidrs.txt
+              
               cp vpc-tfstate/vpc.tfstate updated-vpc-tfstate/vpc.tfstate
               cd paas-bootstrap/terraform/vpc || exit
               terraform init
 
               terraform apply \
                 -auto-approve=true \
-                -var concourse_egress_cidr="${CONCOURSE_EGRESS_IP}/32" \
+                -var concourse_egress_cidrs="[${CIDRS}]" \
                 -var-file="../../../paas-bootstrap/terraform/((aws_account)).tfvars" \
                 -var-file="../../../paas-bootstrap/terraform/((aws_region)).tfvars" \
                 -state=../../../updated-vpc-tfstate/vpc.tfstate
@@ -872,6 +902,25 @@ jobs:
                 ruby paas-bootstrap/concourse/scripts/extract_tf_vars_from_yaml.rb \
                 < bosh-secrets/bosh-secrets.yml > terraform-variables/bosh-secrets.tfvars.sh
 
+      - task: get-concourse-egress-ips
+        config:
+          platform: linux
+          image_resource: *awscli-image-resource
+          outputs:
+          - name: concourse_egress
+          params:
+            AWS_DEFAULT_REGION: ((aws_region))
+            DEPLOY_ENV: ((deploy_env))
+          run:
+            path: sh
+            args:
+            - -e
+            - -c
+            - |
+              aws ec2 describe-instances --filters "Name=tag:instance_group,Values=concourse-worker,concourse-lite" "Name=tag:deploy_env,Values=${DEPLOY_ENV}" \
+                                                     --query "Reservations[*].Instances[*].PublicIpAddress" --output text --region ${AWS_DEFAULT_REGION} \
+              > ./concourse_egress/concourse_egress_cidrs.txt
+
       - task: terraform-apply
         config:
           platform: linux
@@ -882,6 +931,7 @@ jobs:
             - name: bosh-tfstate
             - name: ssh-public-key
             - name: bootstrap-cyber-tfvars
+            - name: concourse_egress
           outputs:
             - name: updated-bosh-tfstate
           params:
@@ -898,19 +948,28 @@ jobs:
               - -e
               - -c
               - |
+                unset CIDRS
+                while read -r p
+                do
+                  if [ -z "$CIDRS" ]
+                  then
+                    CIDRS=$(printf '"%s"' "${p}/32")
+                  else
+                    CIDRS=$(printf '%s, "%s"' "$CIDRS" "${p}/32")
+                  fi
+                done <concourse_egress/concourse_egress_cidrs.txt
+                
                 . terraform-variables/vpc.tfvars.sh
                 . terraform-variables/bosh-secrets.tfvars.sh
 
                 cp ssh-public-key/id_rsa.pub paas-bootstrap/terraform/bosh
-                CONCOURSE_EGRESS_IP=$(wget -q -O - http://169.254.169.254/latest/meta-data/public-ipv4)
-
                 cp bosh-tfstate/bosh.tfstate updated-bosh-tfstate/bosh.tfstate
                 cd paas-bootstrap/terraform/bosh || exit
                 terraform init
 
                 terraform apply \
                   -auto-approve=true \
-                  -var concourse_egress_cidr="${CONCOURSE_EGRESS_IP}/32" \
+                  -var concourse_egress_cidrs="[${CIDRS}]" \
                   -var env="((deploy_env))" \
                   -var-file="../../../paas-bootstrap/terraform/((aws_account)).tfvars" \
                   -var-file="../../../paas-bootstrap/terraform/((aws_region)).tfvars" \
@@ -1295,6 +1354,25 @@ jobs:
               > bosh-terraform-outputs/tfvars.sh
               ls -l bosh-terraform-outputs/tfvars.sh
 
+      - task: get-concourse-egress-ips
+        config:
+          platform: linux
+          image_resource: *awscli-image-resource
+          outputs:
+          - name: concourse_egress
+          params:
+            AWS_DEFAULT_REGION: ((aws_region))
+            DEPLOY_ENV: ((deploy_env))
+          run:
+            path: sh
+            args:
+            - -e
+            - -c
+            - |
+              aws ec2 describe-instances --filters "Name=tag:instance_group,Values=concourse-worker,concourse-lite" "Name=tag:deploy_env,Values=${DEPLOY_ENV}" \
+                                                     --query "Reservations[*].Instances[*].PublicIpAddress" --output text --region ${AWS_DEFAULT_REGION} \
+              > ./concourse_egress/concourse_egress_cidrs.txt
+
       - task: terraform-apply
         config:
           platform: linux
@@ -1305,6 +1383,7 @@ jobs:
           - name: bosh-terraform-outputs
           - name: concourse-tfstate
           - name: git-ssh-public-key
+          - name: concourse_egress
           outputs:
           - name: updated-concourse-tfstate
           params:
@@ -1319,11 +1398,21 @@ jobs:
             - -e
             - -c
             - |
+              unset CIDRS
+              while read -r p
+              do
+                if [ -z "$CIDRS" ]
+                then
+                  CIDRS=$(printf '"%s"' "${p}/32")
+                else
+                  CIDRS=$(printf '%s, "%s"' "$CIDRS" "${p}/32")
+                fi
+              done <concourse_egress/concourse_egress_cidrs.txt
+              
               . vpc-terraform-outputs/tfvars.sh
               . bosh-terraform-outputs/tfvars.sh
               export TF_VAR_git_rsa_id_pub
               TF_VAR_git_rsa_id_pub=$(cat git-ssh-public-key/git_id_rsa.pub)
-              CONCOURSE_EGRESS_IP=$(wget -q -O - http://169.254.169.254/latest/meta-data/public-ipv4)
 
               cp concourse-tfstate/concourse.tfstate updated-concourse-tfstate/concourse.tfstate
               cd paas-bootstrap/terraform/concourse || exit
@@ -1331,7 +1420,7 @@ jobs:
 
               terraform apply \
                 -auto-approve=true \
-                -var concourse_egress_cidr="${CONCOURSE_EGRESS_IP}/32" \
+                -var concourse_egress_cidrs="[${CIDRS}]" \
                 -var-file="../../../paas-bootstrap/terraform/((aws_account)).tfvars" \
                 -var-file="../../../paas-bootstrap/terraform/((aws_region)).tfvars" \
                 -state=../../../updated-concourse-tfstate/concourse.tfstate

--- a/concourse/pipelines/destroy-bosh-concourse.yml
+++ b/concourse/pipelines/destroy-bosh-concourse.yml
@@ -225,6 +225,25 @@ jobs:
               > vpc-terraform-outputs/tfvars.sh
               ls -l vpc-terraform-outputs/tfvars.sh
 
+      - task: get-concourse-egress-cdrs
+        config:
+          platform: linux
+          image_resource: *awscli-image-resource
+          outputs:
+          - name: concourse_egress
+          params:
+            AWS_DEFAULT_REGION: ((aws_region))
+            DEPLOY_ENV: ((deploy_env))
+          run:
+            path: sh
+            args:
+            - -e
+            - -c
+            - |
+              aws ec2 describe-instances --filters "Name=tag:instance_group,Values=concourse-worker,concourse-lite" "Name=tag:deploy_env,Values=${DEPLOY_ENV}" \
+                                                     --query "Reservations[*].Instances[*].PublicIpAddress" --output text --region ${AWS_DEFAULT_REGION} \
+              > ./concourse_egress/concourse_egress_cidrs.txt
+
       - task: add-concourse-ip-to-bosh-sg
         config:
           platform: linux
@@ -234,6 +253,7 @@ jobs:
             - name: vpc-terraform-outputs
             - name: bosh-tfstate
             - name: bootstrap-cyber-tfvars
+            - name: concourse_egress
           outputs:
             - name: updated-bosh-tfstate
           params:
@@ -249,10 +269,20 @@ jobs:
             - -e
             - -c
             - |
+              unset CIDRS
+              while read -r p
+              do
+                if [ -z "$CIDRS" ]
+                then
+                  CIDRS=$(printf '"%s"' "${p}/32")
+                else
+                  CIDRS=$(printf '%s, "%s"' "$CIDRS" "${p}/32")
+                fi
+              done <concourse_egress/concourse_egress_cidrs.txt
+              
               . vpc-terraform-outputs/tfvars.sh
               export TF_VAR_secrets_bosh_postgres_password=""
               export TF_VAR_bosh_az=""
-              CONCOURSE_EGRESS_IP=$(wget -q -O - http://169.254.169.254/latest/meta-data/public-ipv4)
 
               cp bosh-tfstate/bosh.tfstate updated-bosh-tfstate/bosh.tfstate
               cd paas-bootstrap/terraform/bosh || exit
@@ -262,7 +292,7 @@ jobs:
 
               terraform apply \
                 -auto-approve=true \
-                -var concourse_egress_cidr="${CONCOURSE_EGRESS_IP}/32" \
+                -var concourse_egress_cidrs="[${CIDRS}]" \
                 -target=aws_security_group.bosh \
                 -state=../../../updated-bosh-tfstate/bosh.tfstate \
                 -var-file="../../../paas-bootstrap/terraform/((aws_account)).tfvars" \
@@ -541,6 +571,25 @@ jobs:
                 ruby paas-bootstrap/concourse/scripts/extract_tf_vars_from_yaml.rb \
                 < bosh-secrets/bosh-secrets.yml > terraform-variables/bosh-secrets.tfvars.sh
 
+      - task: get-concourse-egress-cdrs
+        config:
+          platform: linux
+          image_resource: *awscli-image-resource
+          outputs:
+          - name: concourse_egress
+          params:
+            AWS_DEFAULT_REGION: ((aws_region))
+            DEPLOY_ENV: ((deploy_env))
+          run:
+            path: sh
+            args:
+            - -e
+            - -c
+            - |
+              aws ec2 describe-instances --filters "Name=tag:instance_group,Values=concourse-worker,concourse-lite" "Name=tag:deploy_env,Values=${DEPLOY_ENV}" \
+                                                     --query "Reservations[*].Instances[*].PublicIpAddress" --output text --region ${AWS_DEFAULT_REGION} \
+              > ./concourse_egress/concourse_egress_cidrs.txt
+
       - task: destroy-terraform
         config:
           platform: linux
@@ -550,6 +599,7 @@ jobs:
             - name: terraform-variables
             - name: bosh-tfstate
             - name: bootstrap-cyber-tfvars
+            - name: concourse_egress
           outputs:
             - name: updated-bosh-tfstate
           params:
@@ -566,20 +616,30 @@ jobs:
               - -e
               - -c
               - |
+                unset CIDRS
+                while read -r p
+                do
+                  if [ -z "$CIDRS" ]
+                  then
+                    CIDRS=$(printf '"%s"' "${p}/32")
+                  else
+                    CIDRS=$(printf '%s, "%s"' "$CIDRS" "${p}/32")
+                  fi
+                done <concourse_egress/concourse_egress_cidrs.txt
+                
                 . terraform-variables/vpc.tfvars.sh
                 . terraform-variables/bosh-secrets.tfvars.sh
 
                 touch paas-bootstrap/terraform/bosh/id_rsa.pub
-                CONCOURSE_EGRESS_IP=$(wget -q -O - http://169.254.169.254/latest/meta-data/public-ipv4)
-
+                
                 cp bosh-tfstate/bosh.tfstate updated-bosh-tfstate/bosh.tfstate
                 cd paas-bootstrap/terraform/bosh || exit
                 terraform init
 
-                sh paas-bootstrap/terraform/./update-terraform-providers.sh updated-bosh-tfstate/bosh.tfstate
+                sh ../../../paas-bootstrap/terraform/./update-terraform-providers.sh ../../../updated-bosh-tfstate/bosh.tfstate
 
                 terraform destroy -auto-approve \
-                  -var concourse_egress_cidr="${CONCOURSE_EGRESS_IP}/32" \
+                  -var concourse_egress_cidrs="[${CIDRS}]" \
                   -var env="((deploy_env))" \
                   -var-file="../../../paas-bootstrap/terraform/((aws_account)).tfvars" \
                   -var-file="../../../paas-bootstrap/terraform/((aws_region)).tfvars" \
@@ -623,7 +683,7 @@ jobs:
               cd paas-bootstrap/terraform/vpc || exit
               terraform init
 
-              sh paas-bootstrap/terraform/./update-terraform-providers.sh updated-vpc-tfstate/vpc.tfstate
+              sh ../../../paas-bootstrap/terraform/./update-terraform-providers.sh ../../../updated-vpc-tfstate/vpc.tfstate
 
               terraform destroy -auto-approve \
                 -var-file="../../../paas-bootstrap/terraform/((aws_account)).tfvars" \
@@ -669,7 +729,7 @@ jobs:
               cd paas-bootstrap/terraform/cyber || exit
               terraform init
 
-              sh paas-bootstrap/terraform/./update-terraform-providers.sh updated-bootstrap-cyber-tfstate/bootstrap-cyber.tfstate
+              sh ../../../paas-bootstrap/terraform/./update-terraform-providers.sh ../../../updated-bootstrap-cyber-tfstate/bootstrap-cyber.tfstate
 
               terraform destroy -auto-approve \
                 -var-file="../../../paas-bootstrap/terraform/((aws_account)).tfvars" \

--- a/terraform/bosh/security_groups.tf
+++ b/terraform/bosh/security_groups.tf
@@ -1,15 +1,3 @@
-data "aws_instances" "concourse_workers" {
-  filter {
-    name   = "tag:instance_group"
-    values = ["concourse-worker", "concourse-lite"]
-  }
-
-  filter {
-    name   = "tag:deploy_env"
-    values = [var.env]
-  }
-}
-
 resource "aws_security_group" "bosh" {
   name        = "${var.env}-bosh"
   description = "Bosh security group"
@@ -26,7 +14,7 @@ resource "aws_security_group" "bosh" {
     from_port   = 22
     to_port     = 22
     protocol    = "tcp"
-    cidr_blocks = formatlist("%s/32", data.aws_instances.concourse_workers.public_ips)
+    cidr_blocks = compact(var.concourse_egress_cidrs)
   }
 
   ingress {
@@ -43,7 +31,7 @@ resource "aws_security_group" "bosh" {
     from_port   = 6868
     to_port     = 6868
     protocol    = "tcp"
-    cidr_blocks = formatlist("%s/32", data.aws_instances.concourse_workers.public_ips)
+    cidr_blocks = compact(var.concourse_egress_cidrs)
   }
 
   ingress {

--- a/terraform/concourse/elb.tf
+++ b/terraform/concourse/elb.tf
@@ -61,7 +61,7 @@ resource "aws_security_group" "concourse-elb" {
         concat(
           var.admin_cidrs,
           ["${aws_eip.concourse.public_ip}/32"],
-          [var.concourse_egress_cidr],
+          var.concourse_egress_cidrs,
         ),
       ),
     )

--- a/terraform/globals.tf
+++ b/terraform/globals.tf
@@ -69,9 +69,10 @@ variable "infra_subnet_ids" {
   default     = ""
 }
 
-variable "concourse_egress_cidr" {
-  description = "Public egress IP address of concourse running the pipeline"
-  default     = ""
+variable "concourse_egress_cidrs" {
+  description = "Public egress IP addresses of concourse workers running the pipeline"
+  type        = list(string)
+  default     = []
 }
 
 variable "microbosh_static_private_ip" {

--- a/terraform/vpc/security-group.tf
+++ b/terraform/vpc/security-group.tf
@@ -14,14 +14,14 @@ resource "aws_security_group" "office-access-ssh" {
     from_port   = 22
     to_port     = 22
     protocol    = "tcp"
-    cidr_blocks = compact(concat(var.admin_cidrs, [var.concourse_egress_cidr]))
+    cidr_blocks = compact(concat(var.admin_cidrs, var.concourse_egress_cidrs))
   }
 
   ingress {
     from_port   = 8443
     to_port     = 8443
     protocol    = "tcp"
-    cidr_blocks = compact(concat(var.admin_cidrs, [var.concourse_egress_cidr]))
+    cidr_blocks = compact(concat(var.admin_cidrs, var.concourse_egress_cidrs))
   }
 
   tags = {


### PR DESCRIPTION
[#184471676] Fixed destroy-bosh-concourse

What
----

Ticket [184471676](https://www.pivotaltracker.com/n/projects/1275640/stories/184471676) has more info.

The original issue was that concourse would obtain the ip of the current concourse worker and add that to various security groups so that the concourse worker would have access to other resources within the vpc, to bosh and to vms via ssh. That was fine for environments that have just one worker to perform all pipeline jobs but was an issue for environments having more than one worker as the success of a job depended upon that job being run by the worker whose ip had been added to the security groups.

A fix had previously been implemented but that had resulted in the ip not being deleted from the bosh security group.

This change has fixed that issue. It has been added to both the create-bosh-concourse and the delete-bosh-concourse pipelines. 

How to review
-------------

1. Run the branch into one of the dev envs.
2. Check that the concourse ip is being removed from the remove-concourse-ip-from-ssh-sg, remove-concourse-ip-from-1.bosh-sg and remove-concourse-ip-from-concourse-sg tasks within the expunge-concourse job.
3. Run the delete-bosh-concourse pipeline in the bootstrap environment. The command to create the pipeline is:
```gds aws paas-dev-admin -- make current-branch devXX deployer-concourse bootstrap```

Who can review
--------------

Any paas engineer.

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
