### PR TITLE
Update to go 1.22

### DIFF
--- a/.github/workflows/test_on_pr.yml
+++ b/.github/workflows/test_on_pr.yml
@@ -6,7 +6,7 @@ env:
   BOSH_CLI_VERSION: "6.1.1"
   CERTSTRAP_VERSION: "1.2.0"
   SHELLCHECK_VERSION: "0.7.0"
-  GO_VERSION: "1.23"
+  GO_VERSION: "1.22"
   RUBY_VERSION: "3.1.0"
 jobs:
   test:

--- a/.github/workflows/test_on_pr.yml
+++ b/.github/workflows/test_on_pr.yml
@@ -6,7 +6,7 @@ env:
   BOSH_CLI_VERSION: "6.1.1"
   CERTSTRAP_VERSION: "1.2.0"
   SHELLCHECK_VERSION: "0.7.0"
-  GO_VERSION: "1.21"
+  GO_VERSION: "1.23"
   RUBY_VERSION: "3.1.0"
 jobs:
   test:

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/alphagov/paas-bootstrap
 
-go 1.21
+go 1.23
 
 require (
 	github.com/ProtonMail/gopenpgp/v2 v2.5.2

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/alphagov/paas-bootstrap
 
-go 1.23
+go 1.22
 
 require (
 	github.com/ProtonMail/gopenpgp/v2 v2.5.2


### PR DESCRIPTION
## What

Use go v1.22

## Why

To keep up to date with latest releases

> Initially intended to upgrade go to 1.23, but reverted to 1.22 due to current buildpack compatibility. Buildpack doesn't yet support 1.23.

## How to review

Ensure that you can successfully bootstrap an environment from this branch

## Who can review

Current PaaS team members

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
