### PR TITLE
`create-bosh-concourse` pipeline: address race condition for `generate-concourse-config`

### DIFF
--- a/concourse/pipelines/create-bosh-concourse.yml
+++ b/concourse/pipelines/create-bosh-concourse.yml
@@ -1344,7 +1344,7 @@ jobs:
           passed: ['concourse-terraform']
         - get: pipeline-trigger
           trigger: true
-          passed: ['concourse-terraform']
+          passed: ['concourse-terraform', 'generate-bosh-config']
         - get: vpc-tfstate
           passed: ['concourse-terraform']
         - get: concourse-tfstate

--- a/terraform/bosh/blobstore.tf
+++ b/terraform/bosh/blobstore.tf
@@ -3,8 +3,17 @@ resource "aws_s3_bucket" "bosh-blobstore" {
   force_destroy = "true"
 }
 
+resource "aws_s3_bucket_ownership_controls" "bosh-blobstore" {
+  bucket = aws_s3_bucket.bosh-blobstore.id
+  rule {
+    object_ownership = "BucketOwnerPreferred"
+  }
+}
+
 resource "aws_s3_bucket_acl" "bosh-blobstore_acl" {
   bucket = aws_s3_bucket.bosh-blobstore.id
   acl    = "private"
+
+  depends_on = [aws_s3_bucket_ownership_controls.bosh-blobstore]
 }
 

--- a/terraform/bucket/tf-state-bucket.tf
+++ b/terraform/bucket/tf-state-bucket.tf
@@ -10,9 +10,18 @@ resource "aws_s3_bucket" "terraform-state-s3" {
   }
 }
 
+resource "aws_s3_bucket_ownership_controls" "terraform-state-s3" {
+  bucket = var.state_bucket
+  rule {
+    object_ownership = "BucketOwnerPreferred"
+  }
+}
+
 resource "aws_s3_bucket_acl" "terraform-state-s3" {
   bucket = var.state_bucket
   acl    = "private"
+
+  depends_on = [aws_s3_bucket_ownership_controls.terraform-state-s3]
 }
 
 resource "aws_s3_bucket_versioning" "terraform-state-s3" {


### PR DESCRIPTION
What
----
If `concourse-terraform` finishes before `generate-bosh-config` and this triggers `generate-concourse-config`, it will pick up an old copy of `bosh-secrets`, not yet updated by `generate-bosh-concourse`. This is bad and can cause severe problems when secrets are being rotated.

This ensures the `pipeline-trigger` doesn't reach `generate-concourse-config` until it has also passed `generate-bosh-config`.

How to review
-------------

This probably needs to be run through an env and the env have its credentials rotated via `drop-bosh-credentials-for-rotation` a la https://team-manual.cloud.service.gov.uk/team/rotating_credentials/#rotating-bosh-credentials-and-certificates. To ensure we test the case where `concourse-terraform` finishes before `generate-bosh-config`, it's probably worth briefly pausing `generate-bosh-config` to delay its start as the release passes it.

We should also test that we can bootstrap an env from concourse-lite with this change, as laborious as it is.

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
