### PR TITLE
Upgrade bosh, awscpi, node-exporter and docker images. Switch to using compiled bosh packages.

### DIFF
--- a/concourse/pipelines/concourse-lite-self-terminate.yml
+++ b/concourse/pipelines/concourse-lite-self-terminate.yml
@@ -8,7 +8,7 @@ meta:
       type: registry-image
       source:
         repository: ghcr.io/alphagov/paas/awscli
-        tag: d233a6d5064fc720fb90fdb1c1e773ac21f3857c
+        tag: acff07cc3f0d4f478f54a7dedd40d47c90ad62f7
 
 resources:
   - name: delete-timer

--- a/concourse/pipelines/create-bosh-concourse.yml
+++ b/concourse/pipelines/create-bosh-concourse.yml
@@ -8,47 +8,47 @@ meta:
       type: registry-image
       source:
         repository: ghcr.io/alphagov/paas/alpine
-        tag: d233a6d5064fc720fb90fdb1c1e773ac21f3857c
+        tag: acff07cc3f0d4f478f54a7dedd40d47c90ad62f7
     awscli: &awscli-image-resource
       type: registry-image
       source:
         repository: ghcr.io/alphagov/paas/awscli
-        tag: d233a6d5064fc720fb90fdb1c1e773ac21f3857c
+        tag: acff07cc3f0d4f478f54a7dedd40d47c90ad62f7
     bosh-cli-v2: &gov-paas-bosh-cli-v2-image-resource
       type: registry-image
       source:
         repository: ghcr.io/alphagov/paas/bosh-cli-v2
-        tag: d233a6d5064fc720fb90fdb1c1e773ac21f3857c
+        tag: acff07cc3f0d4f478f54a7dedd40d47c90ad62f7
     certstrap: &certstrap-image-resource
       type: registry-image
       source:
         repository: ghcr.io/alphagov/paas/certstrap
-        tag: d233a6d5064fc720fb90fdb1c1e773ac21f3857c
+        tag: acff07cc3f0d4f478f54a7dedd40d47c90ad62f7
     git-ssh: &git-ssh-image-resource
       type: registry-image
       source:
         repository: ghcr.io/alphagov/paas/git-ssh
-        tag: d233a6d5064fc720fb90fdb1c1e773ac21f3857c
+        tag: acff07cc3f0d4f478f54a7dedd40d47c90ad62f7
     ruby-slim: &ruby-slim-image-resource
       type: registry-image
       source:
         repository: ghcr.io/alphagov/paas/ruby
-        tag: d233a6d5064fc720fb90fdb1c1e773ac21f3857c
+        tag: acff07cc3f0d4f478f54a7dedd40d47c90ad62f7
     self-update-pipelines: &self-update-pipelines-image-resource
       type: registry-image
       source:
         repository: ghcr.io/alphagov/paas/self-update-pipelines
-        tag: d233a6d5064fc720fb90fdb1c1e773ac21f3857c
+        tag: acff07cc3f0d4f478f54a7dedd40d47c90ad62f7
     spruce: &spruce-image-resource
       type: registry-image
       source:
         repository: ghcr.io/alphagov/paas/spruce
-        tag: d233a6d5064fc720fb90fdb1c1e773ac21f3857c
+        tag: acff07cc3f0d4f478f54a7dedd40d47c90ad62f7
     terraform: &terraform-image-resource
       type: registry-image
       source:
         repository: ghcr.io/alphagov/paas/terraform
-        tag: d233a6d5064fc720fb90fdb1c1e773ac21f3857c
+        tag: acff07cc3f0d4f478f54a7dedd40d47c90ad62f7
 
 groups:
   - name: all
@@ -102,7 +102,7 @@ resource_types:
   type: registry-image
   source:
     repository: ghcr.io/alphagov/paas/keyval-resource
-    tag: d233a6d5064fc720fb90fdb1c1e773ac21f3857c
+    tag: acff07cc3f0d4f478f54a7dedd40d47c90ad62f7
 
 resources:
   - name: paas-bootstrap
@@ -1199,6 +1199,10 @@ jobs:
                 chmod 400 bosh-init-working-dir/.ssh/id_rsa
                 cp bosh-manifest/bosh-manifest.yml bosh-init-working-dir/bosh-manifest.yml
                 cp bosh-init-state/"${BOSH_MANIFEST_STATE}" bosh-init-working-dir/bosh-manifest-state.json
+
+                # uncomment if you want to force a bosh recreate each time
+                # RANDOM=$(cat /dev/urandom | tr -dc 'a-zA-Z0-9' | fold -w 20 | head -n 1)
+                # yq -i ".tags.random = \"${RANDOM}\"" bosh-init-working-dir/bosh-manifest.yml
 
                 bosh -n create-env bosh-init-working-dir/bosh-manifest.yml \
                   --state=bosh-init-working-dir/bosh-manifest-state.json

--- a/concourse/pipelines/destroy-bosh-concourse.yml
+++ b/concourse/pipelines/destroy-bosh-concourse.yml
@@ -8,12 +8,12 @@ meta:
       type: registry-image
       source:
         repository: ghcr.io/alphagov/paas/awscli
-        tag: d233a6d5064fc720fb90fdb1c1e773ac21f3857c
+        tag: acff07cc3f0d4f478f54a7dedd40d47c90ad62f7
     bosh-cli-v2: &gov-paas-bosh-cli-v2-image-resource
       type: registry-image
       source:
         repository: ghcr.io/alphagov/paas/bosh-cli-v2
-        tag: d233a6d5064fc720fb90fdb1c1e773ac21f3857c
+        tag: acff07cc3f0d4f478f54a7dedd40d47c90ad62f7
     ruby-slim: &ruby-slim-image-resource
       type: registry-image
       source:
@@ -23,12 +23,12 @@ meta:
       type: registry-image
       source:
         repository: ghcr.io/alphagov/paas/self-update-pipelines
-        tag: d233a6d5064fc720fb90fdb1c1e773ac21f3857c
+        tag: acff07cc3f0d4f478f54a7dedd40d47c90ad62f7
     terraform: &terraform-image-resource
       type: registry-image
       source:
         repository: ghcr.io/alphagov/paas/terraform
-        tag: d233a6d5064fc720fb90fdb1c1e773ac21f3857c
+        tag: acff07cc3f0d4f478f54a7dedd40d47c90ad62f7
 
 resource_types:
 - name: s3-iam

--- a/concourse/tasks/delete-ssh-keys.yml
+++ b/concourse/tasks/delete-ssh-keys.yml
@@ -4,7 +4,7 @@ image_resource:
   type: registry-image
   source:
     repository: ghcr.io/alphagov/paas/awscli
-    tag: d233a6d5064fc720fb90fdb1c1e773ac21f3857c
+    tag: acff07cc3f0d4f478f54a7dedd40d47c90ad62f7
 inputs:
   - name: paas-bootstrap
 run:

--- a/concourse/tasks/render-bosh-manifest.yml
+++ b/concourse/tasks/render-bosh-manifest.yml
@@ -4,7 +4,7 @@ image_resource:
   type: registry-image
   source:
     repository: ghcr.io/alphagov/paas/bosh-cli-v2
-    tag: d233a6d5064fc720fb90fdb1c1e773ac21f3857c
+    tag: acff07cc3f0d4f478f54a7dedd40d47c90ad62f7
 inputs:
   - name: bosh-vars-store
     optional: true

--- a/manifests/bosh-manifest/operations.d/031-blobstore.yml
+++ b/manifests/bosh-manifest/operations.d/031-blobstore.yml
@@ -17,3 +17,12 @@
 
 - type: remove
   path: /variables/name=blobstore_server_tls
+
+- type: replace
+  path: /instance_groups/name=bosh/properties/agent/env?/bosh/blobstores?/-
+  value:
+    provider: s3
+    options:
+      bucket_name: ((bosh_blobstore_bucket_name))
+      credentials_source: env_or_profile
+      region: ((region))

--- a/manifests/bosh-manifest/operations.d/120-cpi.yml
+++ b/manifests/bosh-manifest/operations.d/120-cpi.yml
@@ -2,10 +2,15 @@
   path: /instance_groups/name=bosh/properties/aws/max_retries?
   value: 16
 
+# We cache the cpi compile in the bosh-cli-v2 docker image.
+# You should update the cpi version here first.
+# See: https://github.com/alphagov/paas-docker-cloudfoundry-tools/blob/main/bosh-cli-v2/Dockerfile
+# If a different version is used in the image versus the below you will add 3-4 mins to the deploy time.
+
 - path: /releases/name=bosh-aws-cpi
   type: replace
   value:
     name: "bosh-aws-cpi"
-    version: "97"
-    url: "https://bosh.io/d/github.com/cloudfoundry/bosh-aws-cpi-release?v=97"
-    sha1: "b6aa84bc178e5cc99faa55a89943214c33488d5f"
+    version: "99"
+    url: "https://bosh.io/d/github.com/cloudfoundry/bosh-aws-cpi-release?v=99"
+    sha1: "ffc4a06d6728d88eb108418f886f46428c2a1bf2"

--- a/manifests/bosh-manifest/operations.d/130-bosh-UPSTREAM.yml
+++ b/manifests/bosh-manifest/operations.d/130-bosh-UPSTREAM.yml
@@ -1,1 +1,0 @@
-../upstream/misc/source-releases/bosh.yml

--- a/manifests/bosh-manifest/operations.d/600-exporters.yml
+++ b/manifests/bosh-manifest/operations.d/600-exporters.yml
@@ -22,9 +22,9 @@
   path: /releases/-
   value:
     name: "node-exporter"
-    version: "4.2.0"
-    url: "https://bosh.io/d/github.com/cloudfoundry-community/node-exporter-boshrelease?v=4.2.0"
-    sha1: "b4ffebacc55fbb9934425ac792bb7179eed7e61c"
+    version: "5.3.0"
+    url: "https://bosh.io/d/github.com/cloudfoundry-community/node-exporter-boshrelease?v=5.3.0"
+    sha1: "4f47c84cb79a543f41fab4412daa930eff12e35b"
 
 - type: replace
   path: /instance_groups/name=bosh/jobs/-

--- a/manifests/runtime-config/runtime-config-base.yml
+++ b/manifests/runtime-config/runtime-config-base.yml
@@ -48,7 +48,7 @@ releases:
     sha1: f2a5fc665b8d6581c302bc90aaa49a7ccd72efb9
     properties: {}
 
-  - name: node-exporter
-    version: "4.2.0"
-    url: "https://bosh.io/d/github.com/cloudfoundry-community/node-exporter-boshrelease?v=4.2.0"
-    sha1: "b4ffebacc55fbb9934425ac792bb7179eed7e61c"
+  - name: "node-exporter"
+    version: "5.3.0"
+    url: "https://bosh.io/d/github.com/cloudfoundry-community/node-exporter-boshrelease?v=5.3.0"
+    sha1: "4f47c84cb79a543f41fab4412daa930eff12e35b"


### PR DESCRIPTION
What
----

Upgrades:
    - bosh to 277.4.3
    - aws-cpi to version 99
    - node-exporter to 5.3.0
    - docker images to pick up new version of bosh-cli-v2

Switch to using the default compiled version of the bosh packages.

Why
----

Last year, as part [of this pr](https://github.com/alphagov/paas-bootstrap/pull/517) we switched to source packages. This was done as at that time we wanted to remain on bionic. When we switched to Jammy we neglected to disable this.

The blobstore config has changed as part of this cpi release. See [these release notes](https://github.com/cloudfoundry/bosh-aws-cpi-release/releases/tag/v98).

How to review
-------------

Deploy to a dev environment.
Tested in dev04
Credential rotations tested in dev04

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
