### PR TITLE
[186049138] Updating openssh with apk is not required

### DIFF
--- a/concourse/pipelines/concourse-lite-self-terminate.yml
+++ b/concourse/pipelines/concourse-lite-self-terminate.yml
@@ -8,7 +8,7 @@ meta:
       type: registry-image
       source:
         repository: ghcr.io/alphagov/paas/awscli
-        tag: cb9acdf5752562c68781cdd358a9a6710219e3c7
+        tag: 9d7b91294e91172c6f2d63caae4c7b645fc46036
 
 resources:
   - name: delete-timer
@@ -45,4 +45,3 @@ jobs:
 
             aws ec2 delete-key-pair --key-name "${VAGRANT_SSH_KEY_NAME}"
             aws ec2 terminate-instances --instance-ids "${AWS_INSTANCE_ID}"
-

--- a/concourse/pipelines/create-bosh-concourse.yml
+++ b/concourse/pipelines/create-bosh-concourse.yml
@@ -8,47 +8,47 @@ meta:
       type: registry-image
       source:
         repository: ghcr.io/alphagov/paas/alpine
-        tag: cb9acdf5752562c68781cdd358a9a6710219e3c7
+        tag: 9d7b91294e91172c6f2d63caae4c7b645fc46036
     awscli: &awscli-image-resource
       type: registry-image
       source:
         repository: ghcr.io/alphagov/paas/awscli
-        tag: cb9acdf5752562c68781cdd358a9a6710219e3c7
+        tag: 9d7b91294e91172c6f2d63caae4c7b645fc46036
     bosh-cli-v2: &gov-paas-bosh-cli-v2-image-resource
       type: registry-image
       source:
         repository: ghcr.io/alphagov/paas/bosh-cli-v2
-        tag: cb9acdf5752562c68781cdd358a9a6710219e3c7
+        tag: 9d7b91294e91172c6f2d63caae4c7b645fc46036
     certstrap: &certstrap-image-resource
       type: registry-image
       source:
         repository: ghcr.io/alphagov/paas/certstrap
-        tag: cb9acdf5752562c68781cdd358a9a6710219e3c7
+        tag: 9d7b91294e91172c6f2d63caae4c7b645fc46036
     git-ssh: &git-ssh-image-resource
       type: registry-image
       source:
         repository: ghcr.io/alphagov/paas/git-ssh
-        tag: cb9acdf5752562c68781cdd358a9a6710219e3c7
+        tag: 9d7b91294e91172c6f2d63caae4c7b645fc46036
     ruby-slim: &ruby-slim-image-resource
       type: registry-image
       source:
         repository: ghcr.io/alphagov/paas/ruby
-        tag: cb9acdf5752562c68781cdd358a9a6710219e3c7
+        tag: 9d7b91294e91172c6f2d63caae4c7b645fc46036
     self-update-pipelines: &self-update-pipelines-image-resource
       type: registry-image
       source:
         repository: ghcr.io/alphagov/paas/self-update-pipelines
-        tag: cb9acdf5752562c68781cdd358a9a6710219e3c7
+        tag: 9d7b91294e91172c6f2d63caae4c7b645fc46036
     spruce: &spruce-image-resource
       type: registry-image
       source:
         repository: ghcr.io/alphagov/paas/spruce
-        tag: cb9acdf5752562c68781cdd358a9a6710219e3c7
+        tag: 9d7b91294e91172c6f2d63caae4c7b645fc46036
     terraform: &terraform-image-resource
       type: registry-image
       source:
         repository: ghcr.io/alphagov/paas/terraform
-        tag: cb9acdf5752562c68781cdd358a9a6710219e3c7
+        tag: 9d7b91294e91172c6f2d63caae4c7b645fc46036
 
 groups:
   - name: all
@@ -642,7 +642,6 @@ jobs:
                 cp git-ssh-private-key/git_id_rsa generated-git-ssh-keys
                 exit 0
               fi
-              apk add --update openssh
               cd generated-git-ssh-keys
               ssh-keygen -t rsa -b 4096 -f git_id_rsa -N ''
         on_success:
@@ -1403,7 +1402,7 @@ jobs:
               . bosh-terraform-outputs/tfvars.sh
               export TF_VAR_git_rsa_id_pub
               TF_VAR_git_rsa_id_pub=$(cat git-ssh-public-key/git_id_rsa.pub)
-              
+
               cp concourse-tfstate/concourse.tfstate updated-concourse-tfstate/concourse.tfstate
               cd paas-bootstrap/terraform/concourse || exit
               terraform init

--- a/concourse/pipelines/destroy-bosh-concourse.yml
+++ b/concourse/pipelines/destroy-bosh-concourse.yml
@@ -8,12 +8,12 @@ meta:
       type: registry-image
       source:
         repository: ghcr.io/alphagov/paas/awscli
-        tag: cb9acdf5752562c68781cdd358a9a6710219e3c7
+        tag: 9d7b91294e91172c6f2d63caae4c7b645fc46036
     bosh-cli-v2: &gov-paas-bosh-cli-v2-image-resource
       type: registry-image
       source:
         repository: ghcr.io/alphagov/paas/bosh-cli-v2
-        tag: cb9acdf5752562c68781cdd358a9a6710219e3c7
+        tag: 9d7b91294e91172c6f2d63caae4c7b645fc46036
     ruby-slim: &ruby-slim-image-resource
       type: registry-image
       source:
@@ -23,12 +23,12 @@ meta:
       type: registry-image
       source:
         repository: ghcr.io/alphagov/paas/self-update-pipelines
-        tag: cb9acdf5752562c68781cdd358a9a6710219e3c7
+        tag: 9d7b91294e91172c6f2d63caae4c7b645fc46036
     terraform: &terraform-image-resource
       type: registry-image
       source:
         repository: ghcr.io/alphagov/paas/terraform
-        tag: cb9acdf5752562c68781cdd358a9a6710219e3c7
+        tag: 9d7b91294e91172c6f2d63caae4c7b645fc46036
 
 resource_types:
 - name: s3-iam
@@ -51,6 +51,7 @@ resource_types:
   source:
     repository: ghcr.io/alphagov/paas/git-resource
     tag: 1f84d4a76b4a2491283e0107ae7ed4bc83c84d1b
+
 resources:
   - name: paas-bootstrap
     type: git

--- a/concourse/tasks/delete-ssh-keys.yml
+++ b/concourse/tasks/delete-ssh-keys.yml
@@ -4,7 +4,7 @@ image_resource:
   type: registry-image
   source:
     repository: ghcr.io/alphagov/paas/awscli
-    tag: cb9acdf5752562c68781cdd358a9a6710219e3c7
+    tag: 9d7b91294e91172c6f2d63caae4c7b645fc46036
 inputs:
   - name: paas-bootstrap
 run:

--- a/concourse/tasks/render-bosh-manifest.yml
+++ b/concourse/tasks/render-bosh-manifest.yml
@@ -4,7 +4,7 @@ image_resource:
   type: registry-image
   source:
     repository: ghcr.io/alphagov/paas/bosh-cli-v2
-    tag: cb9acdf5752562c68781cdd358a9a6710219e3c7
+    tag: 9d7b91294e91172c6f2d63caae4c7b645fc46036
 inputs:
   - name: bosh-vars-store
     optional: true


### PR DESCRIPTION
What
----

This is based on [PR 677 - (186049138 - awscli docker image includes openssh)](https://github.com/alphagov/paas-release-ci/pull/250). That PR went obsolete as newer builds were introduced. Thankfully those builds hold the changes we were aiming to target in the first place.
Based on all that, only one change has not been merged and is part of this PR.

As openssh-client is part of the image there is no need to call apk.

How to review
-------------

Deploy on a test environment and see `create-bosh-concourse` `generate-git-ssh-keys` pipeline task go green.

Who can review
--------------

Anyone how has access to those test environments and understands what this change is.

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
