### PR TITLE
BAU - Pin GitHub action to hash

### DIFF
--- a/.github/workflows/check_gpg_keys.yml
+++ b/.github/workflows/check_gpg_keys.yml
@@ -10,7 +10,7 @@ jobs:
     outputs:
       key_ids: ${{ steps.extract-key-ids.outputs.key_ids }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab
       - name: Extract key ids from .gpg-id and output as a json list
         id: extract-key-ids
         run: echo "key_ids=$(jq -c --raw-input --slurp 'split("\n") | map(select(. != ""))' .gpg-id)" >> $GITHUB_OUTPUT


### PR DESCRIPTION
Description:
----
- Pins the GitHub action to a hash rather than version number

What
----

Code review


---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
