### PR TITLE
using 1.125 jammy stemcell

### DIFF
--- a/manifests/bosh-manifest/operations.d/030-set-stemcell.yml
+++ b/manifests/bosh-manifest/operations.d/030-set-stemcell.yml
@@ -2,5 +2,5 @@
 - type: replace
   path: /resource_pools/name=vms/stemcell
   value:
-    url: https://bosh.io/d/stemcells/bosh-aws-xen-hvm-ubuntu-jammy-go_agent?v=1.117
-    sha1: 37ad067a306b41579828160b9c2669eda795970e
+    url: https://bosh.io/d/stemcells/bosh-aws-xen-hvm-ubuntu-jammy-go_agent?v=1.125
+    sha1: c71677abe2ba5bda6eded38e4db2c13d1fb2f300

--- a/manifests/concourse-manifest/concourse-base.yml
+++ b/manifests/concourse-manifest/concourse-base.yml
@@ -2,7 +2,7 @@
 meta:
   stemcell:
     name: bosh-aws-xen-hvm-ubuntu-jammy-go_agent
-    version: "1.117"
+    version: "1.125"
 
 name: concourse
 


### PR DESCRIPTION
What
----

Stemcell version needs to be aligned with the upcoming upgrade of cf30.5. Doing this as a paired action with the `cflinuxfs4-rollout-take2` branch of `paas-cf`.

How to review
-------------

- Run this repo against a dev environment
- Make sure all things work

Who can review
--------------

People in the PAAS team

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
