### PR TITLE
Revert "[#184602228] Fix create-bosh-concourse initial pipeline trigger"

### DIFF
--- a/concourse/pipelines/create-bosh-concourse.yml
+++ b/concourse/pipelines/create-bosh-concourse.yml
@@ -93,12 +93,6 @@ resource_types:
     repository: ghcr.io/alphagov/paas/git-resource
     tag: 1f84d4a76b4a2491283e0107ae7ed4bc83c84d1b
 
-- name: key-value
-  type: registry-image
-  source:
-    repository: ghcr.io/alphagov/paas/keyval-resource
-    tag: d467945db218918c73ffc804dcc3f5b6281c7164
-
 resources:
   - name: paas-bootstrap
     type: git
@@ -349,9 +343,6 @@ resources:
       region_name: ((aws_region))
       versioned_file: paas-bootstrap-cloud-config.yml
 
-  - name: initial-trigger
-    type: key-value
-
 jobs:
   - name: update-pipeline
     serial: true
@@ -455,8 +446,6 @@ jobs:
             TARGET_CONCOURSE: ((target_concourse))
           inputs:
             - name: self-update-pipeline-status
-          outputs:
-            - name: initial-trigger
           run:
             path: sh
             args:
@@ -483,16 +472,10 @@ jobs:
 
                 echo 'self-update-pipeline failed'
                 exit 1
-      - put: initial-trigger
-        params:
-          directory: initial-trigger
 
   - name: init-bucket
     serial: true
     plan:
-      - get: initial-trigger
-        trigger: true
-        passed: ['update-pipeline']
       - get: paas-bootstrap
         trigger: true
         passed: ['update-pipeline']
@@ -505,7 +488,6 @@ jobs:
             AWS_DEFAULT_REGION: ((aws_region))
           inputs:
             - name: paas-bootstrap
-            - name: initial-trigger
           outputs:
             - name: bucket-state
           run:


### PR DESCRIPTION
Reverts alphagov/paas-bootstrap#583

This appears to break bootstrapping an env from vagrant. We can bring it back once we have proof of it working for a vagrant bootstrap.