### PR TITLE
Allow minor version upgrades for RDS databases

### DIFF
--- a/terraform/bosh/rds.tf
+++ b/terraform/bosh/rds.tf
@@ -47,7 +47,7 @@ resource "aws_db_instance" "bosh" {
   allocated_storage          = 100
   storage_type               = "gp2"
   engine                     = "postgres"
-  engine_version             = "13.20"
+  engine_version             = "13"
   instance_class             = var.bosh_db_instance_class
   username                   = "dbadmin"
   password                   = var.secrets_bosh_postgres_password

--- a/terraform/concourse/rds.tf
+++ b/terraform/concourse/rds.tf
@@ -48,7 +48,7 @@ resource "aws_db_instance" "concourse" {
   allocated_storage          = 100
   storage_type               = "gp2"
   engine                     = "postgres"
-  engine_version             = "13.20"
+  engine_version             = "13"
   instance_class             = var.concourse_db_instance_class
   username                   = "concourse"
   password                   = random_password.concourse_rds_password.result


### PR DESCRIPTION
What
----

RDS is set to auto update minor versions, but then the terraform fails when it can't downgrade to what is specified.

Applied in dev environment: https://deployer.dev02.dev.cloudpipeline.digital/teams/main/pipelines/create-bosh-concourse/jobs/bosh-terraform/builds/3#L67ec0a0a:80

```
  # aws_db_instance.bosh will be updated in-place
  ~ resource "aws_db_instance" "bosh" {
      ~ engine_version                        = "13.20" -> "13"
        id                                    = "db-OQF6HJZFXCIOSZOVLZCIYU4QOE"
        tags                                  = {
            "Name"       = "dev02-bosh"
            "deploy_env" = "dev02"
        }
        # (52 unchanged attributes hidden)
    }
```

The database is still on 13.20 after applying: https://595665891067-e52kd6g7.eu-west-1.console.aws.amazon.com/rds/home?region=eu-west-1#database:id=dev02-bosh;is-cluster=false;tab=configuration

Terraform reference: https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/db_instance

> The engine version to use. If auto_minor_version_upgrade is enabled, you can provide a prefix of the version such as 8.0 (for 8.0.36). The actual engine version used is returned in the attribute engine_version_actual, see [Attribute Reference](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/db_instance#attribute-reference) below. For supported values, see the EngineVersion parameter in [API action CreateDBInstance](https://docs.aws.amazon.com/AmazonRDS/latest/APIReference/API_CreateDBInstance.html). Note that for Amazon Aurora instances the engine version must match the [DB cluster](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/rds_cluster)'s engine version'.


---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
