### PR TITLE
upgrade bosh machines to `c6i.xlarge` in prod

### DIFF
--- a/manifests/bosh-manifest/operations.d/030-update-instance-type.yml
+++ b/manifests/bosh-manifest/operations.d/030-update-instance-type.yml
@@ -1,4 +1,4 @@
 ---
 - type: replace
   path: /resource_pools/name=vms/cloud_properties/instance_type
-  value: m5.large
+  value: c6i.xlarge

--- a/manifests/bosh-manifest/spec/manifest_validation_spec.rb
+++ b/manifests/bosh-manifest/spec/manifest_validation_spec.rb
@@ -155,8 +155,8 @@ RSpec.describe "generic manifest validations" do
       context "when not in development" do
         let(:manifest) { manifest_for_account("prod") }
 
-        it "is m5.large" do
-          expect(instance_type).to eq("m5.large")
+        it "is c6i.xlarge" do
+          expect(instance_type).to eq("c6i.xlarge")
         end
       end
     end


### PR DESCRIPTION
What
----
https://www.pivotaltracker.com/story/show/184736235

c6a providing faster single core performance improves "compile" times and deployment times (slightly). there's a limit to how much extra performance can be achieved by throwing more cores at the problem because bosh appears largely single-threaded.

In my tests, this brings a `bosh-deploy` from >45m to ~35m. 

How to review
-------------

👀  https://deployer.dev04.dev.cloudpipeline.digital/teams/main/pipelines/create-bosh-concourse/jobs/bosh-deploy/builds/24 and previous deployments, read build notes & compare times.


---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
