### PR TITLE
Stemcell and docker update

### DIFF
--- a/concourse/pipelines/concourse-lite-self-terminate.yml
+++ b/concourse/pipelines/concourse-lite-self-terminate.yml
@@ -8,7 +8,7 @@ meta:
       type: registry-image
       source:
         repository: ghcr.io/alphagov/paas/awscli
-        tag: acff07cc3f0d4f478f54a7dedd40d47c90ad62f7
+        tag: b5568301ae03da8220c5ea2f907088dfa38e963d
 
 resources:
   - name: delete-timer

--- a/concourse/pipelines/create-bosh-concourse.yml
+++ b/concourse/pipelines/create-bosh-concourse.yml
@@ -8,47 +8,47 @@ meta:
       type: registry-image
       source:
         repository: ghcr.io/alphagov/paas/alpine
-        tag: acff07cc3f0d4f478f54a7dedd40d47c90ad62f7
+        tag: b5568301ae03da8220c5ea2f907088dfa38e963d
     awscli: &awscli-image-resource
       type: registry-image
       source:
         repository: ghcr.io/alphagov/paas/awscli
-        tag: acff07cc3f0d4f478f54a7dedd40d47c90ad62f7
+        tag: b5568301ae03da8220c5ea2f907088dfa38e963d
     bosh-cli-v2: &gov-paas-bosh-cli-v2-image-resource
       type: registry-image
       source:
         repository: ghcr.io/alphagov/paas/bosh-cli-v2
-        tag: acff07cc3f0d4f478f54a7dedd40d47c90ad62f7
+        tag: b5568301ae03da8220c5ea2f907088dfa38e963d
     certstrap: &certstrap-image-resource
       type: registry-image
       source:
         repository: ghcr.io/alphagov/paas/certstrap
-        tag: acff07cc3f0d4f478f54a7dedd40d47c90ad62f7
+        tag: b5568301ae03da8220c5ea2f907088dfa38e963d
     git-ssh: &git-ssh-image-resource
       type: registry-image
       source:
         repository: ghcr.io/alphagov/paas/git-ssh
-        tag: acff07cc3f0d4f478f54a7dedd40d47c90ad62f7
+        tag: b5568301ae03da8220c5ea2f907088dfa38e963d
     ruby-slim: &ruby-slim-image-resource
       type: registry-image
       source:
         repository: ghcr.io/alphagov/paas/ruby
-        tag: acff07cc3f0d4f478f54a7dedd40d47c90ad62f7
+        tag: b5568301ae03da8220c5ea2f907088dfa38e963d
     self-update-pipelines: &self-update-pipelines-image-resource
       type: registry-image
       source:
         repository: ghcr.io/alphagov/paas/self-update-pipelines
-        tag: acff07cc3f0d4f478f54a7dedd40d47c90ad62f7
+        tag: b5568301ae03da8220c5ea2f907088dfa38e963d
     spruce: &spruce-image-resource
       type: registry-image
       source:
         repository: ghcr.io/alphagov/paas/spruce
-        tag: acff07cc3f0d4f478f54a7dedd40d47c90ad62f7
+        tag: b5568301ae03da8220c5ea2f907088dfa38e963d
     terraform: &terraform-image-resource
       type: registry-image
       source:
         repository: ghcr.io/alphagov/paas/terraform
-        tag: acff07cc3f0d4f478f54a7dedd40d47c90ad62f7
+        tag: b5568301ae03da8220c5ea2f907088dfa38e963d
 
 groups:
   - name: all
@@ -102,7 +102,7 @@ resource_types:
   type: registry-image
   source:
     repository: ghcr.io/alphagov/paas/keyval-resource
-    tag: acff07cc3f0d4f478f54a7dedd40d47c90ad62f7
+    tag: b5568301ae03da8220c5ea2f907088dfa38e963d
 
 resources:
   - name: paas-bootstrap

--- a/concourse/pipelines/destroy-bosh-concourse.yml
+++ b/concourse/pipelines/destroy-bosh-concourse.yml
@@ -8,12 +8,12 @@ meta:
       type: registry-image
       source:
         repository: ghcr.io/alphagov/paas/awscli
-        tag: acff07cc3f0d4f478f54a7dedd40d47c90ad62f7
+        tag: b5568301ae03da8220c5ea2f907088dfa38e963d
     bosh-cli-v2: &gov-paas-bosh-cli-v2-image-resource
       type: registry-image
       source:
         repository: ghcr.io/alphagov/paas/bosh-cli-v2
-        tag: acff07cc3f0d4f478f54a7dedd40d47c90ad62f7
+        tag: b5568301ae03da8220c5ea2f907088dfa38e963d
     ruby-slim: &ruby-slim-image-resource
       type: registry-image
       source:
@@ -23,12 +23,12 @@ meta:
       type: registry-image
       source:
         repository: ghcr.io/alphagov/paas/self-update-pipelines
-        tag: acff07cc3f0d4f478f54a7dedd40d47c90ad62f7
+        tag: b5568301ae03da8220c5ea2f907088dfa38e963d
     terraform: &terraform-image-resource
       type: registry-image
       source:
         repository: ghcr.io/alphagov/paas/terraform
-        tag: acff07cc3f0d4f478f54a7dedd40d47c90ad62f7
+        tag: b5568301ae03da8220c5ea2f907088dfa38e963d
 
 resource_types:
 - name: s3-iam

--- a/concourse/tasks/delete-ssh-keys.yml
+++ b/concourse/tasks/delete-ssh-keys.yml
@@ -4,7 +4,7 @@ image_resource:
   type: registry-image
   source:
     repository: ghcr.io/alphagov/paas/awscli
-    tag: acff07cc3f0d4f478f54a7dedd40d47c90ad62f7
+    tag: b5568301ae03da8220c5ea2f907088dfa38e963d
 inputs:
   - name: paas-bootstrap
 run:

--- a/concourse/tasks/render-bosh-manifest.yml
+++ b/concourse/tasks/render-bosh-manifest.yml
@@ -4,7 +4,7 @@ image_resource:
   type: registry-image
   source:
     repository: ghcr.io/alphagov/paas/bosh-cli-v2
-    tag: acff07cc3f0d4f478f54a7dedd40d47c90ad62f7
+    tag: b5568301ae03da8220c5ea2f907088dfa38e963d
 inputs:
   - name: bosh-vars-store
     optional: true

--- a/manifests/bosh-manifest/operations.d/030-set-stemcell.yml
+++ b/manifests/bosh-manifest/operations.d/030-set-stemcell.yml
@@ -2,5 +2,5 @@
 - type: replace
   path: /resource_pools/name=vms/stemcell
   value:
-    url: https://bosh.io/d/stemcells/bosh-aws-xen-hvm-ubuntu-jammy-go_agent?v=1.199
-    sha1: f96134443a645a08f5de509f8ecd85ce9a2f3d56
+    url: https://bosh.io/d/stemcells/bosh-aws-xen-hvm-ubuntu-jammy-go_agent?v=1.222
+    sha1: 09307535e4898228841aec7305c28fcb9dfa50e5

--- a/manifests/concourse-manifest/concourse-base.yml
+++ b/manifests/concourse-manifest/concourse-base.yml
@@ -2,7 +2,7 @@
 meta:
   stemcell:
     name: bosh-aws-xen-hvm-ubuntu-jammy-go_agent
-    version: "1.199"
+    version: "1.222"
 
 name: concourse
 


### PR DESCRIPTION
What
----

- Bump jammy stemcell to 1.222
- Bump to latest version of docker images.

How to review
-------------

Tested in dev05.

Notes
------

PR in draft until proper merge of docker images.

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
