### PR TITLE
[#184736292] Fix bosh deploy rebuilds from happening every time

### DIFF
--- a/manifests/bosh-manifest/scripts/cleanup-bosh-vars-store.rb
+++ b/manifests/bosh-manifest/scripts/cleanup-bosh-vars-store.rb
@@ -91,7 +91,6 @@ contents.delete("blobstore_ca") if contents.key? "blobstore_ca"
 contents.delete("blobstore_server_tls") if contents.key? "blobstore_server_tls"
 
 contents.delete("credhub_ca") if contents.key? "credhub_ca"
-contents.delete("credhub_tls") if contents.key? "credhub_tls"
 
 puts "New variable names: #{contents.keys}"
 


### PR DESCRIPTION
What
----

After some investigation it turns out that the bosh-cli is recreating the bosh deploy each time because the manifest sha1 doesn't match what is in the bosh state.

While examining the bosh manifest for several runs I could see the credhub_tls certificates were being rotated for every deployment.

I believe this was broken [by this pr](https://github.com/alphagov/paas-bootstrap/pull/378).

The line:

```
contents.delete("credhub_tls") if contents.key? "credhub_tls"
```

Removes the already generated credhub_tls certificates from the vars-store. This means they get recreated as part of the deploy every time.

I believe the original intention of the change was to remove it once in each environment to change the certificates ca and then remove this line at a later point.
 
How to review
-------------

This change was tested in dev-04. You can [see a build here](https://deployer.dev04.dev.cloudpipeline.digital/teams/main/pipelines/create-bosh-concourse/jobs/bosh-deploy/builds/12#L64448a85:31) that no longer redeploys bosh.

I have deployed a test to ensure this certificate will get rotated when a certificate is getting "close" to expiry by adding '--min-remaining-days 400' to the pipeline. You can see [the results here](https://deployer.dev04.dev.cloudpipeline.digital/teams/main/pipelines/create-bosh-concourse/jobs/generate-bosh-config/builds/10#L64445fe6:9). I downloaded the bosh-vars-store.yml file before and after and can confirm this certificate was rotated.

Who can review
--------------

Any team member familiar with the bosh certificate process.

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
