### PR TITLE
load balancers: write logs to region-wide bucket

### DIFF
--- a/terraform/bosh/lb.tf
+++ b/terraform/bosh/lb.tf
@@ -40,6 +40,13 @@ resource "aws_lb" "bosh" {
   tags = {
     Name = "${var.env}-bosh-lb"
   }
+
+  access_logs {
+    bucket  = data.aws_s3_bucket.account_region_wide_alb_access_logs.id
+    prefix  = "${var.env}/bosh"
+    enabled = true
+  }
+
 }
 
 resource "aws_lb_listener" "bosh_tls" {

--- a/terraform/concourse/elb.tf
+++ b/terraform/concourse/elb.tf
@@ -35,6 +35,11 @@ resource "aws_elb" "concourse" {
     lb_protocol        = "ssl"
     ssl_certificate_id = aws_acm_certificate_validation.system.certificate_arn
   }
+  access_logs {
+    bucket        = data.aws_s3_bucket.account_region_wide_alb_access_logs.bucket
+    bucket_prefix = "${var.env}/concourse"
+    enabled       = true
+  }
 
   tags = {
     Name = "${var.env}-concourse-elb"
@@ -113,4 +118,3 @@ resource "aws_route53_record" "concourse" {
   ttl     = "60"
   records = [aws_elb.concourse.dns_name]
 }
-

--- a/terraform/globals.tf
+++ b/terraform/globals.tf
@@ -144,3 +144,7 @@ variable "user_static_cidrs" {
   description = "user static cidrs populated with values from paas-trusted-people"
   default     = []
 }
+
+data "aws_s3_bucket" "account_region_wide_alb_access_logs" {
+  bucket = "gds-paas-${var.aws_account}-account-wide-alb-access-logs-${var.region}"
+}


### PR DESCRIPTION
What
----
https://www.pivotaltracker.com/story/show/185739015

The original version of this #643 was reverted because it didn't take into account LBs only being able to log into a bucket in their own region.

This corrects that, logging to a region-wide bucket (created by https://github.com/alphagov/paas-aws-account-wide-terraform/pull/381)

How to review
-------------

Deploy to a dev env, look at logs in bucket?

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
