### PR TITLE
[#177413892] Switch to using containerd for concourse

### DIFF
--- a/manifests/concourse-manifest/concourse-base.yml
+++ b/manifests/concourse-manifest/concourse-base.yml
@@ -89,8 +89,7 @@ instance_groups:
             host_public_key: ((concourse_tsa_host_key.public_key))
             worker_key: ((concourse_worker_key))
           tags: [colocated-with-web]
-          garden:
-            allow_host_access: true
+          runtime: containerd
           baggageclaim:
             driver: overlay
 
@@ -129,8 +128,7 @@ instance_groups:
           worker_gateway:
             worker_key: ((concourse_worker_key))
             host_public_key: ((concourse_tsa_host_key.public_key))
-          garden:
-            allow_host_access: true
+          runtime: containerd
           baggageclaim:
             driver: overlay
 


### PR DESCRIPTION
What
----

Switch from using guardian to containerd for concourse.

How to review
-------------

[Tested in dev-02.](https://deployer.dev02.dev.cloudpipeline.digital/teams/main/pipelines/create-bosh-concourse/jobs/concourse-deploy/builds/118#L6400ab19:13)

Testing done.

- sshing to the worker node before and after and validating that containerd was not running before and was running afterwards.
- Validate full runs of paas-bootstrap and paas-cf after switching to containerd.
- Backing out change.

Ensure you are happy with the tests done.

Who can review
--------------

Any team member

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
