### PR TITLE
[#185500801] Updated docker images

### DIFF
--- a/concourse/pipelines/concourse-lite-self-terminate.yml
+++ b/concourse/pipelines/concourse-lite-self-terminate.yml
@@ -8,7 +8,7 @@ meta:
       type: registry-image
       source:
         repository: ghcr.io/alphagov/paas/awscli
-        tag: 540813b98e23f9865b33c206a840a8d5633287e9
+        tag: d233a6d5064fc720fb90fdb1c1e773ac21f3857c
 
 resources:
   - name: delete-timer

--- a/concourse/pipelines/create-bosh-concourse.yml
+++ b/concourse/pipelines/create-bosh-concourse.yml
@@ -8,47 +8,47 @@ meta:
       type: registry-image
       source:
         repository: ghcr.io/alphagov/paas/alpine
-        tag: 540813b98e23f9865b33c206a840a8d5633287e9
+        tag: d233a6d5064fc720fb90fdb1c1e773ac21f3857c
     awscli: &awscli-image-resource
       type: registry-image
       source:
         repository: ghcr.io/alphagov/paas/awscli
-        tag: 540813b98e23f9865b33c206a840a8d5633287e9
+        tag: d233a6d5064fc720fb90fdb1c1e773ac21f3857c
     bosh-cli-v2: &gov-paas-bosh-cli-v2-image-resource
       type: registry-image
       source:
         repository: ghcr.io/alphagov/paas/bosh-cli-v2
-        tag: 540813b98e23f9865b33c206a840a8d5633287e9
+        tag: d233a6d5064fc720fb90fdb1c1e773ac21f3857c
     certstrap: &certstrap-image-resource
       type: registry-image
       source:
         repository: ghcr.io/alphagov/paas/certstrap
-        tag: 540813b98e23f9865b33c206a840a8d5633287e9
+        tag: d233a6d5064fc720fb90fdb1c1e773ac21f3857c
     git-ssh: &git-ssh-image-resource
       type: registry-image
       source:
         repository: ghcr.io/alphagov/paas/git-ssh
-        tag: 540813b98e23f9865b33c206a840a8d5633287e9
+        tag: d233a6d5064fc720fb90fdb1c1e773ac21f3857c
     ruby-slim: &ruby-slim-image-resource
       type: registry-image
       source:
         repository: ghcr.io/alphagov/paas/ruby
-        tag: 540813b98e23f9865b33c206a840a8d5633287e9
+        tag: d233a6d5064fc720fb90fdb1c1e773ac21f3857c
     self-update-pipelines: &self-update-pipelines-image-resource
       type: registry-image
       source:
         repository: ghcr.io/alphagov/paas/self-update-pipelines
-        tag: 540813b98e23f9865b33c206a840a8d5633287e9
+        tag: d233a6d5064fc720fb90fdb1c1e773ac21f3857c
     spruce: &spruce-image-resource
       type: registry-image
       source:
         repository: ghcr.io/alphagov/paas/spruce
-        tag: 540813b98e23f9865b33c206a840a8d5633287e9
+        tag: d233a6d5064fc720fb90fdb1c1e773ac21f3857c
     terraform: &terraform-image-resource
       type: registry-image
       source:
         repository: ghcr.io/alphagov/paas/terraform
-        tag: 540813b98e23f9865b33c206a840a8d5633287e9
+        tag: d233a6d5064fc720fb90fdb1c1e773ac21f3857c
 
 groups:
   - name: all
@@ -102,7 +102,7 @@ resource_types:
   type: registry-image
   source:
     repository: ghcr.io/alphagov/paas/keyval-resource
-    tag: d467945db218918c73ffc804dcc3f5b6281c7164
+    tag: d233a6d5064fc720fb90fdb1c1e773ac21f3857c
 
 resources:
   - name: paas-bootstrap

--- a/concourse/pipelines/destroy-bosh-concourse.yml
+++ b/concourse/pipelines/destroy-bosh-concourse.yml
@@ -8,12 +8,12 @@ meta:
       type: registry-image
       source:
         repository: ghcr.io/alphagov/paas/awscli
-        tag: 540813b98e23f9865b33c206a840a8d5633287e9
+        tag: d233a6d5064fc720fb90fdb1c1e773ac21f3857c
     bosh-cli-v2: &gov-paas-bosh-cli-v2-image-resource
       type: registry-image
       source:
         repository: ghcr.io/alphagov/paas/bosh-cli-v2
-        tag: 540813b98e23f9865b33c206a840a8d5633287e9
+        tag: d233a6d5064fc720fb90fdb1c1e773ac21f3857c
     ruby-slim: &ruby-slim-image-resource
       type: registry-image
       source:
@@ -23,12 +23,12 @@ meta:
       type: registry-image
       source:
         repository: ghcr.io/alphagov/paas/self-update-pipelines
-        tag: 540813b98e23f9865b33c206a840a8d5633287e9
+        tag: d233a6d5064fc720fb90fdb1c1e773ac21f3857c
     terraform: &terraform-image-resource
       type: registry-image
       source:
         repository: ghcr.io/alphagov/paas/terraform
-        tag: 540813b98e23f9865b33c206a840a8d5633287e9
+        tag: d233a6d5064fc720fb90fdb1c1e773ac21f3857c
 
 resource_types:
 - name: s3-iam

--- a/concourse/spec/image_resource_spec.rb
+++ b/concourse/spec/image_resource_spec.rb
@@ -47,7 +47,7 @@ RSpec.describe "image resources" do
         .select { |repo, _| repo.match?(%r{^ghcr.io/alphagov/paas/}) }
         .reject { |repo, _| repo.match?(/-resource$/) }
         .to_h.values .flatten .uniq.tap do |all_tags|
-          it "onlies have one tag" do
+          it "only have one tag" do
             expect(all_tags.length).to eq(1)
           end
         end

--- a/concourse/tasks/delete-ssh-keys.yml
+++ b/concourse/tasks/delete-ssh-keys.yml
@@ -4,7 +4,7 @@ image_resource:
   type: registry-image
   source:
     repository: ghcr.io/alphagov/paas/awscli
-    tag: 540813b98e23f9865b33c206a840a8d5633287e9
+    tag: d233a6d5064fc720fb90fdb1c1e773ac21f3857c
 inputs:
   - name: paas-bootstrap
 run:

--- a/concourse/tasks/render-bosh-manifest.yml
+++ b/concourse/tasks/render-bosh-manifest.yml
@@ -4,7 +4,7 @@ image_resource:
   type: registry-image
   source:
     repository: ghcr.io/alphagov/paas/bosh-cli-v2
-    tag: 540813b98e23f9865b33c206a840a8d5633287e9
+    tag: d233a6d5064fc720fb90fdb1c1e773ac21f3857c
 inputs:
   - name: bosh-vars-store
     optional: true


### PR DESCRIPTION
What
----

The cf cli has been upgraded to v8.7.1 as requested in Pivotal Tracker storey 185500801.

All images created by github actions in paas-docker-cloudfoundry-tools have had their tag updated.

How to review
-------------

1 - Run the branch into a dev env.
2 - Confirm that the new version of the cf cli has been installed by hijacking a relevant container and checking the version of the cf cli.
3 - Confirm that there are no errors related to the cf cli within the pipeline.

Who can review
--------------

Any paas dev.

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
