### PR TITLE
bosh-cli.sh: don't use the `mktemp` `-t` option

### DIFF
--- a/scripts/bosh-cli.sh
+++ b/scripts/bosh-cli.sh
@@ -6,7 +6,7 @@ if [[ -n "${PAAS_IN_BOSH_CLI_SUBSHELL:-}" ]]; then
   exit 1
 fi
 
-bosh_config_dir="$(mktemp -dt "bosh-cli--${DEPLOY_ENV}")"
+bosh_config_dir="$(mktemp -d)"
 if [[ ! -d "${bosh_config_dir}" ]]; then
   echo "Failed to create temporary directory: ${bosh_config_dir}"
   exit 1


### PR DESCRIPTION
What
----

#606 breaks the `bosh-cli` script if you're using linux/gnu `mktemp`, as it has a different approach to directory prefixes. The `-t` flag is effectively non-portable. Luckily it's just a nicety to have pretty temp dir names.

How to review
-------------

Do a `make bosh-cli` on linux (or a gnu-based stdenv like nix provides) and macos, check it works. 

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
