### PR TITLE
Revert "load balancers: write logs to global bucket"

### DIFF
--- a/terraform/bosh/lb.tf
+++ b/terraform/bosh/lb.tf
@@ -40,13 +40,6 @@ resource "aws_lb" "bosh" {
   tags = {
     Name = "${var.env}-bosh-lb"
   }
-
-  access_logs {
-    bucket  = data.aws_s3_bucket.account_wide_alb_access_logs.id
-    prefix  = "${var.env}/bosh"
-    enabled = true
-  }
-
 }
 
 resource "aws_lb_listener" "bosh_tls" {

--- a/terraform/concourse/elb.tf
+++ b/terraform/concourse/elb.tf
@@ -35,11 +35,6 @@ resource "aws_elb" "concourse" {
     lb_protocol        = "ssl"
     ssl_certificate_id = aws_acm_certificate_validation.system.certificate_arn
   }
-  access_logs {
-    bucket        = data.aws_s3_bucket.account_wide_alb_access_logs.bucket
-    bucket_prefix = "${var.env}/concourse"
-    enabled       = true
-  }
 
   tags = {
     Name = "${var.env}-concourse-elb"
@@ -118,3 +113,4 @@ resource "aws_route53_record" "concourse" {
   ttl     = "60"
   records = [aws_elb.concourse.dns_name]
 }
+

--- a/terraform/globals.tf
+++ b/terraform/globals.tf
@@ -144,7 +144,3 @@ variable "user_static_cidrs" {
   description = "user static cidrs populated with values from paas-trusted-people"
   default     = []
 }
-
-data "aws_s3_bucket" "account_wide_alb_access_logs" {
-  bucket = "gds-paas-${var.aws_account}-account-wide-alb-access-logs"
-}


### PR DESCRIPTION
Reverts alphagov/paas-bootstrap#643

Let's roll this back to unblock pipelines while we figure out the cross-region nonsense.