### PR TITLE
ENG-608: Offboard Corin Wilkins

### DIFF
--- a/manifests/concourse-manifest/github_auth/config.yml
+++ b/manifests/concourse-manifest/github_auth/config.yml
@@ -18,7 +18,6 @@ instance_groups:
                   github:
                     users:
                     - DominicGriffin
-                    - CorinWilkins
                     - monotypical
                     - EduardoAquinta
                     - NahomCO

--- a/manifests/concourse-manifest/github_auth/dev_ci_additional_users.yml
+++ b/manifests/concourse-manifest/github_auth/dev_ci_additional_users.yml
@@ -15,7 +15,6 @@ instance_groups:
                   github:
                     users:
                     - DominicGriffin
-                    - CorinWilkins
                     - monotypical
                     - EduardoAquinta
                     - NahomCO


### PR DESCRIPTION
What
----

- Remove `Corin Wilkins` from Github users due to him [being off-boarded](https://gds-cyber-and-engineering.atlassian.net/browse/ENG-608) from the GDS Engineering Enablement squad

How to review
-------------

- Sanity check change

Who can review
--------------

- Anyone

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
