### PR TITLE
Upgrade concourse to 7.10.0

### DIFF
--- a/manifests/concourse-manifest/concourse-base.yml
+++ b/manifests/concourse-manifest/concourse-base.yml
@@ -16,13 +16,13 @@ stemcells:
 # relevant tag of https://github.com/concourse/concourse-bosh-deployment
 releases:
   - name: "concourse"
-    version: "7.9.0"
-    url: "https://bosh.io/d/github.com/concourse/concourse-bosh-release?v=7.9.0"
-    sha1: "0920d2a3c13a81f50529ae72118a9d83bece7e65"
+    version: "7.10.0"
+    url: "https://bosh.io/d/github.com/concourse/concourse-bosh-release?v=7.10.0"
+    sha1: "0b7c6b8ab6a0da832d91a5e30d2cc56ce80de06e"
   - name: "bpm"
-    version: "1.1.18"
-    url: "https://bosh.io/d/github.com/cloudfoundry/bpm-release?v=1.1.18"
-    sha1: "86675f90d66f7018c57f4ae0312f1b3834dd58c9"
+    version: "1.2.6"
+    url: "https://bosh.io/d/github.com/cloudfoundry/bpm-release?v=1.2.6"
+    sha1: "1321e81a231065a64cc3988e48a39b7c7f68b9c7"
   - name: awslogs
     version: 0.1.8
     url: https://s3-eu-west-1.amazonaws.com/gds-paas-build-releases/awslogs-0.1.8.tgz

--- a/vagrant/docker-compose.yml
+++ b/vagrant/docker-compose.yml
@@ -10,7 +10,7 @@ services:
     - PGDATA=/database
 
   concourse-web:
-    image: concourse/concourse:7.9.0
+    image: concourse/concourse:7.10.0
     command: web
     privileged: true
     depends_on: [concourse-db]
@@ -32,7 +32,7 @@ services:
     - CONCOURSE_SESSION_SIGNING_KEY=/keys/session_signing_key
 
   concourse-worker-colocated:
-    image: concourse/concourse:7.9.0
+    image: concourse/concourse:7.10.0
     command: worker
     privileged: true
     depends_on: [concourse-db, concourse-web]
@@ -50,7 +50,7 @@ services:
     - CONCOURSE_GARDEN_DNS_SERVER=169.254.169.253
 
   concourse-worker-normal:
-    image: concourse/concourse:7.9.0
+    image: concourse/concourse:7.10.0
     command: worker
     privileged: true
     depends_on: [concourse-db, concourse-web]

--- a/vagrant/post-deploy.d/00-run-docker.sh
+++ b/vagrant/post-deploy.d/00-run-docker.sh
@@ -27,13 +27,13 @@ export CONCOURSE_EXTERNAL_URL="$CONCOURSE_URL"
 
 mkdir -p /tmp/keys
 
-sudo docker run --rm -v /tmp/keys:/keys concourse/concourse:7.9.0 \
+sudo docker run --rm -v /tmp/keys:/keys concourse/concourse:7.10.0 \
   generate-key -t rsa -f /keys/session_signing_key
 
-sudo docker run --rm -v /tmp/keys:/keys concourse/concourse:7.9.0 \
+sudo docker run --rm -v /tmp/keys:/keys concourse/concourse:7.10.0 \
   generate-key -t ssh -f /keys/tsa_host_key
 
-sudo docker run --rm -v /tmp/keys:/keys concourse/concourse:7.9.0 \
+sudo docker run --rm -v /tmp/keys:/keys concourse/concourse:7.10.0 \
   generate-key -t ssh -f /keys/worker_key
 
 sudo -E docker-compose up -d


### PR DESCRIPTION
What
----

Upgrade concourse to 7.10.0

How to review
-------------

- Tested create-bosh-concourse in dev05
- Tested cf-deploy in dev05
- Tested create-bosh-concourse from vagrant vm

There is a breaking change listed to do with the cf resource type. We don't use it.

Who can review
--------------

Any team member.
---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
