### PR TITLE
[#184537961] Get personal static ips from paas-trusted-people

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -67,6 +67,7 @@ GEM
     unicode-display_width (2.3.0)
 
 PLATFORMS
+  arm64-darwin-21
   x86_64-darwin-21
 
 DEPENDENCIES

--- a/concourse/pipelines/create-bosh-concourse.yml
+++ b/concourse/pipelines/create-bosh-concourse.yml
@@ -4,6 +4,11 @@ display:
 
 meta:
   containers:
+    alpine: &alpine-image-resource
+      type: registry-image
+      source:
+        repository: ghcr.io/alphagov/paas/alpine
+        tag: b25554b10d0efb9da2aef192f9a890199863f59e
     awscli: &awscli-image-resource
       type: registry-image
       source:
@@ -611,6 +616,7 @@ jobs:
         - get: vpc-tfstate
         - get: git-ssh-public-key
         - get: git-ssh-private-key
+        - get: paas-trusted-people
 
       - task: generate-git-ssh-keys
         config:
@@ -648,6 +654,26 @@ jobs:
               params:
                 file: generated-git-ssh-keys/git_id_rsa
 
+      - task: create-static-cdrs
+        config:
+          platform: linux
+          image_resource: *ruby-slim-image-resource
+          inputs:
+          - name: paas-bootstrap
+          - name: paas-trusted-people
+          outputs:
+          - name: static-cidrs-tfvars
+          params:
+            AWS_ACCOUNT: ((aws_account))
+          run:
+            path: sh
+            args:
+            - -e
+            - -c
+            - |
+              cd paas-trusted-people
+              ruby ../paas-bootstrap/concourse/scripts/get_static_cidrs.rb > ../static-cidrs-tfvars/user_static_cidrs.tfvars
+
       - task: deploy-vpc
         config:
           platform: linux
@@ -655,6 +681,7 @@ jobs:
           inputs:
           - name: paas-bootstrap
           - name: vpc-tfstate
+          - name: static-cidrs-tfvars
           outputs:
           - name: updated-vpc-tfstate
           params:
@@ -673,6 +700,7 @@ jobs:
               terraform apply \
                 -auto-approve=true \
                 -var="set_concourse_egress_cidrs=true" \
+                -var-file="../../../static-cidrs-tfvars/user_static_cidrs.tfvars" \
                 -var-file="../../../paas-bootstrap/terraform/((aws_account)).tfvars" \
                 -var-file="../../../paas-bootstrap/terraform/((aws_region)).tfvars" \
                 -state=../../../updated-vpc-tfstate/vpc.tfstate
@@ -866,6 +894,7 @@ jobs:
           passed: ['cyber-terraform']
         - get: ssh-public-key
           passed: ['generate-secrets']
+        - get: paas-trusted-people
 
       - task: extract-terraform-variables
         config:
@@ -875,8 +904,12 @@ jobs:
             - name: paas-bootstrap
             - name: vpc-tfstate
             - name: bosh-secrets
+            - name: paas-trusted-people
           outputs:
             - name: terraform-variables
+            - name: static-cidrs-tfvars
+          params:
+            AWS_ACCOUNT: ((aws_account))
           run:
             path: sh
             args:
@@ -887,6 +920,8 @@ jobs:
                 < vpc-tfstate/vpc.tfstate > terraform-variables/vpc.tfvars.sh
                 ruby paas-bootstrap/concourse/scripts/extract_tf_vars_from_yaml.rb \
                 < bosh-secrets/bosh-secrets.yml > terraform-variables/bosh-secrets.tfvars.sh
+                cd paas-trusted-people
+                ruby ../paas-bootstrap/concourse/scripts/get_static_cidrs.rb > ../static-cidrs-tfvars/user_static_cidrs.tfvars
 
       - task: terraform-apply
         config:
@@ -898,6 +933,7 @@ jobs:
             - name: bosh-tfstate
             - name: ssh-public-key
             - name: bootstrap-cyber-tfvars
+            - name: static-cidrs-tfvars
           outputs:
             - name: updated-bosh-tfstate
           params:
@@ -926,6 +962,7 @@ jobs:
                   -auto-approve=true \
                   -var="set_concourse_egress_cidrs=true" \
                   -var env="((deploy_env))" \
+                  -var-file="../../../static-cidrs-tfvars/user_static_cidrs.tfvars" \
                   -var-file="../../../paas-bootstrap/terraform/((aws_account)).tfvars" \
                   -var-file="../../../paas-bootstrap/terraform/((aws_region)).tfvars" \
                   -var-file="../../../bootstrap-cyber-tfvars/bootstrap-cyber.tfvars" \
@@ -1162,6 +1199,7 @@ jobs:
                 chmod 400 bosh-init-working-dir/.ssh/id_rsa
                 cp bosh-manifest/bosh-manifest.yml bosh-init-working-dir/bosh-manifest.yml
                 cp bosh-init-state/"${BOSH_MANIFEST_STATE}" bosh-init-working-dir/bosh-manifest-state.json
+
                 bosh -n create-env bosh-init-working-dir/bosh-manifest.yml \
                   --state=bosh-init-working-dir/bosh-manifest-state.json
         ensure:
@@ -1283,6 +1321,27 @@ jobs:
           passed: ['bosh-terraform']
         - get: concourse-tfstate
         - get: git-ssh-public-key
+        - get: paas-trusted-people
+
+      - task: create-static-cdrs
+        config:
+          platform: linux
+          image_resource: *ruby-slim-image-resource
+          inputs:
+          - name: paas-bootstrap
+          - name: paas-trusted-people
+          outputs:
+          - name: static-cidrs-tfvars
+          params:
+            AWS_ACCOUNT: ((aws_account))
+          run:
+            path: sh
+            args:
+            - -e
+            - -c
+            - |
+              cd paas-trusted-people
+              ruby ../paas-bootstrap/concourse/scripts/get_static_cidrs.rb > ../static-cidrs-tfvars/user_static_cidrs.tfvars
 
       - task: terraform-outputs-to-sh
         config:
@@ -1292,6 +1351,7 @@ jobs:
           - name: paas-bootstrap
           - name: vpc-tfstate
           - name: bosh-tfstate
+          - name: paas-trusted-people
           outputs:
           - name: vpc-terraform-outputs
           - name: bosh-terraform-outputs
@@ -1320,6 +1380,7 @@ jobs:
           - name: bosh-terraform-outputs
           - name: concourse-tfstate
           - name: git-ssh-public-key
+          - name: static-cidrs-tfvars
           outputs:
           - name: updated-concourse-tfstate
           params:
@@ -1346,6 +1407,7 @@ jobs:
               terraform apply \
                 -auto-approve=true \
                 -var="set_concourse_egress_cidrs=true" \
+                -var-file="../../../static-cidrs-tfvars/user_static_cidrs.tfvars" \
                 -var-file="../../../paas-bootstrap/terraform/((aws_account)).tfvars" \
                 -var-file="../../../paas-bootstrap/terraform/((aws_region)).tfvars" \
                 -state=../../../updated-concourse-tfstate/concourse.tfstate
@@ -2063,6 +2125,27 @@ jobs:
         - get: bosh-tfstate
         - get: concourse-tfstate
         - get: bootstrap-cyber-tfvars
+        - get: paas-trusted-people
+
+      - task: create-static-cdrs
+        config:
+          platform: linux
+          image_resource: *ruby-slim-image-resource
+          inputs:
+          - name: paas-bootstrap
+          - name: paas-trusted-people
+          outputs:
+          - name: static-cidrs-tfvars
+          params:
+            AWS_ACCOUNT: ((aws_account))
+          run:
+            path: sh
+            args:
+            - -e
+            - -c
+            - |
+              cd paas-trusted-people
+              ruby ../paas-bootstrap/concourse/scripts/get_static_cidrs.rb > ../static-cidrs-tfvars/user_static_cidrs.tfvars
 
       - task: terraform-outputs-to-sh
         config:
@@ -2097,6 +2180,7 @@ jobs:
           inputs:
           - name: paas-bootstrap
           - name: vpc-tfstate
+          - name: static-cidrs-tfvars
           outputs:
           - name: updated-vpc-tfstate
           params:
@@ -2116,6 +2200,7 @@ jobs:
                 -auto-approve=true \
                 -target=aws_security_group.office-access-ssh \
                 -var="set_concourse_egress_cidrs=false" \
+                -var-file="../../../static-cidrs-tfvars/user_static_cidrs.tfvars" \
                 -var-file="../../../paas-bootstrap/terraform/((aws_account)).tfvars" \
                 -var-file="../../../paas-bootstrap/terraform/((aws_region)).tfvars" \
                 -target=aws_subnet.infra \
@@ -2134,6 +2219,7 @@ jobs:
           - name: vpc-terraform-outputs
           - name: bosh-tfstate
           - name: bootstrap-cyber-tfvars
+          - name: static-cidrs-tfvars
           outputs:
           - name: updated-bosh-tfstate
           params:
@@ -2162,6 +2248,7 @@ jobs:
                 -target=aws_security_group.bosh \
                 -state=../../../updated-bosh-tfstate/bosh.tfstate \
                 -var="set_concourse_egress_cidrs=false" \
+                -var-file="../../../static-cidrs-tfvars/user_static_cidrs.tfvars" \
                 -var-file="../../../paas-bootstrap/terraform/((aws_account)).tfvars" \
                 -var-file="../../../paas-bootstrap/terraform/((aws_region)).tfvars" \
                 -var-file="../../../bootstrap-cyber-tfvars/bootstrap-cyber.tfvars"
@@ -2179,6 +2266,7 @@ jobs:
           - name: vpc-terraform-outputs
           - name: bosh-terraform-outputs
           - name: concourse-tfstate
+          - name: static-cidrs-tfvars
           outputs:
           - name: updated-concourse-tfstate
           params:
@@ -2205,6 +2293,7 @@ jobs:
                 -auto-approve=true \
                 -target=aws_security_group.concourse \
                 -var="set_concourse_egress_cidrs=false" \
+                -var-file="../../../static-cidrs-tfvars/user_static_cidrs.tfvars" \
                 -var-file="../../../paas-bootstrap/terraform/((aws_account)).tfvars" \
                 -var-file="../../../paas-bootstrap/terraform/((aws_region)).tfvars" \
                 -state=../../../updated-concourse-tfstate/concourse.tfstate

--- a/concourse/scripts/get_static_cidrs.rb
+++ b/concourse/scripts/get_static_cidrs.rb
@@ -1,0 +1,17 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require "yaml"
+
+users = YAML.load_file("users.yml", aliases: true)
+
+deploy_env = ENV["AWS_ACCOUNT"]
+
+# Collect static IPs for users with the aws-access role in the specified environment
+static_ips = users["users"].select { |user| user["roles"]&.dig(deploy_env)&.any? { |role| role["role"] == "aws-access" } }.map { |user| user["static_ip"] }.compact
+
+# Format the static IPs as a Terraform command line variable
+terraform_var = static_ips.empty? ? "" : "user_static_cidrs=[\"#{static_ips.join('/32","')}/32\"]"
+
+# Print the Terraform variable
+puts terraform_var

--- a/terraform/bosh/blobstore.tf
+++ b/terraform/bosh/blobstore.tf
@@ -16,4 +16,3 @@ resource "aws_s3_bucket_acl" "bosh-blobstore_acl" {
 
   depends_on = [aws_s3_bucket_ownership_controls.bosh-blobstore]
 }
-

--- a/terraform/bosh/lb.tf
+++ b/terraform/bosh/lb.tf
@@ -11,10 +11,13 @@ resource "aws_security_group" "bosh_lb" {
   }
 
   ingress {
-    from_port   = 443
-    to_port     = 443
-    protocol    = "tcp"
-    cidr_blocks = var.admin_cidrs
+    from_port = 443
+    to_port   = 443
+    protocol  = "tcp"
+    cidr_blocks = concat(
+      var.admin_cidrs,
+      var.user_static_cidrs,
+    )
   }
 
   tags = {
@@ -97,4 +100,3 @@ resource "aws_route53_record" "bosh_uaa_external" {
     evaluate_target_health = false
   }
 }
-

--- a/terraform/bucket/tf-state-bucket.tf
+++ b/terraform/bucket/tf-state-bucket.tf
@@ -11,16 +11,15 @@ resource "aws_s3_bucket" "terraform-state-s3" {
 }
 
 resource "aws_s3_bucket_ownership_controls" "terraform-state-s3" {
-  bucket = var.state_bucket
+  bucket = aws_s3_bucket.terraform-state-s3.id
   rule {
     object_ownership = "BucketOwnerPreferred"
   }
 }
 
 resource "aws_s3_bucket_acl" "terraform-state-s3" {
-  bucket = var.state_bucket
-  acl    = "private"
-
+  bucket     = aws_s3_bucket.terraform-state-s3.id
+  acl        = "private"
   depends_on = [aws_s3_bucket_ownership_controls.terraform-state-s3]
 }
 

--- a/terraform/concourse/elb.tf
+++ b/terraform/concourse/elb.tf
@@ -72,6 +72,7 @@ resource "aws_security_group" "concourse-elb" {
       distinct(
         concat(
           var.admin_cidrs,
+          var.user_static_cidrs,
           ["${aws_eip.concourse.public_ip}/32"],
           var.set_concourse_egress_cidrs == false ? [] : formatlist("%s/32", data.aws_instances.concourse_workers.public_ips),
         ),

--- a/terraform/concourse/security_group.tf
+++ b/terraform/concourse/security_group.tf
@@ -27,6 +27,7 @@ resource "aws_security_group" "concourse" {
       concat(
         var.admin_cidrs,
         [format("%s/32", var.microbosh_static_private_ip)],
+        var.user_static_cidrs,
       ),
     )
   }
@@ -74,6 +75,7 @@ resource "aws_security_group" "concourse-worker" {
       concat(
         var.admin_cidrs,
         [format("%s/32", var.microbosh_static_private_ip)],
+        var.user_static_cidrs,
       ),
     )
   }

--- a/terraform/globals.tf
+++ b/terraform/globals.tf
@@ -95,8 +95,12 @@ variable "admin_cidrs" {
     "213.86.153.237/32",
     "51.149.8.0/25",     # New DR VPN
     "51.149.8.128/29",   # New DR BYOD VPN
-    "82.71.58.244/32",   # LP remote
-    "51.148.163.199/32", # TW remote
+    "90.155.48.192/26",  # ITHC 2023
+    "81.2.127.144/28",   # ITHC 2023
+    "81.187.169.170/32", # ITHC 2023
+    "88.97.60.11/32",    # ITHC 2023
+    "3.10.4.97/32",      # ITHC 2023
+    "51.104.217.191/32", # ITHC 2023
   ]
 }
 
@@ -134,4 +138,9 @@ variable "aws_vpc_endpoint_cidrs_per_zone" {
     zone1 = "10.0.79.16/28"
     zone2 = "10.0.79.32/28"
   }
+}
+
+variable "user_static_cidrs" {
+  description = "user static cidrs populated with values from paas-trusted-people"
+  default     = []
 }

--- a/terraform/vpc/security-group.tf
+++ b/terraform/vpc/security-group.tf
@@ -26,14 +26,14 @@ resource "aws_security_group" "office-access-ssh" {
     from_port   = 22
     to_port     = 22
     protocol    = "tcp"
-    cidr_blocks = compact(concat(var.admin_cidrs, var.set_concourse_egress_cidrs == false ? [] : formatlist("%s/32", data.aws_instances.concourse_workers.public_ips)))
+    cidr_blocks = compact(concat(var.admin_cidrs, var.user_static_cidrs, var.set_concourse_egress_cidrs == false ? [] : formatlist("%s/32", data.aws_instances.concourse_workers.public_ips)))
   }
 
   ingress {
     from_port   = 8443
     to_port     = 8443
     protocol    = "tcp"
-    cidr_blocks = compact(concat(var.admin_cidrs, var.set_concourse_egress_cidrs == false ? [] : formatlist("%s/32", data.aws_instances.concourse_workers.public_ips)))
+    cidr_blocks = compact(concat(var.admin_cidrs, var.user_static_cidrs, var.set_concourse_egress_cidrs == false ? [] : formatlist("%s/32", data.aws_instances.concourse_workers.public_ips)))
   }
 
   tags = {


### PR DESCRIPTION
What
----

Changes for [pivotal tracker storey](https://www.pivotaltracker.com/n/projects/1275640/stories/184537961). Made related changes to [paas-cf](https://github.com/alphagov/paas-cf/pull/3163), [paas-trusted-people](https://github.com/alphagov/paas-trusted-people/pull/116) and [paas-aws-account-wide-terraform](https://github.com/alphagov/paas-aws-account-wide-terraform/pull/352) repos.

How to review
-------------

The new procedure for testing changes to paas-bootstrap is to run the branch into a new bootstrap environment.

Ensure that the **PAAS_TRUSTED_PEOPLE_BRANCH** var is set to the related branch in the paas-trusted-people repo before uploading the secrets.

Once the terraform jobs have completed check that you have the same access to the system components as you had before.

The expunge-concourse concourse job should not remove the user_static_cidrs from the security groups.

Who can review
--------------

The change should be tested by anyone with a current static ip address exposed in paas-cf and paas-bootstrap.

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
