### PR TITLE
pipeline docker images: bump to terraform-1.5.2 images

### DIFF
--- a/concourse/pipelines/concourse-lite-self-terminate.yml
+++ b/concourse/pipelines/concourse-lite-self-terminate.yml
@@ -8,7 +8,7 @@ meta:
       type: registry-image
       source:
         repository: ghcr.io/alphagov/paas/awscli
-        tag: b25554b10d0efb9da2aef192f9a890199863f59e
+        tag: 540813b98e23f9865b33c206a840a8d5633287e9
 
 resources:
   - name: delete-timer

--- a/concourse/pipelines/create-bosh-concourse.yml
+++ b/concourse/pipelines/create-bosh-concourse.yml
@@ -8,47 +8,47 @@ meta:
       type: registry-image
       source:
         repository: ghcr.io/alphagov/paas/alpine
-        tag: b25554b10d0efb9da2aef192f9a890199863f59e
+        tag: 540813b98e23f9865b33c206a840a8d5633287e9
     awscli: &awscli-image-resource
       type: registry-image
       source:
         repository: ghcr.io/alphagov/paas/awscli
-        tag: b25554b10d0efb9da2aef192f9a890199863f59e
+        tag: 540813b98e23f9865b33c206a840a8d5633287e9
     bosh-cli-v2: &gov-paas-bosh-cli-v2-image-resource
       type: registry-image
       source:
         repository: ghcr.io/alphagov/paas/bosh-cli-v2
-        tag: b25554b10d0efb9da2aef192f9a890199863f59e
+        tag: 540813b98e23f9865b33c206a840a8d5633287e9
     certstrap: &certstrap-image-resource
       type: registry-image
       source:
         repository: ghcr.io/alphagov/paas/certstrap
-        tag: b25554b10d0efb9da2aef192f9a890199863f59e
+        tag: 540813b98e23f9865b33c206a840a8d5633287e9
     git-ssh: &git-ssh-image-resource
       type: registry-image
       source:
         repository: ghcr.io/alphagov/paas/git-ssh
-        tag: b25554b10d0efb9da2aef192f9a890199863f59e
+        tag: 540813b98e23f9865b33c206a840a8d5633287e9
     ruby-slim: &ruby-slim-image-resource
       type: registry-image
       source:
         repository: ghcr.io/alphagov/paas/ruby
-        tag: b25554b10d0efb9da2aef192f9a890199863f59e
+        tag: 540813b98e23f9865b33c206a840a8d5633287e9
     self-update-pipelines: &self-update-pipelines-image-resource
       type: registry-image
       source:
         repository: ghcr.io/alphagov/paas/self-update-pipelines
-        tag: b25554b10d0efb9da2aef192f9a890199863f59e
+        tag: 540813b98e23f9865b33c206a840a8d5633287e9
     spruce: &spruce-image-resource
       type: registry-image
       source:
         repository: ghcr.io/alphagov/paas/spruce
-        tag: b25554b10d0efb9da2aef192f9a890199863f59e
+        tag: 540813b98e23f9865b33c206a840a8d5633287e9
     terraform: &terraform-image-resource
       type: registry-image
       source:
         repository: ghcr.io/alphagov/paas/terraform
-        tag: b25554b10d0efb9da2aef192f9a890199863f59e
+        tag: 540813b98e23f9865b33c206a840a8d5633287e9
 
 groups:
   - name: all

--- a/concourse/pipelines/destroy-bosh-concourse.yml
+++ b/concourse/pipelines/destroy-bosh-concourse.yml
@@ -8,12 +8,12 @@ meta:
       type: registry-image
       source:
         repository: ghcr.io/alphagov/paas/awscli
-        tag: b25554b10d0efb9da2aef192f9a890199863f59e
+        tag: 540813b98e23f9865b33c206a840a8d5633287e9
     bosh-cli-v2: &gov-paas-bosh-cli-v2-image-resource
       type: registry-image
       source:
         repository: ghcr.io/alphagov/paas/bosh-cli-v2
-        tag: b25554b10d0efb9da2aef192f9a890199863f59e
+        tag: 540813b98e23f9865b33c206a840a8d5633287e9
     ruby-slim: &ruby-slim-image-resource
       type: registry-image
       source:
@@ -23,12 +23,12 @@ meta:
       type: registry-image
       source:
         repository: ghcr.io/alphagov/paas/self-update-pipelines
-        tag: b25554b10d0efb9da2aef192f9a890199863f59e
+        tag: 540813b98e23f9865b33c206a840a8d5633287e9
     terraform: &terraform-image-resource
       type: registry-image
       source:
         repository: ghcr.io/alphagov/paas/terraform
-        tag: b25554b10d0efb9da2aef192f9a890199863f59e
+        tag: 540813b98e23f9865b33c206a840a8d5633287e9
 
 resource_types:
 - name: s3-iam

--- a/concourse/tasks/delete-ssh-keys.yml
+++ b/concourse/tasks/delete-ssh-keys.yml
@@ -4,7 +4,7 @@ image_resource:
   type: registry-image
   source:
     repository: ghcr.io/alphagov/paas/awscli
-    tag: b25554b10d0efb9da2aef192f9a890199863f59e
+    tag: 540813b98e23f9865b33c206a840a8d5633287e9
 inputs:
   - name: paas-bootstrap
 run:

--- a/concourse/tasks/render-bosh-manifest.yml
+++ b/concourse/tasks/render-bosh-manifest.yml
@@ -4,7 +4,7 @@ image_resource:
   type: registry-image
   source:
     repository: ghcr.io/alphagov/paas/bosh-cli-v2
-    tag: b25554b10d0efb9da2aef192f9a890199863f59e
+    tag: 540813b98e23f9865b33c206a840a8d5633287e9
 inputs:
   - name: bosh-vars-store
     optional: true


### PR DESCRIPTION
What
----

https://www.pivotaltracker.com/story/show/185500753

Bumped bootstrap's pipeline docker images to a set including terraform 1.5.2.

How to review
-------------

See dev02, which was most recently torn down/brought up by this image.

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
