### PR TITLE
[184427313] Adding Jamie to build CI

### DIFF
--- a/manifests/concourse-manifest/github_auth/dev_ci_additional_users.yml
+++ b/manifests/concourse-manifest/github_auth/dev_ci_additional_users.yml
@@ -28,3 +28,4 @@ instance_groups:
                     - jackjoy-gds
                     - dark5un
                     - corlettb
+                    - fearoffish


### PR DESCRIPTION
What
----

Adding Jamie Van Dyke to Build CI

How to review
-------------

Verify the github user name to be owned by Jamie

Who can review
--------------

- Paas team
- @fearoffish 
---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
