### PR TITLE
184281154 concourse rebuilds corrupt state

### DIFF
--- a/concourse/pipelines/create-bosh-concourse.yml
+++ b/concourse/pipelines/create-bosh-concourse.yml
@@ -209,28 +209,6 @@ resources:
       initial_version: "-"
       initial_content_text: ""
 
-  - name: bootstrap-cyber-tfstate
-    type: s3-iam
-    source:
-      bucket: ((state_bucket))
-      versioned_file: bootstrap-cyber.tfstate
-      region_name: ((aws_region))
-      initial_version: "-"
-      initial_content_text: |
-        {
-            "version": 1,
-            "serial": 0,
-            "modules": [
-                {
-                    "path": [
-                        "root"
-                    ],
-                    "outputs": {},
-                    "resources": {}
-                }
-            ]
-        }
-
   - name: ssh-private-key
     type: s3-iam
     source:
@@ -590,7 +568,6 @@ jobs:
         - get: pipeline-trigger
           trigger: true
           passed: ['check-for-secrets']
-        - get: vpc-tfstate
         - get: git-ssh-public-key
         - get: git-ssh-private-key
 
@@ -636,9 +613,6 @@ jobs:
           image_resource: *terraform-image-resource
           inputs:
           - name: paas-bootstrap
-          - name: vpc-tfstate
-          outputs:
-          - name: updated-vpc-tfstate
           params:
             TF_VAR_env: ((deploy_env))
             AWS_DEFAULT_REGION: ((aws_region))
@@ -649,20 +623,17 @@ jobs:
             - -c
             - |
               CONCOURSE_EGRESS_IP=$(wget -q -O - http://169.254.169.254/latest/meta-data/public-ipv4)
-              cp vpc-tfstate/vpc.tfstate updated-vpc-tfstate/vpc.tfstate
               cd paas-bootstrap/terraform/vpc || exit
-              terraform init
+
+              terraform init --reconfigure \
+                -backend-config="bucket=((state_bucket))" \
+                -backend-config="region=((aws_region))"
 
               terraform apply \
                 -auto-approve=true \
                 -var concourse_egress_cidr="${CONCOURSE_EGRESS_IP}/32" \
                 -var-file="../../../paas-bootstrap/terraform/((aws_account)).tfvars" \
-                -var-file="../../../paas-bootstrap/terraform/((aws_region)).tfvars" \
-                -state=../../../updated-vpc-tfstate/vpc.tfstate
-        ensure:
-          put: vpc-tfstate
-          params:
-            file: updated-vpc-tfstate/vpc.tfstate
+                -var-file="../../../paas-bootstrap/terraform/((aws_region)).tfvars"
 
   - name: cyber-terraform
     serial: true
@@ -676,7 +647,6 @@ jobs:
         - get: paas-bootstrap
           passed: ['check-for-secrets']
         - get: bootstrap-cyber-tfvars
-        - get: bootstrap-cyber-tfstate
 
       - task: terraform-apply
         config:
@@ -684,10 +654,7 @@ jobs:
           image_resource: *terraform-image-resource
           inputs:
             - name: paas-bootstrap
-            - name: bootstrap-cyber-tfstate
             - name: bootstrap-cyber-tfvars
-          outputs:
-            - name: updated-bootstrap-cyber-tfstate
           params:
             DEPLOY_ENV: ((deploy_env))
             AWS_DEFAULT_REGION: ((aws_region))
@@ -699,23 +666,18 @@ jobs:
               - -e
               - -c
               - |
-                cp bootstrap-cyber-tfstate/bootstrap-cyber.tfstate \
-                   updated-bootstrap-cyber-tfstate/bootstrap-cyber.tfstate
                 cd paas-bootstrap/terraform/cyber || exit
-                terraform init
+
+                terraform init --reconfigure \
+                  -backend-config="bucket=((state_bucket))" \
+                  -backend-config="region=((aws_region))"
 
                 terraform apply \
                   -auto-approve=true \
                   -var env="((deploy_env))" \
                   -var-file="../../../paas-bootstrap/terraform/((aws_account)).tfvars" \
                   -var-file="../../../paas-bootstrap/terraform/((aws_region)).tfvars" \
-                  -var-file="../../../bootstrap-cyber-tfvars/bootstrap-cyber.tfvars" \
-                  -state=../../../updated-bootstrap-cyber-tfstate/bootstrap-cyber.tfstate
-
-        ensure:
-          put: bootstrap-cyber-tfstate
-          params:
-            file: updated-bootstrap-cyber-tfstate/bootstrap-cyber.tfstate
+                  -var-file="../../../bootstrap-cyber-tfvars/bootstrap-cyber.tfvars"
 
   - name: generate-secrets
     serial: true
@@ -844,8 +806,6 @@ jobs:
         - get: bosh-secrets
           passed: ['generate-secrets']
         - get: vpc-tfstate
-          passed: ['vpc']
-        - get: bosh-tfstate
         - get: bootstrap-cyber-tfvars
           passed: ['cyber-terraform']
         - get: ssh-public-key
@@ -879,11 +839,8 @@ jobs:
           inputs:
             - name: paas-bootstrap
             - name: terraform-variables
-            - name: bosh-tfstate
             - name: ssh-public-key
             - name: bootstrap-cyber-tfvars
-          outputs:
-            - name: updated-bosh-tfstate
           params:
             DEPLOY_ENV: ((deploy_env))
             AWS_DEFAULT_REGION: ((aws_region))
@@ -904,9 +861,11 @@ jobs:
                 cp ssh-public-key/id_rsa.pub paas-bootstrap/terraform/bosh
                 CONCOURSE_EGRESS_IP=$(wget -q -O - http://169.254.169.254/latest/meta-data/public-ipv4)
 
-                cp bosh-tfstate/bosh.tfstate updated-bosh-tfstate/bosh.tfstate
                 cd paas-bootstrap/terraform/bosh || exit
-                terraform init
+
+                terraform init --reconfigure \
+                  -backend-config="bucket=((state_bucket))" \
+                  -backend-config="region=((aws_region))"
 
                 terraform apply \
                   -auto-approve=true \
@@ -914,12 +873,7 @@ jobs:
                   -var env="((deploy_env))" \
                   -var-file="../../../paas-bootstrap/terraform/((aws_account)).tfvars" \
                   -var-file="../../../paas-bootstrap/terraform/((aws_region)).tfvars" \
-                  -var-file="../../../bootstrap-cyber-tfvars/bootstrap-cyber.tfvars" \
-                  -state=../../../updated-bosh-tfstate/bosh.tfstate
-        ensure:
-          put: bosh-tfstate
-          params:
-            file: updated-bosh-tfstate/bosh.tfstate
+                  -var-file="../../../bootstrap-cyber-tfvars/bootstrap-cyber.tfvars"
 
   - name: generate-bosh-config
     serial_groups: [bosh-deploy]
@@ -936,9 +890,7 @@ jobs:
         - get: bosh-ca
         - get: bosh-vars-store
         - get: vpc-tfstate
-          passed: ['bosh-terraform']
         - get: bosh-tfstate
-          passed: ['bosh-terraform']
         - get: bosh-uaa-google-oauth-secrets
         - get: bosh-cyber-secrets
         - get: paas-trusted-people
@@ -1125,6 +1077,27 @@ jobs:
         - get: bosh-init-state
         - get: ssh-private-key
 
+        # task to work around potential bosh state corruption on build re-runs - 184281154
+      - task: fetch-bosh-init-state
+        config:
+          platform: linux
+          image_resource: *awscli-image-resource
+          params:
+            AWS_DEFAULT_REGION: ((aws_region))
+            BOSH_MANIFEST_STATE: ((bosh_manifest_state))
+          outputs:
+            - name: bosh-init-state
+          run:
+            path: sh
+            args:
+            - -e
+            - -x
+            - -u
+            - -c
+            - |
+              cd bosh-init-state
+              aws s3 cp "s3://((state_bucket))/${BOSH_MANIFEST_STATE}" .
+
       - task: bosh-create-env
         config:
           platform: linux
@@ -1265,8 +1238,6 @@ jobs:
         - get: vpc-tfstate
           passed: ['bosh-terraform']
         - get: bosh-tfstate
-          passed: ['bosh-terraform']
-        - get: concourse-tfstate
         - get: git-ssh-public-key
 
       - task: terraform-outputs-to-sh
@@ -1303,10 +1274,7 @@ jobs:
           - name: paas-bootstrap
           - name: vpc-terraform-outputs
           - name: bosh-terraform-outputs
-          - name: concourse-tfstate
           - name: git-ssh-public-key
-          outputs:
-          - name: updated-concourse-tfstate
           params:
             TF_VAR_env: ((deploy_env))
             TF_VAR_concourse_hostname: ((concourse_hostname))
@@ -1325,20 +1293,17 @@ jobs:
               TF_VAR_git_rsa_id_pub=$(cat git-ssh-public-key/git_id_rsa.pub)
               CONCOURSE_EGRESS_IP=$(wget -q -O - http://169.254.169.254/latest/meta-data/public-ipv4)
 
-              cp concourse-tfstate/concourse.tfstate updated-concourse-tfstate/concourse.tfstate
               cd paas-bootstrap/terraform/concourse || exit
-              terraform init
+
+              terraform init --reconfigure \
+                -backend-config="bucket=((state_bucket))" \
+                -backend-config="region=((aws_region))"
 
               terraform apply \
                 -auto-approve=true \
                 -var concourse_egress_cidr="${CONCOURSE_EGRESS_IP}/32" \
                 -var-file="../../../paas-bootstrap/terraform/((aws_account)).tfvars" \
-                -var-file="../../../paas-bootstrap/terraform/((aws_region)).tfvars" \
-                -state=../../../updated-concourse-tfstate/concourse.tfstate
-        ensure:
-          put: concourse-tfstate
-          params:
-            file: updated-concourse-tfstate/concourse.tfstate
+                -var-file="../../../paas-bootstrap/terraform/((aws_region)).tfvars"
 
   - name: generate-concourse-config
     serial: true
@@ -1352,7 +1317,6 @@ jobs:
         - get: vpc-tfstate
           passed: ['concourse-terraform']
         - get: concourse-tfstate
-          passed: ['concourse-terraform']
         - get: bosh-secrets
           passed: ['generate-bosh-config']
         - get: bosh-tfstate
@@ -2047,7 +2011,6 @@ jobs:
           passed: ['post-deploy']
         - get: vpc-tfstate
         - get: bosh-tfstate
-        - get: concourse-tfstate
         - get: bootstrap-cyber-tfvars
 
       - task: terraform-outputs-to-sh
@@ -2082,9 +2045,6 @@ jobs:
           image_resource: *terraform-image-resource
           inputs:
           - name: paas-bootstrap
-          - name: vpc-tfstate
-          outputs:
-          - name: updated-vpc-tfstate
           params:
             TF_VAR_env: ((deploy_env))
             AWS_DEFAULT_REGION: ((aws_region))
@@ -2094,21 +2054,18 @@ jobs:
             - -e
             - -c
             - |
-              cp vpc-tfstate/vpc.tfstate updated-vpc-tfstate/vpc.tfstate
               cd paas-bootstrap/terraform/vpc || exit
-              terraform init
+
+              terraform init --reconfigure \
+                -backend-config="bucket=((state_bucket))" \
+                -backend-config="region=((aws_region))"
 
               terraform apply \
                 -auto-approve=true \
                 -target=aws_security_group.office-access-ssh \
                 -var-file="../../../paas-bootstrap/terraform/((aws_account)).tfvars" \
                 -var-file="../../../paas-bootstrap/terraform/((aws_region)).tfvars" \
-                -target=aws_subnet.infra \
-                -state=../../../updated-vpc-tfstate/vpc.tfstate
-        ensure:
-          put: vpc-tfstate
-          params:
-            file: updated-vpc-tfstate/vpc.tfstate
+                -target=aws_subnet.infra
 
       - task: remove-concourse-ip-from-bosh-sg
         config:
@@ -2117,10 +2074,7 @@ jobs:
           inputs:
           - name: paas-bootstrap
           - name: vpc-terraform-outputs
-          - name: bosh-tfstate
           - name: bootstrap-cyber-tfvars
-          outputs:
-          - name: updated-bosh-tfstate
           params:
             TF_VAR_env: ((deploy_env))
             TF_VAR_system_dns_zone_name: ((system_dns_zone_name))
@@ -2138,21 +2092,17 @@ jobs:
               export TF_VAR_secrets_bosh_postgres_password=""
               export TF_VAR_bosh_az=""
 
-              cp bosh-tfstate/bosh.tfstate updated-bosh-tfstate/bosh.tfstate
               cd paas-bootstrap/terraform/bosh || exit
-              terraform init
+              terraform init --reconfigure \
+                -backend-config="bucket=((state_bucket))" \
+                -backend-config="region=((aws_region))"
 
               terraform apply \
                 -auto-approve=true \
                 -target=aws_security_group.bosh \
-                -state=../../../updated-bosh-tfstate/bosh.tfstate \
                 -var-file="../../../paas-bootstrap/terraform/((aws_account)).tfvars" \
                 -var-file="../../../paas-bootstrap/terraform/((aws_region)).tfvars" \
                 -var-file="../../../bootstrap-cyber-tfvars/bootstrap-cyber.tfvars"
-        ensure:
-          put: bosh-tfstate
-          params:
-            file: updated-bosh-tfstate/bosh.tfstate
 
       - task: remove-concourse-ip-from-concourse-sg
         config:
@@ -2162,9 +2112,6 @@ jobs:
           - name: paas-bootstrap
           - name: vpc-terraform-outputs
           - name: bosh-terraform-outputs
-          - name: concourse-tfstate
-          outputs:
-          - name: updated-concourse-tfstate
           params:
             TF_VAR_env: ((deploy_env))
             TF_VAR_concourse_hostname: ((concourse_hostname))
@@ -2181,20 +2128,16 @@ jobs:
               . vpc-terraform-outputs/tfvars.sh
               . bosh-terraform-outputs/tfvars.sh
 
-              cp concourse-tfstate/concourse.tfstate updated-concourse-tfstate/concourse.tfstate
               cd paas-bootstrap/terraform/concourse || exit
-              terraform init
+              terraform init --reconfigure \
+                -backend-config="bucket=((state_bucket))" \
+                -backend-config="region=((aws_region))"
 
               terraform apply \
                 -auto-approve=true \
                 -target=aws_security_group.concourse \
                 -var-file="../../../paas-bootstrap/terraform/((aws_account)).tfvars" \
                 -var-file="../../../paas-bootstrap/terraform/((aws_region)).tfvars" \
-                -state=../../../updated-concourse-tfstate/concourse.tfstate
-        ensure:
-          put: concourse-tfstate
-          params:
-            file: updated-concourse-tfstate/concourse.tfstate
 
   - name: clear-concourse-credentials
     plan:

--- a/scripts/lint_terraform.sh
+++ b/scripts/lint_terraform.sh
@@ -11,7 +11,7 @@ CWD=$(pwd)
 
 for dir in terraform/*/; do
   cd "${dir}"
-  terraform init >/dev/null
+  terraform init -backend=false >/dev/null
   terraform validate >/dev/null
   terraform fmt -check -diff
   cd "${CWD}"

--- a/terraform/bosh/backend.tf
+++ b/terraform/bosh/backend.tf
@@ -1,0 +1,5 @@
+terraform {
+  backend "s3" {
+    key = "bosh.tfstate"
+  }
+}

--- a/terraform/concourse/backend.tf
+++ b/terraform/concourse/backend.tf
@@ -1,0 +1,5 @@
+terraform {
+  backend "s3" {
+    key = "concourse.tfstate"
+  }
+}

--- a/terraform/cyber/backend.tf
+++ b/terraform/cyber/backend.tf
@@ -1,0 +1,5 @@
+terraform {
+  backend "s3" {
+    key = "bootstrap-cyber.tfstate"
+  }
+}

--- a/terraform/vpc/backend.tf
+++ b/terraform/vpc/backend.tf
@@ -1,0 +1,5 @@
+terraform {
+  backend "s3" {
+    key = "vpc.tfstate"
+  }
+}


### PR DESCRIPTION
What
----

The [pivotal storey](https://www.pivotaltracker.com/n/projects/1275640/stories/184281154) provides the detail.

The create-bosh-concourse pipeline has been changed such that Terraform is now configured with its own backend and is no longer reliant on the pipeline providing and saving its state via resources.

I have also used the aws cli to pull down a file from an s3 bucket to obtain the current bosh manifest state.

How to review
-------------

1 - Review the code.
2 - Run the branch through a dev env (I've tested this branch on dev01).
3 - After the run, check the size of the files (bosh.tfstate, bosh-manifest-state-(region).json, concourse.tfstate, bootstrap-cyber.tfstate, vpc.tfstate) in the appropriate bucket for the env e.g. for dev01 the bucket would be gds-paas-dev01-state

Who can review
--------------

Not me.

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
