### PR TITLE
[#184281154] Fix rebuilds can cause state corruption

### DIFF
--- a/concourse/pipelines/create-bosh-concourse.yml
+++ b/concourse/pipelines/create-bosh-concourse.yml
@@ -590,7 +590,6 @@ jobs:
         - get: pipeline-trigger
           trigger: true
           passed: ['check-for-secrets']
-        - get: vpc-tfstate
         - get: git-ssh-public-key
         - get: git-ssh-private-key
 
@@ -636,9 +635,6 @@ jobs:
           image_resource: *terraform-image-resource
           inputs:
           - name: paas-bootstrap
-          - name: vpc-tfstate
-          outputs:
-          - name: updated-vpc-tfstate
           params:
             TF_VAR_env: ((deploy_env))
             AWS_DEFAULT_REGION: ((aws_region))
@@ -648,22 +644,18 @@ jobs:
             - -e
             - -c
             - |
-              CONCOURSE_EGRESS_IP=$(wget -q -O - http://169.254.169.254/latest/meta-data/public-ipv4)
-              cp vpc-tfstate/vpc.tfstate updated-vpc-tfstate/vpc.tfstate
               cd paas-bootstrap/terraform/vpc || exit
-              terraform init
+
+              terraform init --reconfigure \
+                -backend-config="bucket=((state_bucket))" \
+                -backend-config="region=((aws_region))"
 
               terraform apply \
                 -auto-approve=true \
-                -var concourse_egress_cidr="${CONCOURSE_EGRESS_IP}/32" \
+                -var="concourse_egress_cidrs=true" \
                 -var-file="../../../paas-bootstrap/terraform/((aws_account)).tfvars" \
-                -var-file="../../../paas-bootstrap/terraform/((aws_region)).tfvars" \
-                -state=../../../updated-vpc-tfstate/vpc.tfstate
-        ensure:
-          put: vpc-tfstate
-          params:
-            file: updated-vpc-tfstate/vpc.tfstate
-
+                -var-file="../../../paas-bootstrap/terraform/((aws_region)).tfvars" 
+              
   - name: cyber-terraform
     serial: true
     # This is not in the mainline of the pipeline
@@ -702,7 +694,11 @@ jobs:
                 cp bootstrap-cyber-tfstate/bootstrap-cyber.tfstate \
                    updated-bootstrap-cyber-tfstate/bootstrap-cyber.tfstate
                 cd paas-bootstrap/terraform/cyber || exit
-                terraform init
+
+                terraform init --reconfigure \
+                -backend-config="bucket=((state_bucket))" \
+                -backend-config="region=((aws_region))" \
+                -backend-config="key=bootstrap-cyber.tfstate"
 
                 terraform apply \
                   -auto-approve=true \
@@ -710,12 +706,6 @@ jobs:
                   -var-file="../../../paas-bootstrap/terraform/((aws_account)).tfvars" \
                   -var-file="../../../paas-bootstrap/terraform/((aws_region)).tfvars" \
                   -var-file="../../../bootstrap-cyber-tfvars/bootstrap-cyber.tfvars" \
-                  -state=../../../updated-bootstrap-cyber-tfstate/bootstrap-cyber.tfstate
-
-        ensure:
-          put: bootstrap-cyber-tfstate
-          params:
-            file: updated-bootstrap-cyber-tfstate/bootstrap-cyber.tfstate
 
   - name: generate-secrets
     serial: true
@@ -844,7 +834,6 @@ jobs:
         - get: bosh-secrets
           passed: ['generate-secrets']
         - get: vpc-tfstate
-          passed: ['vpc']
         - get: bosh-tfstate
         - get: bootstrap-cyber-tfvars
           passed: ['cyber-terraform']
@@ -902,24 +891,21 @@ jobs:
                 . terraform-variables/bosh-secrets.tfvars.sh
 
                 cp ssh-public-key/id_rsa.pub paas-bootstrap/terraform/bosh
-                CONCOURSE_EGRESS_IP=$(wget -q -O - http://169.254.169.254/latest/meta-data/public-ipv4)
 
                 cp bosh-tfstate/bosh.tfstate updated-bosh-tfstate/bosh.tfstate
                 cd paas-bootstrap/terraform/bosh || exit
-                terraform init
+
+                terraform init --reconfigure \
+                -backend-config="bucket=((state_bucket))" \
+                -backend-config="region=((aws_region))"
 
                 terraform apply \
                   -auto-approve=true \
-                  -var concourse_egress_cidr="${CONCOURSE_EGRESS_IP}/32" \
                   -var env="((deploy_env))" \
+                  -var="concourse_egress_cidrs=true" \
                   -var-file="../../../paas-bootstrap/terraform/((aws_account)).tfvars" \
                   -var-file="../../../paas-bootstrap/terraform/((aws_region)).tfvars" \
                   -var-file="../../../bootstrap-cyber-tfvars/bootstrap-cyber.tfvars" \
-                  -state=../../../updated-bosh-tfstate/bosh.tfstate
-        ensure:
-          put: bosh-tfstate
-          params:
-            file: updated-bosh-tfstate/bosh.tfstate
 
   - name: generate-bosh-config
     serial_groups: [bosh-deploy]
@@ -1125,6 +1111,27 @@ jobs:
         - get: bosh-init-state
         - get: ssh-private-key
 
+        # task to work around potential bosh state corruption on build re-runs - 184281154
+      - task: fetch-bosh-init-state
+        config:
+          platform: linux
+          image_resource: *awscli-image-resource
+          params:
+            AWS_DEFAULT_REGION: ((aws_region))
+            BOSH_MANIFEST_STATE: ((bosh_manifest_state))
+          outputs:
+            - name: bosh-init-state
+          run:
+            path: sh
+            args:
+            - -e
+            - -u
+            - -c
+            - |
+              cd bosh-init-state
+              aws s3 cp "s3://((state_bucket))/${BOSH_MANIFEST_STATE}" .
+              ls -l
+
       - task: bosh-create-env
         config:
           platform: linux
@@ -1322,23 +1329,20 @@ jobs:
               . vpc-terraform-outputs/tfvars.sh
               . bosh-terraform-outputs/tfvars.sh
               export TF_VAR_git_rsa_id_pub
-              TF_VAR_git_rsa_id_pub=$(cat git-ssh-public-key/git_id_rsa.pub)
-              CONCOURSE_EGRESS_IP=$(wget -q -O - http://169.254.169.254/latest/meta-data/public-ipv4)
 
-              cp concourse-tfstate/concourse.tfstate updated-concourse-tfstate/concourse.tfstate
+              TF_VAR_git_rsa_id_pub=$(cat git-ssh-public-key/git_id_rsa.pub)
+              
               cd paas-bootstrap/terraform/concourse || exit
-              terraform init
+
+              terraform init --reconfigure \
+                -backend-config="bucket=((state_bucket))" \
+                -backend-config="region=((aws_region))"
 
               terraform apply \
                 -auto-approve=true \
-                -var concourse_egress_cidr="${CONCOURSE_EGRESS_IP}/32" \
+                -var="concourse_egress_cidrs=true" \
                 -var-file="../../../paas-bootstrap/terraform/((aws_account)).tfvars" \
                 -var-file="../../../paas-bootstrap/terraform/((aws_region)).tfvars" \
-                -state=../../../updated-concourse-tfstate/concourse.tfstate
-        ensure:
-          put: concourse-tfstate
-          params:
-            file: updated-concourse-tfstate/concourse.tfstate
 
   - name: generate-concourse-config
     serial: true
@@ -2094,21 +2098,19 @@ jobs:
             - -e
             - -c
             - |
-              cp vpc-tfstate/vpc.tfstate updated-vpc-tfstate/vpc.tfstate
               cd paas-bootstrap/terraform/vpc || exit
-              terraform init
+
+              terraform init --reconfigure \
+                -backend-config="bucket=((state_bucket))" \
+                -backend-config="region=((aws_region))"
 
               terraform apply \
                 -auto-approve=true \
                 -target=aws_security_group.office-access-ssh \
+                -var="concourse_egress_cidrs=false" \
                 -var-file="../../../paas-bootstrap/terraform/((aws_account)).tfvars" \
                 -var-file="../../../paas-bootstrap/terraform/((aws_region)).tfvars" \
                 -target=aws_subnet.infra \
-                -state=../../../updated-vpc-tfstate/vpc.tfstate
-        ensure:
-          put: vpc-tfstate
-          params:
-            file: updated-vpc-tfstate/vpc.tfstate
 
       - task: remove-concourse-ip-from-bosh-sg
         config:
@@ -2138,21 +2140,18 @@ jobs:
               export TF_VAR_secrets_bosh_postgres_password=""
               export TF_VAR_bosh_az=""
 
-              cp bosh-tfstate/bosh.tfstate updated-bosh-tfstate/bosh.tfstate
               cd paas-bootstrap/terraform/bosh || exit
-              terraform init
+              terraform init --reconfigure \
+                -backend-config="bucket=((state_bucket))" \
+                -backend-config="region=((aws_region))"
 
               terraform apply \
                 -auto-approve=true \
                 -target=aws_security_group.bosh \
-                -state=../../../updated-bosh-tfstate/bosh.tfstate \
+                -var="concourse_egress_cidrs=false" \
                 -var-file="../../../paas-bootstrap/terraform/((aws_account)).tfvars" \
                 -var-file="../../../paas-bootstrap/terraform/((aws_region)).tfvars" \
                 -var-file="../../../bootstrap-cyber-tfvars/bootstrap-cyber.tfvars"
-        ensure:
-          put: bosh-tfstate
-          params:
-            file: updated-bosh-tfstate/bosh.tfstate
 
       - task: remove-concourse-ip-from-concourse-sg
         config:
@@ -2181,20 +2180,17 @@ jobs:
               . vpc-terraform-outputs/tfvars.sh
               . bosh-terraform-outputs/tfvars.sh
 
-              cp concourse-tfstate/concourse.tfstate updated-concourse-tfstate/concourse.tfstate
               cd paas-bootstrap/terraform/concourse || exit
-              terraform init
+              terraform init --reconfigure \
+                -backend-config="bucket=((state_bucket))" \
+                -backend-config="region=((aws_region))"
 
               terraform apply \
                 -auto-approve=true \
                 -target=aws_security_group.concourse \
+                -var="concourse_egress_cidrs=false" \
                 -var-file="../../../paas-bootstrap/terraform/((aws_account)).tfvars" \
                 -var-file="../../../paas-bootstrap/terraform/((aws_region)).tfvars" \
-                -state=../../../updated-concourse-tfstate/concourse.tfstate
-        ensure:
-          put: concourse-tfstate
-          params:
-            file: updated-concourse-tfstate/concourse.tfstate
 
   - name: clear-concourse-credentials
     plan:

--- a/scripts/lint_terraform.sh
+++ b/scripts/lint_terraform.sh
@@ -11,7 +11,7 @@ CWD=$(pwd)
 
 for dir in terraform/*/; do
   cd "${dir}"
-  terraform init >/dev/null
+  terraform init -backend=false >/dev/null
   terraform validate >/dev/null
   terraform fmt -check -diff
   cd "${CWD}"

--- a/terraform/bosh/backend.tf
+++ b/terraform/bosh/backend.tf
@@ -1,0 +1,5 @@
+terraform {
+  backend "s3" {
+    key = "bosh.tfstate"
+  }
+}

--- a/terraform/bosh/blobstore.tf
+++ b/terraform/bosh/blobstore.tf
@@ -1,6 +1,10 @@
 resource "aws_s3_bucket" "bosh-blobstore" {
   bucket        = "gds-paas-${var.env}-bosh-blobstore"
-  acl           = "private"
   force_destroy = "true"
+}
+
+resource "aws_s3_bucket_acl" "bosh-blobstore_acl" {
+  bucket = aws_s3_bucket.bosh-blobstore.id
+  acl    = "private"
 }
 

--- a/terraform/bosh/outputs.tf
+++ b/terraform/bosh/outputs.tf
@@ -46,7 +46,7 @@ output "bosh_db_username" {
 }
 
 output "bosh_db_dbname" {
-  value = aws_db_instance.bosh.name
+  value = aws_db_instance.bosh.db_name
 }
 
 output "bosh_az" {
@@ -77,3 +77,6 @@ output "bosh_security_group_id" {
   value = aws_security_group.bosh.id
 }
 
+output "concourse_egress_cidrs" {
+  value = var.concourse_egress_cidrs
+}

--- a/terraform/bosh/security_groups.tf
+++ b/terraform/bosh/security_groups.tf
@@ -26,7 +26,7 @@ resource "aws_security_group" "bosh" {
     from_port   = 22
     to_port     = 22
     protocol    = "tcp"
-    cidr_blocks = formatlist("%s/32", data.aws_instances.concourse_workers.public_ips)
+    cidr_blocks = var.concourse_egress_cidrs == false ? [] : formatlist("%s/32", data.aws_instances.concourse_workers.public_ips)
   }
 
   ingress {
@@ -43,7 +43,7 @@ resource "aws_security_group" "bosh" {
     from_port   = 6868
     to_port     = 6868
     protocol    = "tcp"
-    cidr_blocks = formatlist("%s/32", data.aws_instances.concourse_workers.public_ips)
+    cidr_blocks = var.concourse_egress_cidrs == false ? [] : formatlist("%s/32", data.aws_instances.concourse_workers.public_ips)
   }
 
   ingress {

--- a/terraform/concourse/backend.tf
+++ b/terraform/concourse/backend.tf
@@ -1,0 +1,5 @@
+terraform {
+  backend "s3" {
+    key = "concourse.tfstate"
+  }
+}

--- a/terraform/concourse/outputs.tf
+++ b/terraform/concourse/outputs.tf
@@ -44,7 +44,7 @@ output "git_concourse_pool_clone_full_url_ssh" {
 }
 
 output "concourse_db_name" {
-  value = aws_db_instance.concourse.name
+  value = aws_db_instance.concourse.db_name
 }
 
 output "concourse_db_username" {
@@ -62,5 +62,9 @@ output "concourse_db_address" {
 
 output "concourse_db_port" {
   value = aws_db_instance.concourse.port
+}
+
+output "concourse_egress_cidrs" {
+  value = var.concourse_egress_cidrs
 }
 

--- a/terraform/cyber/backend.tf
+++ b/terraform/cyber/backend.tf
@@ -1,0 +1,4 @@
+terraform {
+  backend "s3" {
+  }
+}

--- a/terraform/globals.tf
+++ b/terraform/globals.tf
@@ -69,9 +69,9 @@ variable "infra_subnet_ids" {
   default     = ""
 }
 
-variable "concourse_egress_cidr" {
-  description = "Public egress IP address of concourse running the pipeline"
-  default     = ""
+variable "concourse_egress_cidrs" {
+  description = "Should cidrs be added or removed"
+  default     = false
 }
 
 variable "microbosh_static_private_ip" {

--- a/terraform/vpc/backend.tf
+++ b/terraform/vpc/backend.tf
@@ -1,0 +1,5 @@
+terraform {
+  backend "s3" {
+    key = "vpc.tfstate"
+  }
+}

--- a/terraform/vpc/security-group.tf
+++ b/terraform/vpc/security-group.tf
@@ -1,3 +1,15 @@
+data "aws_instances" "concourse_workers" {
+  filter {
+    name   = "tag:instance_group"
+    values = ["concourse-worker", "concourse-lite"]
+  }
+
+  filter {
+    name   = "tag:deploy_env"
+    values = [var.env]
+  }
+}
+
 resource "aws_security_group" "office-access-ssh" {
   vpc_id      = aws_vpc.paas.id
   name        = "${var.env}-office-access-ssh"
@@ -14,14 +26,14 @@ resource "aws_security_group" "office-access-ssh" {
     from_port   = 22
     to_port     = 22
     protocol    = "tcp"
-    cidr_blocks = compact(concat(var.admin_cidrs, [var.concourse_egress_cidr]))
+    cidr_blocks = compact(concat(var.admin_cidrs, var.concourse_egress_cidrs == false ? [] : formatlist("%s/32", data.aws_instances.concourse_workers.public_ips)))
   }
 
   ingress {
     from_port   = 8443
     to_port     = 8443
     protocol    = "tcp"
-    cidr_blocks = compact(concat(var.admin_cidrs, [var.concourse_egress_cidr]))
+    cidr_blocks = compact(concat(var.admin_cidrs, var.concourse_egress_cidrs == false ? [] : formatlist("%s/32", data.aws_instances.concourse_workers.public_ips)))
   }
 
   tags = {


### PR DESCRIPTION
What
----

The [pivotal storey](https://www.pivotaltracker.com/n/projects/1275640/stories/184281154) provides the detail.

The create-bosh-concourse pipeline has been changed such that Terraform is now configured with its own backend and is no longer reliant on the pipeline providing and saving its state via resources.

I have also used the aws cli to pull down a file from an s3 bucket to obtain the current bosh manifest state.

How to review
-------------

1 - Review the code.
2 - Run the branch through a dev env (I've tested this branch on dev01).
3 - After the run, check the size of the files (bosh.tfstate, bosh-manifest-state-(region).json, concourse.tfstate, bootstrap-cyber.tfstate, vpc.tfstate) in the appropriate bucket for the env e.g. for dev01 the bucket would be gds-paas-dev01-state

Who can review
--------------

Not me.

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
