### PR TITLE
terraform: add VPC flow logs logging parquet files to a bucket

### DIFF
--- a/terraform/vpc/flow-log.tf
+++ b/terraform/vpc/flow-log.tf
@@ -1,0 +1,52 @@
+resource "aws_s3_bucket" "vpc-flow-logs" {
+  bucket = "gds-paas-${var.env}-vpc-flow-logs"
+
+  tags = {
+    Environment = var.env
+  }
+}
+
+resource "aws_s3_bucket_ownership_controls" "vpc-flow-logs" {
+  bucket = aws_s3_bucket.vpc-flow-logs.id
+  rule {
+    object_ownership = "BucketOwnerPreferred"
+  }
+}
+
+resource "aws_s3_bucket_acl" "vpc-flow-logs" {
+  bucket     = aws_s3_bucket.vpc-flow-logs.id
+  acl        = "private"
+  depends_on = [aws_s3_bucket_ownership_controls.vpc-flow-logs]
+}
+
+resource "aws_s3_bucket_lifecycle_configuration" "vpc-flow-logs-30d" {
+  bucket = aws_s3_bucket.vpc-flow-logs.id
+
+
+  rule {
+    id     = "Expire old logs"
+    status = "Enabled"
+
+    expiration {
+      # S3 charges for a minimum period of 30 days so may as well
+      # use at least 30d
+      days = 30
+    }
+  }
+}
+
+resource "aws_flow_log" "paas" {
+  log_destination      = aws_s3_bucket.vpc-flow-logs.arn
+  log_destination_type = "s3"
+  traffic_type         = "ALL"
+  vpc_id               = aws_vpc.paas.id
+  destination_options {
+    file_format        = "parquet"
+    per_hour_partition = true
+  }
+
+  tags = {
+    Name        = "${var.env}-all-to-parquet"
+    Environment = var.env
+  }
+}


### PR DESCRIPTION
What
----

https://www.pivotaltracker.com/story/show/185202227

This uses a bucket expiry time of 30d as that's the minimum we will be charged for.

The generated parquet files are quite convenient to work with - I've had good success querying them with `duckdb`.

My thinking is to leave this enabled on all envs as the volume it's likely to create on dev will pale in comparison to prod.

This depends on https://github.com/alphagov/paas-aws-account-wide-terraform/pull/360 having been run in the target aws account before deploying.

How to review
-------------

Deploy to a dev env. Go look at the `gds-paas-${var.env}-vpc-flow-logs` bucket it has created filling with parquet files.

I've also tested bringing a dev env all the way down and up again with this successfully.

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
