### PR TITLE
186049138 - awscli docker image includes openssh

### DIFF
--- a/concourse/pipelines/concourse-lite-self-terminate.yml
+++ b/concourse/pipelines/concourse-lite-self-terminate.yml
@@ -8,7 +8,7 @@ meta:
       type: registry-image
       source:
         repository: ghcr.io/alphagov/paas/awscli
-        tag: b5568301ae03da8220c5ea2f907088dfa38e963d
+        tag: 11251948d5dd4867552f9b9836a9e02110304df5
 
 resources:
   - name: delete-timer

--- a/concourse/pipelines/create-bosh-concourse.yml
+++ b/concourse/pipelines/create-bosh-concourse.yml
@@ -8,47 +8,47 @@ meta:
       type: registry-image
       source:
         repository: ghcr.io/alphagov/paas/alpine
-        tag: b5568301ae03da8220c5ea2f907088dfa38e963d
+        tag: 11251948d5dd4867552f9b9836a9e02110304df5
     awscli: &awscli-image-resource
       type: registry-image
       source:
         repository: ghcr.io/alphagov/paas/awscli
-        tag: b5568301ae03da8220c5ea2f907088dfa38e963d
+        tag: 11251948d5dd4867552f9b9836a9e02110304df5
     bosh-cli-v2: &gov-paas-bosh-cli-v2-image-resource
       type: registry-image
       source:
         repository: ghcr.io/alphagov/paas/bosh-cli-v2
-        tag: b5568301ae03da8220c5ea2f907088dfa38e963d
+        tag: 11251948d5dd4867552f9b9836a9e02110304df5
     certstrap: &certstrap-image-resource
       type: registry-image
       source:
         repository: ghcr.io/alphagov/paas/certstrap
-        tag: b5568301ae03da8220c5ea2f907088dfa38e963d
+        tag: 11251948d5dd4867552f9b9836a9e02110304df5
     git-ssh: &git-ssh-image-resource
       type: registry-image
       source:
         repository: ghcr.io/alphagov/paas/git-ssh
-        tag: b5568301ae03da8220c5ea2f907088dfa38e963d
+        tag: 11251948d5dd4867552f9b9836a9e02110304df5
     ruby-slim: &ruby-slim-image-resource
       type: registry-image
       source:
         repository: ghcr.io/alphagov/paas/ruby
-        tag: b5568301ae03da8220c5ea2f907088dfa38e963d
+        tag: 11251948d5dd4867552f9b9836a9e02110304df5
     self-update-pipelines: &self-update-pipelines-image-resource
       type: registry-image
       source:
         repository: ghcr.io/alphagov/paas/self-update-pipelines
-        tag: b5568301ae03da8220c5ea2f907088dfa38e963d
+        tag: 11251948d5dd4867552f9b9836a9e02110304df5
     spruce: &spruce-image-resource
       type: registry-image
       source:
         repository: ghcr.io/alphagov/paas/spruce
-        tag: b5568301ae03da8220c5ea2f907088dfa38e963d
+        tag: 11251948d5dd4867552f9b9836a9e02110304df5
     terraform: &terraform-image-resource
       type: registry-image
       source:
         repository: ghcr.io/alphagov/paas/terraform
-        tag: b5568301ae03da8220c5ea2f907088dfa38e963d
+        tag: 11251948d5dd4867552f9b9836a9e02110304df5
 
 groups:
   - name: all
@@ -102,7 +102,7 @@ resource_types:
   type: registry-image
   source:
     repository: ghcr.io/alphagov/paas/keyval-resource
-    tag: b5568301ae03da8220c5ea2f907088dfa38e963d
+    tag: 11251948d5dd4867552f9b9836a9e02110304df5
 
 resources:
   - name: paas-bootstrap
@@ -642,7 +642,6 @@ jobs:
                 cp git-ssh-private-key/git_id_rsa generated-git-ssh-keys
                 exit 0
               fi
-              apk add --update openssh
               cd generated-git-ssh-keys
               ssh-keygen -t rsa -b 4096 -f git_id_rsa -N ''
         on_success:

--- a/concourse/pipelines/destroy-bosh-concourse.yml
+++ b/concourse/pipelines/destroy-bosh-concourse.yml
@@ -8,12 +8,12 @@ meta:
       type: registry-image
       source:
         repository: ghcr.io/alphagov/paas/awscli
-        tag: b5568301ae03da8220c5ea2f907088dfa38e963d
+        tag: 11251948d5dd4867552f9b9836a9e02110304df5
     bosh-cli-v2: &gov-paas-bosh-cli-v2-image-resource
       type: registry-image
       source:
         repository: ghcr.io/alphagov/paas/bosh-cli-v2
-        tag: b5568301ae03da8220c5ea2f907088dfa38e963d
+        tag: 11251948d5dd4867552f9b9836a9e02110304df5
     ruby-slim: &ruby-slim-image-resource
       type: registry-image
       source:
@@ -23,12 +23,12 @@ meta:
       type: registry-image
       source:
         repository: ghcr.io/alphagov/paas/self-update-pipelines
-        tag: b5568301ae03da8220c5ea2f907088dfa38e963d
+        tag: 11251948d5dd4867552f9b9836a9e02110304df5
     terraform: &terraform-image-resource
       type: registry-image
       source:
         repository: ghcr.io/alphagov/paas/terraform
-        tag: b5568301ae03da8220c5ea2f907088dfa38e963d
+        tag: 11251948d5dd4867552f9b9836a9e02110304df5
 
 resource_types:
 - name: s3-iam

--- a/concourse/tasks/delete-ssh-keys.yml
+++ b/concourse/tasks/delete-ssh-keys.yml
@@ -4,7 +4,7 @@ image_resource:
   type: registry-image
   source:
     repository: ghcr.io/alphagov/paas/awscli
-    tag: b5568301ae03da8220c5ea2f907088dfa38e963d
+    tag: 11251948d5dd4867552f9b9836a9e02110304df5
 inputs:
   - name: paas-bootstrap
 run:

--- a/concourse/tasks/render-bosh-manifest.yml
+++ b/concourse/tasks/render-bosh-manifest.yml
@@ -4,7 +4,7 @@ image_resource:
   type: registry-image
   source:
     repository: ghcr.io/alphagov/paas/bosh-cli-v2
-    tag: b5568301ae03da8220c5ea2f907088dfa38e963d
+    tag: 11251948d5dd4867552f9b9836a9e02110304df5
 inputs:
   - name: bosh-vars-store
     optional: true


### PR DESCRIPTION
Description:
----
- Since the newer awscli-image-resource now includes openssh we can bump the version and remove the line installing it using apk

How to review
-------------

- See https://deployer.dev02.dev.cloudpipeline.digital/teams/main/pipelines/create-bosh-concourse/jobs/update-pipeline/builds/18 for a clean run of `create-bosh-concourse`

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
