### PR TITLE
[#184471676] Fix create-bosh-concourse

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,8 @@ These instructions contain placeholders where the exact command may vary. This t
 - [ ] `AWS_DEFAULT_REGION` environment set to the desired region for the environment
 - [ ] [Github OAuth application credentials](https://docs.github.com/en/developers/apps/building-oauth-apps/creating-an-oauth-app).
   If you're deploying a production/staging/shared dev environment (for example, dev01, dev02), the app should belong to the alphagov organisation, and the credentials should be added to `paas-credentials` <br />
-  If you're deploying a short-lived environment (for example, for penetration testing), the credentials can be associated with your GitHub account. You can put them in your personal password store, and set the path to it using the `GITHUB_PASSWORD_STORE_DIR` environment variable
+  If you're deploying a short-lived environment (for example, for penetration testing) the credentials can be associated with your GitHub account. You can put them in your personal password store, and set the path to it using the `GITHUB_PASSWORD_STORE_DIR` environment variable.
+  If you are setting up Github OAuth for your dev pipeline the callback url to use is https://deployer.${DEPLOY_ENV}.dev.cloudpipeline.digital/sky/issuer/callback
 
 ## Deploying the bootstrap for Cloud Foundry
 

--- a/concourse/pipelines/create-bosh-concourse.yml
+++ b/concourse/pipelines/create-bosh-concourse.yml
@@ -648,14 +648,13 @@ jobs:
             - -e
             - -c
             - |
-              CONCOURSE_EGRESS_IP=$(wget -q -O - http://169.254.169.254/latest/meta-data/public-ipv4)
               cp vpc-tfstate/vpc.tfstate updated-vpc-tfstate/vpc.tfstate
               cd paas-bootstrap/terraform/vpc || exit
               terraform init
 
               terraform apply \
                 -auto-approve=true \
-                -var concourse_egress_cidr="${CONCOURSE_EGRESS_IP}/32" \
+                -var="set_concourse_egress_cidrs=true" \
                 -var-file="../../../paas-bootstrap/terraform/((aws_account)).tfvars" \
                 -var-file="../../../paas-bootstrap/terraform/((aws_region)).tfvars" \
                 -state=../../../updated-vpc-tfstate/vpc.tfstate
@@ -711,7 +710,6 @@ jobs:
                   -var-file="../../../paas-bootstrap/terraform/((aws_region)).tfvars" \
                   -var-file="../../../bootstrap-cyber-tfvars/bootstrap-cyber.tfvars" \
                   -state=../../../updated-bootstrap-cyber-tfstate/bootstrap-cyber.tfstate
-
         ensure:
           put: bootstrap-cyber-tfstate
           params:
@@ -902,15 +900,13 @@ jobs:
                 . terraform-variables/bosh-secrets.tfvars.sh
 
                 cp ssh-public-key/id_rsa.pub paas-bootstrap/terraform/bosh
-                CONCOURSE_EGRESS_IP=$(wget -q -O - http://169.254.169.254/latest/meta-data/public-ipv4)
-
                 cp bosh-tfstate/bosh.tfstate updated-bosh-tfstate/bosh.tfstate
                 cd paas-bootstrap/terraform/bosh || exit
                 terraform init
 
                 terraform apply \
                   -auto-approve=true \
-                  -var concourse_egress_cidr="${CONCOURSE_EGRESS_IP}/32" \
+                  -var="set_concourse_egress_cidrs=true" \
                   -var env="((deploy_env))" \
                   -var-file="../../../paas-bootstrap/terraform/((aws_account)).tfvars" \
                   -var-file="../../../paas-bootstrap/terraform/((aws_region)).tfvars" \
@@ -1253,6 +1249,7 @@ jobs:
                 credhub set --name=/"${DEPLOY_ENV}"/concourse/region --type value --value "${AWS_REGION}"
 
                 credhub find --path=/
+
   - name: concourse-terraform
     serial: true
     plan:
@@ -1323,15 +1320,14 @@ jobs:
               . bosh-terraform-outputs/tfvars.sh
               export TF_VAR_git_rsa_id_pub
               TF_VAR_git_rsa_id_pub=$(cat git-ssh-public-key/git_id_rsa.pub)
-              CONCOURSE_EGRESS_IP=$(wget -q -O - http://169.254.169.254/latest/meta-data/public-ipv4)
-
+              
               cp concourse-tfstate/concourse.tfstate updated-concourse-tfstate/concourse.tfstate
               cd paas-bootstrap/terraform/concourse || exit
               terraform init
 
               terraform apply \
                 -auto-approve=true \
-                -var concourse_egress_cidr="${CONCOURSE_EGRESS_IP}/32" \
+                -var="set_concourse_egress_cidrs=true" \
                 -var-file="../../../paas-bootstrap/terraform/((aws_account)).tfvars" \
                 -var-file="../../../paas-bootstrap/terraform/((aws_region)).tfvars" \
                 -state=../../../updated-concourse-tfstate/concourse.tfstate
@@ -2101,6 +2097,7 @@ jobs:
               terraform apply \
                 -auto-approve=true \
                 -target=aws_security_group.office-access-ssh \
+                -var="set_concourse_egress_cidrs=false" \
                 -var-file="../../../paas-bootstrap/terraform/((aws_account)).tfvars" \
                 -var-file="../../../paas-bootstrap/terraform/((aws_region)).tfvars" \
                 -target=aws_subnet.infra \
@@ -2146,6 +2143,7 @@ jobs:
                 -auto-approve=true \
                 -target=aws_security_group.bosh \
                 -state=../../../updated-bosh-tfstate/bosh.tfstate \
+                -var="set_concourse_egress_cidrs=false" \
                 -var-file="../../../paas-bootstrap/terraform/((aws_account)).tfvars" \
                 -var-file="../../../paas-bootstrap/terraform/((aws_region)).tfvars" \
                 -var-file="../../../bootstrap-cyber-tfvars/bootstrap-cyber.tfvars"
@@ -2188,6 +2186,7 @@ jobs:
               terraform apply \
                 -auto-approve=true \
                 -target=aws_security_group.concourse \
+                -var="set_concourse_egress_cidrs=false" \
                 -var-file="../../../paas-bootstrap/terraform/((aws_account)).tfvars" \
                 -var-file="../../../paas-bootstrap/terraform/((aws_region)).tfvars" \
                 -state=../../../updated-concourse-tfstate/concourse.tfstate

--- a/concourse/pipelines/destroy-bosh-concourse.yml
+++ b/concourse/pipelines/destroy-bosh-concourse.yml
@@ -252,7 +252,6 @@ jobs:
               . vpc-terraform-outputs/tfvars.sh
               export TF_VAR_secrets_bosh_postgres_password=""
               export TF_VAR_bosh_az=""
-              CONCOURSE_EGRESS_IP=$(wget -q -O - http://169.254.169.254/latest/meta-data/public-ipv4)
 
               cp bosh-tfstate/bosh.tfstate updated-bosh-tfstate/bosh.tfstate
               cd paas-bootstrap/terraform/bosh || exit
@@ -262,7 +261,7 @@ jobs:
 
               terraform apply \
                 -auto-approve=true \
-                -var concourse_egress_cidr="${CONCOURSE_EGRESS_IP}/32" \
+                -var="set_concourse_egress_cidrs=true" \
                 -target=aws_security_group.bosh \
                 -state=../../../updated-bosh-tfstate/bosh.tfstate \
                 -var-file="../../../paas-bootstrap/terraform/((aws_account)).tfvars" \
@@ -570,16 +569,15 @@ jobs:
                 . terraform-variables/bosh-secrets.tfvars.sh
 
                 touch paas-bootstrap/terraform/bosh/id_rsa.pub
-                CONCOURSE_EGRESS_IP=$(wget -q -O - http://169.254.169.254/latest/meta-data/public-ipv4)
 
                 cp bosh-tfstate/bosh.tfstate updated-bosh-tfstate/bosh.tfstate
                 cd paas-bootstrap/terraform/bosh || exit
                 terraform init
 
-                sh paas-bootstrap/terraform/./update-terraform-providers.sh updated-bosh-tfstate/bosh.tfstate
+                sh ../../../paas-bootstrap/terraform/./update-terraform-providers.sh ../../../updated-bosh-tfstate/bosh.tfstate
 
                 terraform destroy -auto-approve \
-                  -var concourse_egress_cidr="${CONCOURSE_EGRESS_IP}/32" \
+                  -var="set_concourse_egress_cidrs=true" \
                   -var env="((deploy_env))" \
                   -var-file="../../../paas-bootstrap/terraform/((aws_account)).tfvars" \
                   -var-file="../../../paas-bootstrap/terraform/((aws_region)).tfvars" \
@@ -623,7 +621,7 @@ jobs:
               cd paas-bootstrap/terraform/vpc || exit
               terraform init
 
-              sh paas-bootstrap/terraform/./update-terraform-providers.sh updated-vpc-tfstate/vpc.tfstate
+              sh ../../../paas-bootstrap/terraform/./update-terraform-providers.sh ../../../updated-vpc-tfstate/vpc.tfstate
 
               terraform destroy -auto-approve \
                 -var-file="../../../paas-bootstrap/terraform/((aws_account)).tfvars" \
@@ -669,7 +667,7 @@ jobs:
               cd paas-bootstrap/terraform/cyber || exit
               terraform init
 
-              sh paas-bootstrap/terraform/./update-terraform-providers.sh updated-bootstrap-cyber-tfstate/bootstrap-cyber.tfstate
+              sh ../../../paas-bootstrap/terraform/./update-terraform-providers.sh ../../../updated-bootstrap-cyber-tfstate/bootstrap-cyber.tfstate
 
               terraform destroy -auto-approve \
                 -var-file="../../../paas-bootstrap/terraform/((aws_account)).tfvars" \

--- a/terraform/bosh/blobstore.tf
+++ b/terraform/bosh/blobstore.tf
@@ -1,6 +1,10 @@
 resource "aws_s3_bucket" "bosh-blobstore" {
   bucket        = "gds-paas-${var.env}-bosh-blobstore"
-  acl           = "private"
   force_destroy = "true"
+}
+
+resource "aws_s3_bucket_acl" "bosh-blobstore_acl" {
+  bucket = aws_s3_bucket.bosh-blobstore.id
+  acl    = "private"
 }
 

--- a/terraform/bosh/outputs.tf
+++ b/terraform/bosh/outputs.tf
@@ -46,7 +46,7 @@ output "bosh_db_username" {
 }
 
 output "bosh_db_dbname" {
-  value = aws_db_instance.bosh.name
+  value = aws_db_instance.bosh.db_name
 }
 
 output "bosh_az" {
@@ -77,3 +77,6 @@ output "bosh_security_group_id" {
   value = aws_security_group.bosh.id
 }
 
+output "set_concourse_egress_cidrs" {
+  value = var.set_concourse_egress_cidrs
+}

--- a/terraform/bosh/security_groups.tf
+++ b/terraform/bosh/security_groups.tf
@@ -26,7 +26,7 @@ resource "aws_security_group" "bosh" {
     from_port   = 22
     to_port     = 22
     protocol    = "tcp"
-    cidr_blocks = formatlist("%s/32", data.aws_instances.concourse_workers.public_ips)
+    cidr_blocks = var.set_concourse_egress_cidrs == false ? [] : formatlist("%s/32", data.aws_instances.concourse_workers.public_ips)
   }
 
   ingress {
@@ -43,7 +43,7 @@ resource "aws_security_group" "bosh" {
     from_port   = 6868
     to_port     = 6868
     protocol    = "tcp"
-    cidr_blocks = formatlist("%s/32", data.aws_instances.concourse_workers.public_ips)
+    cidr_blocks = var.set_concourse_egress_cidrs == false ? [] : formatlist("%s/32", data.aws_instances.concourse_workers.public_ips)
   }
 
   ingress {

--- a/terraform/concourse/elb.tf
+++ b/terraform/concourse/elb.tf
@@ -1,3 +1,15 @@
+data "aws_instances" "concourse_workers" {
+  filter {
+    name   = "tag:instance_group"
+    values = ["concourse-worker", "concourse-lite"]
+  }
+
+  filter {
+    name   = "tag:deploy_env"
+    values = [var.env]
+  }
+}
+
 resource "aws_elb" "concourse" {
   name         = "${var.env}-concourse"
   subnets      = split(",", var.infra_subnet_ids)
@@ -61,7 +73,7 @@ resource "aws_security_group" "concourse-elb" {
         concat(
           var.admin_cidrs,
           ["${aws_eip.concourse.public_ip}/32"],
-          [var.concourse_egress_cidr],
+          var.set_concourse_egress_cidrs == false ? [] : formatlist("%s/32", data.aws_instances.concourse_workers.public_ips),
         ),
       ),
     )

--- a/terraform/concourse/outputs.tf
+++ b/terraform/concourse/outputs.tf
@@ -44,7 +44,7 @@ output "git_concourse_pool_clone_full_url_ssh" {
 }
 
 output "concourse_db_name" {
-  value = aws_db_instance.concourse.name
+  value = aws_db_instance.concourse.db_name
 }
 
 output "concourse_db_username" {
@@ -62,5 +62,9 @@ output "concourse_db_address" {
 
 output "concourse_db_port" {
   value = aws_db_instance.concourse.port
+}
+
+output "set_concourse_egress_cidrs" {
+  value = var.set_concourse_egress_cidrs
 }
 

--- a/terraform/globals.tf
+++ b/terraform/globals.tf
@@ -69,9 +69,10 @@ variable "infra_subnet_ids" {
   default     = ""
 }
 
-variable "concourse_egress_cidr" {
-  description = "Public egress IP address of concourse running the pipeline"
-  default     = ""
+variable "set_concourse_egress_cidrs" {
+  description = "Allow or restrict public egress IP address of concourse workers"
+  type        = bool
+  default     = false
 }
 
 variable "microbosh_static_private_ip" {

--- a/terraform/providers.tf
+++ b/terraform/providers.tf
@@ -6,4 +6,3 @@ provider "aws" {
   alias  = "codecommit"
   region = "us-east-1"
 }
-

--- a/terraform/vpc/security-group.tf
+++ b/terraform/vpc/security-group.tf
@@ -1,3 +1,15 @@
+data "aws_instances" "concourse_workers" {
+  filter {
+    name   = "tag:instance_group"
+    values = ["concourse-worker", "concourse-lite"]
+  }
+
+  filter {
+    name   = "tag:deploy_env"
+    values = [var.env]
+  }
+}
+
 resource "aws_security_group" "office-access-ssh" {
   vpc_id      = aws_vpc.paas.id
   name        = "${var.env}-office-access-ssh"
@@ -14,14 +26,14 @@ resource "aws_security_group" "office-access-ssh" {
     from_port   = 22
     to_port     = 22
     protocol    = "tcp"
-    cidr_blocks = compact(concat(var.admin_cidrs, [var.concourse_egress_cidr]))
+    cidr_blocks = compact(concat(var.admin_cidrs, var.set_concourse_egress_cidrs == false ? [] : formatlist("%s/32", data.aws_instances.concourse_workers.public_ips)))
   }
 
   ingress {
     from_port   = 8443
     to_port     = 8443
     protocol    = "tcp"
-    cidr_blocks = compact(concat(var.admin_cidrs, [var.concourse_egress_cidr]))
+    cidr_blocks = compact(concat(var.admin_cidrs, var.set_concourse_egress_cidrs == false ? [] : formatlist("%s/32", data.aws_instances.concourse_workers.public_ips)))
   }
 
   tags = {

--- a/vagrant/deploy.sh
+++ b/vagrant/deploy.sh
@@ -27,7 +27,7 @@ if aws ec2 describe-key-pairs --key-name "${VAGRANT_SSH_KEY_NAME}" >/dev/null 2>
   # Remove the aws key pair
   aws ec2 delete-key-pair --key-name "${VAGRANT_SSH_KEY_NAME}"
 fi
-
+ 
 # Create the key pair online.
 aws ec2 create-key-pair --key-name "${VAGRANT_SSH_KEY_NAME}" | jq -r ".KeyMaterial" > "${VAGRANT_SSH_KEY}"
 


### PR DESCRIPTION
What
----

Ticket [184471676](https://www.pivotaltracker.com/n/projects/1275640/stories/184471676) has more info.

The original issue was that concourse would obtain the ip of the current concourse worker and add that to various security groups so that the concourse worker would have access to resources that it required to communicate with. That was fine for environments that have just one worker to perform all pipeline jobs but was an issue for environments having more than one worker as the success of a job depended upon that job being run by the worker whose ip had been added to the security groups.

How to review
-------------

It should be run into the build env which has 4 workers and check that the concourse worker ips are being removed from the remove-concourse-ip-from-ssh-sg, remove-concourse-ip-from-bosh-sg and remove-concourse-ip-from-concourse-sg tasks within the expunge-concourse job.

Who can review
--------------

Any paas developer with gpg key in paas-credentials

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
