### PR TITLE
Vagrant fixes after testing

### DIFF
--- a/concourse/pipelines/create-bosh-concourse.yml
+++ b/concourse/pipelines/create-bosh-concourse.yml
@@ -93,6 +93,12 @@ resource_types:
     repository: ghcr.io/alphagov/paas/git-resource
     tag: 1f84d4a76b4a2491283e0107ae7ed4bc83c84d1b
 
+- name: key-value
+  type: registry-image
+  source:
+    repository: ghcr.io/alphagov/paas/keyval-resource
+    tag: d467945db218918c73ffc804dcc3f5b6281c7164
+
 resources:
   - name: paas-bootstrap
     type: git
@@ -365,6 +371,9 @@ resources:
       region_name: ((aws_region))
       versioned_file: paas-bootstrap-cloud-config.yml
 
+  - name: initial-trigger
+    type: key-value
+
 jobs:
   - name: update-pipeline
     serial: true
@@ -468,6 +477,8 @@ jobs:
             TARGET_CONCOURSE: ((target_concourse))
           inputs:
             - name: self-update-pipeline-status
+          outputs:
+            - name: initial-trigger
           run:
             path: sh
             args:
@@ -494,10 +505,16 @@ jobs:
 
                 echo 'self-update-pipeline failed'
                 exit 1
+      - put: initial-trigger
+        params:
+          directory: initial-trigger
 
   - name: init-bucket
     serial: true
     plan:
+      - get: initial-trigger
+        trigger: true
+        passed: ['update-pipeline']
       - get: paas-bootstrap
         trigger: true
         passed: ['update-pipeline']
@@ -510,6 +527,7 @@ jobs:
             AWS_DEFAULT_REGION: ((aws_region))
           inputs:
             - name: paas-bootstrap
+            - name: initial-trigger
           outputs:
             - name: bucket-state
           run:

--- a/vagrant/deploy.sh
+++ b/vagrant/deploy.sh
@@ -23,16 +23,19 @@ export CONCOURSE_WEB_USER CONCOURSE_WEB_PASSWORD
 export VAGRANT_DEFAULT_PROVIDER="aws"
 export VAGRANT_BOX_NAME="aws_vagrant_box"
 
-if aws ec2 describe-key-pairs --key-name "${VAGRANT_SSH_KEY_NAME}" >/dev/null 2>&1 ; then
-  # Remove the aws key pair
-  aws ec2 delete-key-pair --key-name "${VAGRANT_SSH_KEY_NAME}"
-fi
- 
-# Create the key pair online.
-aws ec2 create-key-pair --key-name "${VAGRANT_SSH_KEY_NAME}" | jq -r ".KeyMaterial" > "${VAGRANT_SSH_KEY}"
+if ! vagrant status 2>&1 | grep "running\ (aws)" >/dev/null; then
+  echo "Concourse Bootstrap VM is not running."
+  if aws ec2 describe-key-pairs --key-name "${VAGRANT_SSH_KEY_NAME}" >/dev/null 2>&1 ; then
+    echo "Cleaning up old key pair..."
+    aws ec2 delete-key-pair --key-name "${VAGRANT_SSH_KEY_NAME}"
+  fi
+  echo "Creating new key pair..."
+  # Create the key pair online.
+  aws ec2 create-key-pair --key-name "${VAGRANT_SSH_KEY_NAME}" | jq -r ".KeyMaterial" > "${VAGRANT_SSH_KEY}"
 
-# Secure the local key.
-chmod 600 "${VAGRANT_SSH_KEY}"
+  # Secure the local key.
+  chmod 600 "${VAGRANT_SSH_KEY}"
+fi
 
 # Install aws dummy box if not present
 if ! vagrant box list | grep -qe "^${VAGRANT_BOX_NAME} "; then
@@ -42,10 +45,12 @@ fi
 
 vagrant up
 
-echo "Setting up SSH tunnel to concourse..."
-
-vagrant ssh -- -L 8080:127.0.0.1:8080 -fN
-
+if ! pgrep -f "ssh.*${VAGRANT_SSH_KEY_NAME}.*-L 8080:127.0.0.1:8080 -fN" >/dev/null; then
+  echo "Setting up SSH tunnel to concourse..."
+  vagrant ssh -- -L 8080:127.0.0.1:8080 -fN
+else
+  echo "SSH tunnel to concourse already running."
+fi
 timeout=180
 deadline=$(($(date +%s) + timeout))
 echo -n "Waiting for concourse to start for ${timeout}s..."

--- a/vagrant/post-deploy.d/00-run-docker.sh
+++ b/vagrant/post-deploy.d/00-run-docker.sh
@@ -27,13 +27,13 @@ export CONCOURSE_EXTERNAL_URL="$CONCOURSE_URL"
 
 mkdir -p /tmp/keys
 
-sudo docker run --rm -v /tmp/keys:/keys concourse/concourse \
+sudo docker run --rm -v /tmp/keys:/keys concourse/concourse:7.9.0 \
   generate-key -t rsa -f /keys/session_signing_key
 
-sudo docker run --rm -v /tmp/keys:/keys concourse/concourse \
+sudo docker run --rm -v /tmp/keys:/keys concourse/concourse:7.9.0 \
   generate-key -t ssh -f /keys/tsa_host_key
 
-sudo docker run --rm -v /tmp/keys:/keys concourse/concourse \
+sudo docker run --rm -v /tmp/keys:/keys concourse/concourse:7.9.0 \
   generate-key -t ssh -f /keys/worker_key
 
 sudo -E docker-compose up -d


### PR DESCRIPTION
What
----

- Revert [Revert "[#184602228] Fix create-bosh-concourse initial pipeline trigger](https://github.com/alphagov/paas-bootstrap/pull/585/files). After testing this did not cause any problems.
- Fix path issues with update-terraform-providers.sh as part of destroy-bosh-concourse. It looks like this has been broken for some time.
- Ensure the vagrant deploy.sh is idempotent.
- Used fixed versions of the concourse docker image rather than latest.

How to review
-------------

This has been tested against a new environment.

Who can review
--------------

Team elder.

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
