### PR TITLE
Update to go 1.21

### DIFF
--- a/.github/workflows/test_on_pr.yml
+++ b/.github/workflows/test_on_pr.yml
@@ -6,7 +6,7 @@ env:
   BOSH_CLI_VERSION: "6.1.1"
   CERTSTRAP_VERSION: "1.2.0"
   SHELLCHECK_VERSION: "0.7.0"
-  GO_VERSION: "1.18"
+  GO_VERSION: "1.21"
   RUBY_VERSION: "3.1.0"
 jobs:
   test:

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/alphagov/paas-bootstrap
 
-go 1.18
+go 1.21
 
 require (
 	github.com/ProtonMail/gopenpgp/v2 v2.5.2

--- a/go.sum
+++ b/go.sum
@@ -13,6 +13,7 @@ github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSs
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/golang/protobuf v1.5.2 h1:ROPKBNFfQgOUMifHyP+KYbvpjbdoFNs+aK7DXlji0Tw=
+github.com/golang/protobuf v1.5.2/go.mod h1:XVQd3VNwM+JqD3oG2Ue2ip4fOMUkwXdXDdiuN0vRsmY=
 github.com/google/go-cmp v0.5.8 h1:e6P7q2lk1O+qJJb4BtCQXlK8vWEO8V1ZeuEdJNOqZyg=
 github.com/google/go-cmp v0.5.8/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/onsi/ginkgo/v2 v2.1.4 h1:GNapqRSid3zijZ9H77KrgVG4/8KqiyRsxcSxe+7ApXY=
@@ -72,6 +73,7 @@ golang.org/x/tools v0.0.0-20191119224855-298f0cb1881e/go.mod h1:b+2E5dAYhXwXZwtn
 golang.org/x/tools v0.1.12/go.mod h1:hNGJHUnrk76NpqgfD5Aqm5Crs+Hm0VOH/i9J2+nxYbc=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 google.golang.org/protobuf v1.28.0 h1:w43yiav+6bVFTBQFZX0r7ipe9JQ1QsbMgHwbBziscLw=
+google.golang.org/protobuf v1.28.0/go.mod h1:HV8QOd/L58Z+nl8r43ehVNZIU/HEI6OcFqwMG9pJV4I=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v2 v2.4.0 h1:D8xgwECY7CYvx+Y2n4sBz93Jn9JRvxdiyyo8CTfuKaY=


### PR DESCRIPTION
## What

Use go v1.21

## Why

A recent go buildpack update is dropping support for go 1.20, so updating to 1.21 will let us update this buildpack

## How to review

Ensure that you can successfully bootstrap an environment from this branch

## Who can review

Current PaaS team members

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨

