### PR TITLE
Upgrade stemcell to v1.340

### DIFF
--- a/manifests/bosh-manifest/operations.d/030-set-stemcell.yml
+++ b/manifests/bosh-manifest/operations.d/030-set-stemcell.yml
@@ -2,5 +2,5 @@
 - type: replace
   path: /resource_pools/name=vms/stemcell
   value:
-    url: https://bosh.io/d/stemcells/bosh-aws-xen-hvm-ubuntu-jammy-go_agent?v=1.309
-    sha1: 102171246af60f96ad8770a82217950cf5c8e9c0
+    url: https://bosh.io/d/stemcells/bosh-aws-xen-hvm-ubuntu-jammy-go_agent?v=1.340
+    sha1: a13326e63a2a89d379eae1d1097659aec1385bcd

--- a/manifests/concourse-manifest/concourse-base.yml
+++ b/manifests/concourse-manifest/concourse-base.yml
@@ -2,7 +2,7 @@
 meta:
   stemcell:
     name: bosh-aws-xen-hvm-ubuntu-jammy-go_agent
-    version: "1.309"
+    version: "1.340"
 
 name: concourse
 


### PR DESCRIPTION
What
----

The stemcell has been upgraded to v1.340.

How to review
-------------

1 - Check the code to ensure that the stemcell has been set wherever it needs to be specified.
2 - Run into a dev env.

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
