### PR TITLE
Specify containerd as the worker runtime for bootstrap workers

### DIFF
--- a/vagrant/docker-compose.yml
+++ b/vagrant/docker-compose.yml
@@ -47,7 +47,8 @@ services:
     - CONCOURSE_TSA_WORKER_PRIVATE_KEY=/keys/worker_key
     - CONCOURSE_WORKER_WORK_DIR=/tmp/worker-colocated
     - CONCOURSE_TAG=colocated-with-web
-    - CONCOURSE_GARDEN_DNS_SERVER=169.254.169.253
+    - CONCOURSE_CONTAINERD_DNS_SERVER=169.254.169.253
+    - CONCOURSE_RUNTIME=containerd
 
   concourse-worker-normal:
     image: concourse/concourse:7.11.2
@@ -63,5 +64,6 @@ services:
     - CONCOURSE_TSA_HOST=concourse-web:2222
     - CONCOURSE_TSA_PUBLIC_KEY=/keys/tsa_host_key.pub
     - CONCOURSE_TSA_WORKER_PRIVATE_KEY=/keys/worker_key
-    - CONCOURSE_WORKER_WORK_DIR=/tmp/worker-normal
-    - CONCOURSE_GARDEN_DNS_SERVER=169.254.169.253
+    - CONCOURSE_WORKER_WORK_DIR=/tmp/worker-normal\
+    - CONCOURSE_CONTAINERD_DNS_SERVER=169.254.169.253
+    - CONCOURSE_RUNTIME=containerd


### PR DESCRIPTION
What
----

The version of Ubuntu we use uses cgroups v2, which only works with containerd as the worker runtime, and the worker fails to start when attempting to use guardian, which it does by default.

See also: https://github.com/concourse/concourse/issues/7237

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
