### PR TITLE
184097170 Add Panos GPG key

### DIFF
--- a/manifests/concourse-manifest/github_auth/config.yml
+++ b/manifests/concourse-manifest/github_auth/config.yml
@@ -20,6 +20,7 @@ instance_groups:
                     users:
                     - AP-Hunt
                     - corlettb
+                    - dark5un
                     - kr8n3r
                     - jackjoy-gds
                     - LeePorte


### PR DESCRIPTION
Description:
- Adds Panos GPG key as well as giving him access to prod Concourse
- See [here](https://deployer.dev04.dev.cloudpipeline.digital/teams/main/pipelines/create-bosh-concourse) for a successful run


🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
